### PR TITLE
Fix Flask blueprint imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -146,9 +146,14 @@ from flask import Flask, jsonify, render_template, redirect, url_for, request, s
 import sys
 import os
 from werkzeug.utils import secure_filename
-from blueprints.auth import auth_bp
-from blueprints.animals import animals_bp
-from blueprints.clinic import clinic_bp
+try:
+    from blueprints.auth import auth_bp
+    from blueprints.animals import animals_bp
+    from blueprints.clinic import clinic_bp
+except ImportError:  # pragma: no cover - fallback for package imports
+    from .blueprints.auth import auth_bp
+    from .blueprints.animals import animals_bp
+    from .blueprints.clinic import clinic_bp
 
 app.register_blueprint(auth_bp)
 app.register_blueprint(animals_bp)

--- a/blueprints/animals.py
+++ b/blueprints/animals.py
@@ -1,10 +1,16 @@
 from flask import Blueprint, render_template, redirect, url_for, request, flash
 from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
-from models import Animal, Species, Breed, Message, Interest
-from forms import AnimalForm, MessageForm
-from extensions import db
-from s3_utils import upload_to_s3
+try:
+    from models import Animal, Species, Breed, Message, Interest
+    from forms import AnimalForm, MessageForm
+    from extensions import db
+    from s3_utils import upload_to_s3
+except ImportError:  # pragma: no cover - fallback for package imports
+    from ..models import Animal, Species, Breed, Message, Interest
+    from ..forms import AnimalForm, MessageForm
+    from ..extensions import db
+    from ..s3_utils import upload_to_s3
 import uuid
 
 animals_bp = Blueprint('animals', __name__)

--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -1,11 +1,18 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request
 from flask_login import login_user, login_required, logout_user, current_user
 
-from forms import RegistrationForm, LoginForm, EditProfileForm, ResetPasswordRequestForm, ResetPasswordForm
-from models import User, Endereco, Transaction
-from extensions import db, mail
-from werkzeug.utils import secure_filename
-from s3_utils import upload_to_s3
+try:
+    from forms import RegistrationForm, LoginForm, EditProfileForm, ResetPasswordRequestForm, ResetPasswordForm
+    from models import User, Endereco, Transaction
+    from extensions import db, mail
+    from werkzeug.utils import secure_filename
+    from s3_utils import upload_to_s3
+except ImportError:  # pragma: no cover - fallback for package imports
+    from ..forms import RegistrationForm, LoginForm, EditProfileForm, ResetPasswordRequestForm, ResetPasswordForm
+    from ..models import User, Endereco, Transaction
+    from ..extensions import db, mail
+    from werkzeug.utils import secure_filename
+    from ..s3_utils import upload_to_s3
 from flask_mail import Message as MailMessage
 from itsdangerous import URLSafeTimedSerializer
 import os

--- a/blueprints/clinic.py
+++ b/blueprints/clinic.py
@@ -1,7 +1,11 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, abort, request
 from flask_login import login_required, current_user
-from models import Consulta, Animal, TipoRacao, Species, Breed
-from extensions import db
+try:
+    from models import Consulta, Animal, TipoRacao, Species, Breed
+    from extensions import db
+except ImportError:  # pragma: no cover - fallback for package imports
+    from ..models import Consulta, Animal, TipoRacao, Species, Breed
+    from ..extensions import db
 
 clinic_bp = Blueprint('clinic', __name__)
 


### PR DESCRIPTION
## Summary
- fix imports for blueprints so `flask run` works

## Testing
- `python -m py_compile app.py blueprints/animals.py blueprints/auth.py blueprints/clinic.py`
- `flask run --port 5001`

------
https://chatgpt.com/codex/tasks/task_e_6879126facb8832ea43cb85bd8f42aff