### PR TITLE
Handle missing Mercado Pago webhook secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ export MERCADOPAGO_PUBLIC_KEY="<your public key>"
 export MERCADOPAGO_WEBHOOK_SECRET="<random secret>"
 ```
 
+`MERCADOPAGO_WEBHOOK_SECRET` **must** be set so webhook signatures can be
+verified. When unset, notifications will be rejected.
+
 These credentials are used when generating checkout preferences and embedding
 payment widgets. Never commit your real keys into version control.
 

--- a/app.py
+++ b/app.py
@@ -3192,8 +3192,10 @@ def verify_mp_signature(req, secret: str) -> bool:
         bool: True if signature is valid, False otherwise
     """
     if not secret:
-        current_app.logger.warning("Webhook sem chave – bypass")
-        return True
+        current_app.logger.warning(
+            "Webhook sem chave – verificacao impossivel"
+        )
+        return False
 
     x_signature = req.headers.get("X-Signature", "")
     m = _SIG_RE.search(x_signature)


### PR DESCRIPTION
## Summary
- fail Mercado Pago webhook verification if the secret is missing
- document that `MERCADOPAGO_WEBHOOK_SECRET` must be set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a4424fd4832e8868a9b53250083b