### PR TITLE
Add pytest and basic route tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# PetOrlândia
+
+This project is a Flask application for managing pets. The repository now includes basic unit tests.
+
+## Running the tests
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Execute the tests with `pytest`:
+   ```bash
+   pytest
+   ```
+
+The tests run without needing external services or a database connection.

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ urllib3==2.3.0
 Werkzeug==3.1.3
 WTForms==3.1.2
 yarl==1.20.1
+pytest==8.2.2

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,38 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app
+from models import User
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    yield flask_app
+
+def test_login_page(app):
+    client = app.test_client()
+    response = client.get('/login')
+    assert response.status_code == 200
+
+def test_login_invalid_credentials(monkeypatch, app):
+    client = app.test_client()
+
+    class FakeQuery:
+        def filter_by(self, **kw):
+            return self
+        def first(self):
+            return None
+
+    with app.app_context():
+        monkeypatch.setattr(User, 'query', FakeQuery())
+
+    response = client.post('/login', data={'email': 'foo@bar.com', 'password': 'x'}, follow_redirects=True)
+    assert b'Email ou senha inv\xc3\xa1lidos' in response.data
+
+def test_add_animal_requires_login(app):
+    client = app.test_client()
+    response = client.get('/add-animal')
+    assert response.status_code == 302
+    assert '/login' in response.headers['Location']


### PR DESCRIPTION
## Summary
- configure pytest dependency
- add simple tests for login and animal creation routes
- document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687956c6d8c0832ebdc6188478d25ff9