### PR TITLE
Fix relative import of extensions

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,8 +166,12 @@ except ImportError:
     from .models import *
 
 # Reimporta explicitamente o objeto `db` das extensões para evitar
-# possíveis conflitos de importacão.
-from extensions import db as _db
+# possíveis conflitos de importação tanto quando o módulo é executado
+# diretamente quanto quando é importado como parte do pacote
+try:
+    from extensions import db as _db
+except ImportError:  # quando importado como pacote
+    from .extensions import db as _db
 db = _db
 
 from wtforms.fields import SelectField


### PR DESCRIPTION
## Summary
- fix package import logic for database extensions so running with `flask --app` works

## Testing
- `pytest -q`
- `flask --app app.py run -p 5001` (started then stopped)

------
https://chatgpt.com/codex/tasks/task_e_687ce9153dd4832e85958cc8947dabe3