### PR TITLE
Store payment amount

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -28,7 +28,7 @@
           </div>
           <div class="small text-muted">
             <div>Cliente: {{ ord.user.name if ord and ord.user else "—" }}</div>
-            <div>Valor: R$ {{ ord.total_value()|round(2) if ord else "—" }}</div>
+            <div>Valor: R$ {{ ((ord.payment.__dict__.get('amount') if ord and ord.payment else None) or (ord.total_value() if ord else 0)) | round(2) if ord else "—" }}</div>
 
             {% if r.status == "pendente" %}
               <div>Solicitado em {{ r.requested_at.strftime("%d/%m/%Y %H:%M") }}</div>

--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -23,7 +23,7 @@
 
           <div class="small text-muted">
             {% if ord and ord.user %}Cliente: {{ ord.user.name }}<br>{% endif %}
-            {% if ord %}Valor: R$ {{ ord.total_value()|round(2) }}<br>{% endif %}
+            {% if ord %}Valor: R$ {{ ((ord.payment.__dict__.get('amount') if ord.payment else None) or ord.total_value()) | round(2) }}<br>{% endif %}
 
             {% if req.status == 'pendente'      %}
               Solicitado {{ req.requested_at.strftime('%d/%m/%Y %H:%M') }}

--- a/templates/minhas_compras.html
+++ b/templates/minhas_compras.html
@@ -19,7 +19,7 @@
         <tr>
           <td>{{ o.id }}</td>
           <td>{{ o.created_at.strftime('%d/%m/%Y') }}</td>
-          <td>R$ {{ '%.2f'|format(o.total_value()) }}</td>
+          <td>R$ {{ '%.2f'|format(((o.payment.__dict__.get('amount') if o.payment else None) or o.total_value())) }}</td>
           <td>
             <span class="badge{% if o.payment and o.payment.status == PaymentStatus.COMPLETED %} bg-success{% elif not o.payment or o.payment.status == PaymentStatus.PENDING %} bg-warning text-dark{% else %} bg-danger{% endif %}">
               {{ o.payment.status.value if o.payment else 'Pendente' }}

--- a/templates/pagamento.html
+++ b/templates/pagamento.html
@@ -3,7 +3,7 @@
 <div class="container mt-4">
   <h2 class="text-center mb-4">Pagamento via Pix</h2>
   <div class="text-center">
-    <p>Total: <strong>R$ {{ order.total_value()|round(2) }}</strong></p>
+    <p>Total: <strong>R$ {{ (payment.__dict__.get('amount') or order.total_value())|round(2) }}</strong></p>
     <img src="{{ url_for('static', filename='img/qr_simulado.png') }}" alt="QR Code Pix" width="250">
     <p class="mt-2">Escaneie com seu app de banco ou clique abaixo para simular:</p>
     <form action="{{ url_for('confirmar_pagamento', payment_id=payment.id) }}" method="post">

--- a/templates/payment_status.html
+++ b/templates/payment_status.html
@@ -43,7 +43,7 @@
       </li>
       {% endfor %}
     </ul>
-    <p class="text-end fw-bold">Total: R$ {{ '%.2f'|format(order.total_value()) }}</p>
+    <p class="text-end fw-bold">Total: R$ {{ '%.2f'|format((payment.__dict__.get('amount') or order.total_value())) }}</p>
     {% endif %}
 
     <div class="d-flex justify-content-center flex-wrap gap-3">

--- a/templates/pedido_detail.html
+++ b/templates/pedido_detail.html
@@ -13,7 +13,7 @@
       </li>
       {% endfor %}
     </ul>
-    <p class="text-end fw-bold mt-3">Total: R$ {{ '%.2f'|format(order.total_value()) }}</p>
+    <p class="text-end fw-bold mt-3">Total: R$ {{ '%.2f'|format(((order.payment.__dict__.get('amount') if order.payment else None) or order.total_value())) }}</p>
   </div>
 
   <div class="card mb-4">


### PR DESCRIPTION
## Summary
- store frozen payment amount on checkout
- return stored amount via API
- display stored totals across templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a43d3a2c832ea02a800812b23caf