### PR TITLE
Add retry button for failed Mercado Pago payments

### DIFF
--- a/app.py
+++ b/app.py
@@ -3371,6 +3371,8 @@ def payment_status(payment_id):
     payment = Payment.query.get_or_404(payment_id)
     result  = request.args.get("status") or payment.status.name.lower()
 
+    form = CheckoutForm()
+
     delivery_req = (DeliveryRequest.query
                     .filter_by(order_id=payment.order_id)
                     .first())
@@ -3388,7 +3390,8 @@ def payment_status(payment_id):
         result       = result,
         req_id       = delivery_req.id if delivery_req else None,
         req_endpoint = endpoint,
-        order        = payment.order
+        order        = payment.order,
+        form         = form
     )
 
 

--- a/templates/payment_status.html
+++ b/templates/payment_status.html
@@ -46,7 +46,16 @@
     <p class="text-end fw-bold">Total: R$ {{ '%.2f'|format(order.total_value()) }}</p>
     {% endif %}
 
-    <div class="d-flex justify-content-center gap-3">
+    <div class="d-flex justify-content-center flex-wrap gap-3">
+
+{% if result in ['failure', 'failed'] %}
+  <form action="{{ url_for('checkout') }}" method="post" class="m-0">
+    {{ form.hidden_tag() }}
+    <button type="submit" class="btn btn-primary">
+      <i class="bi bi-arrow-repeat me-1"></i> Pagar com Mercado Pago
+    </button>
+  </form>
+{% endif %}
 
 {% if req_id %}
   <a href="{{ url_for(req_endpoint, req_id=req_id) }}"


### PR DESCRIPTION
## Summary
- allow retrying Mercado Pago checkout when a payment fails
- pass `CheckoutForm` to payment status view
- add Mercado Pago retry form on payment status page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ba852888832e9b5a5d7dcb516e3c