### PR TITLE
Implement customer order history

### DIFF
--- a/migrations/versions/b1d1be123abc_add_indexes_to_orders_payments.py
+++ b/migrations/versions/b1d1be123abc_add_indexes_to_orders_payments.py
@@ -1,0 +1,26 @@
+"""add indexes to orders and payments
+
+Revision ID: b1d1be123abc
+Revises: e8aff173e0fe
+Create Date: 2025-07-23 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b1d1be123abc'
+down_revision = 'e8aff173e0fe'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_order_user_id', 'order', ['user_id'])
+    op.create_index('ix_payment_user_id', 'payment', ['user_id'])
+    op.create_index('ix_payment_status', 'payment', ['status'])
+
+
+def downgrade():
+    op.drop_index('ix_payment_status', table_name='payment')
+    op.drop_index('ix_payment_user_id', table_name='payment')
+    op.drop_index('ix_order_user_id', table_name='order')

--- a/models.py
+++ b/models.py
@@ -533,7 +533,7 @@ class Product(db.Model):
 
 class Order(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True, index=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     user = db.relationship('User', backref='orders')
@@ -636,6 +636,7 @@ class Payment(db.Model):
     status = db.Column(
         PgEnum(PaymentStatus, name="paymentstatus", create_type=False),
         default=PaymentStatus.PENDING,
+        index=True,
     )
 
     transaction_id     = db.Column(db.String(255))
@@ -644,7 +645,7 @@ class Payment(db.Model):
 
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
     user    = db.relationship("User", backref="payments")
 
     init_point = db.Column(db.String)

--- a/templates/minhas_compras.html
+++ b/templates/minhas_compras.html
@@ -1,0 +1,53 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container py-5">
+  <h2 class="mb-4">Minhas Compras</h2>
+  {% if orders %}
+  <div class="table-responsive">
+    <table class="table align-middle">
+      <thead>
+        <tr>
+          <th>Nº pedido</th>
+          <th>Data</th>
+          <th>Valor</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for o in orders %}
+        <tr>
+          <td>{{ o.id }}</td>
+          <td>{{ o.created_at.strftime('%d/%m/%Y') }}</td>
+          <td>R$ {{ '%.2f'|format(o.total_value()) }}</td>
+          <td>
+            <span class="badge{% if o.payment and o.payment.status == PaymentStatus.COMPLETED %} bg-success{% elif not o.payment or o.payment.status == PaymentStatus.PENDING %} bg-warning text-dark{% else %} bg-danger{% endif %}">
+              {{ o.payment.status.value if o.payment else 'Pendente' }}
+            </span>
+          </td>
+          <td>
+            <a href="{{ url_for('pedido_detail', order_id=o.id) }}" class="btn btn-sm btn-outline-primary" aria-label="Ver detalhes do pedido {{ o.id }}">
+              <i class="bi bi-search"></i> Detalhes
+            </a>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p>Nenhuma compra registrada.</p>
+  {% endif %}
+  {% if pagination.pages > 1 %}
+  <nav aria-label="Paginação" class="mt-4">
+    <ul class="pagination justify-content-center">
+      {% for p in range(1, pagination.pages + 1) %}
+      <li class="page-item{% if p == pagination.page %} active{% endif %}">
+        <a class="page-link" href="{{ url_for('minhas_compras', page=p) }}">{{ p }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </nav>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/payment_status.html
+++ b/templates/payment_status.html
@@ -5,22 +5,24 @@
 
     <h2 class="fw-bold mb-3 text-center">Status do pagamento</h2>
 
-    {% if result in ['success', 'completed'] %}
-      <div class="alert alert-success text-center">
-        <i class="bi bi-check-circle-fill me-2"></i>
-        Pagamento aprovado! Seu pedido já está em preparação.
-      </div>
-    {% elif result in ['failure', 'failed'] %}
-      <div class="alert alert-danger text-center">
-        <i class="bi bi-x-circle-fill me-2"></i>
-        O pagamento foi recusado ou cancelado.
-      </div>
-    {% else %}
-      <div class="alert alert-warning text-center">
-        <i class="bi bi-hourglass-split me-2"></i>
-        Estamos aguardando a confirmação do pagamento.
-      </div>
-    {% endif %}
+    <div id="loading" class="text-center my-4"{% if result != 'pending' %} style="display:none"{% endif %}>
+      <div class="spinner-border text-primary" role="status" aria-label="Carregando"></div>
+      <p class="mt-3">Aguardando a confirmação do pagamento...</p>
+    </div>
+
+    <div id="status-banner"{% if result == 'pending' %} style="display:none"{% endif %}>
+      {% if result in ['success', 'completed', 'approved'] %}
+        <div class="alert alert-success text-center" role="alert">
+          <i class="bi bi-check-circle-fill me-2"></i>
+          Compra aprovada!
+        </div>
+      {% elif result in ['failure', 'failed'] %}
+        <div class="alert alert-danger text-center" role="alert">
+          <i class="bi bi-x-circle-fill me-2"></i>
+          Falha no pagamento.
+        </div>
+      {% endif %}
+    </div>
 
     <dl class="row mb-4">
 
@@ -30,6 +32,19 @@
       <dt class="col-sm-4">Status interno:</dt>
       <dd class="col-sm-8">{{ payment.status.name }}</dd>
     </dl>
+
+    {% if order %}
+    <h5 class="mt-4">Resumo do Pedido</h5>
+    <ul class="list-group mb-3">
+      {% for item in order.items %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ item.item_name }} × {{ item.quantity }}</span>
+        <span>R$ {{ '%.2f'|format(item.product.price if item.product else 0) }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    <p class="text-end fw-bold">Total: R$ {{ '%.2f'|format(order.total_value()) }}</p>
+    {% endif %}
 
     <div class="d-flex justify-content-center gap-3">
 
@@ -48,6 +63,23 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const result = '{{ result }}';
+  if(result === 'pending') {
+    setInterval(async function(){
+      const resp = await fetch('{{ url_for('api_payment_status', payment_id=payment.id) }}');
+      const data = await resp.json();
+      if(data.status !== 'PENDING') {
+        window.location.href = '{{ url_for('payment_status', payment_id=payment.id) }}?status=' + data.status.toLowerCase();
+      }
+    }, 5000);
+  }
+});
+</script>
 {% endblock %}
 
 

--- a/templates/pedido_detail.html
+++ b/templates/pedido_detail.html
@@ -1,0 +1,49 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container py-4">
+  <h2 class="mb-4">Pedido #{{ order.id }}</h2>
+
+  <div class="mb-3">
+    <h5>Produtos</h5>
+    <ul class="list-group">
+      {% for item in order.items %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ item.item_name }} × {{ item.quantity }}</span>
+        <span>R$ {{ '%.2f'|format(item.product.price if item.product else 0) }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    <p class="text-end fw-bold mt-3">Total: R$ {{ '%.2f'|format(order.total_value()) }}</p>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-body">
+      <h5 class="card-title">Linha do Tempo</h5>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Criado em {{ order.created_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        {% if order.payment and order.payment.status == PaymentStatus.COMPLETED %}
+        <li class="list-group-item">Pago em {{ order.payment.created_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        {% endif %}
+        {% if delivery and delivery.accepted_at %}
+        <li class="list-group-item">Em preparo desde {{ delivery.accepted_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        {% endif %}
+        {% if delivery and delivery.completed_at %}
+        <li class="list-group-item">Entregue em {{ delivery.completed_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+
+  {% if delivery and delivery.tracking_code %}
+  <div class="mb-4">
+    <label class="form-label fw-bold">Código de Rastreio</label>
+    <div class="input-group">
+      <input type="text" class="form-control" value="{{ delivery.tracking_code }}" readonly id="trackInput">
+      <button class="btn btn-outline-secondary" type="button" onclick="navigator.clipboard.writeText(document.getElementById('trackInput').value)">
+        <i class="bi bi-clipboard"></i>
+      </button>
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add DB indexes for payment and order filtering
- poll payment status via API with spinner feedback
- show order summary on payment status page
- create customer order history and detail pages
- expose API to return logged-in user's orders
- test new routes and access controls

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801b098f04832ebeabe4faae19af53