### PR TITLE
Add delivery management models and UI

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,5 +1,14 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, SelectField, PasswordField, SubmitField, BooleanField, DecimalField
+from wtforms import (
+    StringField,
+    TextAreaField,
+    SelectField,
+    PasswordField,
+    SubmitField,
+    BooleanField,
+    DecimalField,
+    IntegerField,
+)
 from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional
 from flask_wtf.file import FileField, FileAllowed
 
@@ -82,3 +91,11 @@ class EditProfileForm(FlaskForm):
 class MessageForm(FlaskForm):
     content = TextAreaField('Mensagem', validators=[DataRequired(), Length(max=1000)])
     submit = SubmitField('Enviar Mensagem')
+
+class OrderItemForm(FlaskForm):
+    item_name = StringField('Item', validators=[DataRequired()])
+    quantity = IntegerField('Quantidade', validators=[DataRequired()])
+    submit = SubmitField('Adicionar')
+
+class DeliveryRequestForm(FlaskForm):
+    submit = SubmitField('Gerar Solicitação')

--- a/migrations/versions/3d436ed763ae_add_order_models.py
+++ b/migrations/versions/3d436ed763ae_add_order_models.py
@@ -1,0 +1,50 @@
+"""add order models"
+
+Revision ID: 3d436ed763ae
+Revises: dee1b546c208
+Create Date: 2025-07-02 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '3d436ed763ae'
+down_revision = 'dee1b546c208'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'order',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table(
+        'order_item',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('order_id', sa.Integer(), nullable=False),
+        sa.Column('item_name', sa.String(length=100), nullable=False),
+        sa.Column('quantity', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['order_id'], ['order.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table(
+        'delivery_request',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('order_id', sa.Integer(), nullable=False),
+        sa.Column('requested_by_id', sa.Integer(), nullable=False),
+        sa.Column('requested_at', sa.DateTime(), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.ForeignKeyConstraint(['order_id'], ['order.id']),
+        sa.ForeignKeyConstraint(['requested_by_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+def downgrade():
+    op.drop_table('delivery_request')
+    op.drop_table('order_item')
+    op.drop_table('order')

--- a/models.py
+++ b/models.py
@@ -502,3 +502,27 @@ class Favorite(db.Model):
 
 
 
+
+class Order(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship('User', backref='orders')
+    items = db.relationship('OrderItem', backref='order', cascade='all, delete-orphan')
+
+class OrderItem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    order_id = db.Column(db.Integer, db.ForeignKey('order.id'), nullable=False)
+    item_name = db.Column(db.String(100), nullable=False)
+    quantity = db.Column(db.Integer, nullable=False, default=1)
+
+class DeliveryRequest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    order_id = db.Column(db.Integer, db.ForeignKey('order.id'), nullable=False)
+    requested_by_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    requested_at = db.Column(db.DateTime, default=datetime.utcnow)
+    status = db.Column(db.String(20), default='pendente')
+
+    order = db.relationship('Order', backref='delivery_requests')
+    requested_by = db.relationship('User')

--- a/templates/create_order.html
+++ b/templates/create_order.html
@@ -1,0 +1,39 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container mt-4">
+  <h2 class="mb-3">📦 Novo Pedido</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="row g-2 mb-3">
+      <div class="col-md-6">
+        {{ form.item_name.label(class="form-label") }}
+        {{ form.item_name(class="form-control") }}
+      </div>
+      <div class="col-md-3">
+        {{ form.quantity.label(class="form-label") }}
+        {{ form.quantity(class="form-control") }}
+      </div>
+      <div class="col-md-3 d-flex align-items-end">
+        {{ form.submit(class="btn btn-outline-primary w-100") }}
+      </div>
+    </div>
+  </form>
+
+  {% if order.items %}
+  <h5 class="mt-4">Itens do Pedido</h5>
+  <ul class="list-group mb-3">
+    {% for item in order.items %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      {{ item.item_name }}
+      <span class="badge bg-secondary rounded-pill">{{ item.quantity }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+  <div class="alert alert-info">Quantidade total: {{ total_quantity }}</div>
+  <form action="{{ url_for('request_delivery', order_id=order.id) }}" method="post">
+    {{ delivery_form.hidden_tag() }}
+    {{ delivery_form.submit(class="btn btn-success") }}
+  </form>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -1,0 +1,18 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container mt-4">
+  <h2 class="mb-4">🚚 Solicitações de Entrega</h2>
+  {% if requests %}
+  <ul class="list-group">
+    {% for req in requests %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      Pedido #{{ req.order_id }} - {{ req.status }}
+      <small class="text-muted">{{ req.requested_at|datetime_brazil }}</small>
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>Nenhuma solicitação.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -94,5 +94,20 @@
             </div>
         </div>
     {% endif %}
+
+    {% if current_user.is_authenticated and current_user.worker == 'delivery' %}
+    <!-- Área de Entregas -->
+        <div class="card shadow-lg p-4 rounded-4 mb-5" style="background: #ffffff;">
+            <h5 class="mb-4">Área de Entregas</h5>
+            <div class="d-flex flex-wrap justify-content-center gap-3">
+                <a href="{{ url_for('create_order') }}" class="btn btn-outline-primary rounded-pill shadow-sm px-4 py-2">
+                    📦 Novo Pedido
+                </a>
+                <a href="{{ url_for('list_delivery_requests') }}" class="btn btn-outline-secondary rounded-pill shadow-sm px-4 py-2">
+                    🚚 Solicitações
+                </a>
+            </div>
+        </div>
+    {% endif %}
 </div>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -204,6 +204,13 @@
                   <li class="nav-item">
                     <a class="nav-link" href="{{ url_for('add_animal') }}">➕ Animal</a>
                   </li>
+                {% elif current_user.worker == 'delivery' %}
+                  <li class="nav-item">
+                    <a class="nav-link" href="{{ url_for('create_order') }}">📦 Pedidos</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" href="{{ url_for('list_delivery_requests') }}">🚚 Solicitações</a>
+                  </li>
                 {% endif %}
 
                 <li class="nav-item position-relative">


### PR DESCRIPTION
## Summary
- add Order, OrderItem and DeliveryRequest models
- create new forms for orders
- expose delivery-only pages and navbar links
- update index with a delivery area
- include Alembic migration for new tables

## Testing
- `python3 -m py_compile app.py models.py forms.py`

------
https://chatgpt.com/codex/tasks/task_e_68796dffd13c832ea1e05e25dcf44841