### PR TITLE
Remove global MP SDK

### DIFF
--- a/app.py
+++ b/app.py
@@ -3096,9 +3096,6 @@ def ver_carrinho():
 import json, logging, os
 from flask import current_app, redirect, url_for, flash, session
 from flask_login import login_required, current_user
-from mercadopago import SDK
-
-sdk = SDK(os.getenv("MERCADOPAGO_ACCESS_TOKEN"))       # inicializa 1×
 
 @app.route("/checkout", methods=["POST"])
 @login_required
@@ -3147,7 +3144,7 @@ def checkout():
 
     # 5️⃣ cria Preference no Mercado Pago
     try:
-        resp = sdk.preference().create(preference_data)
+        resp = mp_sdk().preference().create(preference_data)
     except Exception:
         current_app.logger.exception("Erro de conexão com Mercado Pago")
         flash("Falha ao conectar com Mercado Pago.", "danger")
@@ -3265,7 +3262,7 @@ def notificacoes_mercado_pago():
         return jsonify(status="ignored"), 200
 
     # Query payment
-    resp = sdk.payment().get(mp_id)
+    resp = mp_sdk().payment().get(mp_id)
     if resp.get("status") == 404:
         with db.session.begin():
             p = PendingWebhook.query.filter_by(mp_id=mp_id).first()
@@ -3382,7 +3379,7 @@ from flask import render_template, abort, request, jsonify
 def _refresh_mp_status(payment: Payment) -> None:
     if payment.status != PaymentStatus.PENDING:
         return
-    resp = sdk.payment().get(payment.mercado_pago_id or payment.transaction_id)
+    resp = mp_sdk().payment().get(payment.mercado_pago_id or payment.transaction_id)
     if resp.get("status") != 200:
         current_app.logger.warning("MP lookup falhou: %s", resp)
         return

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 import app as app_module
-from app import app as flask_app, sdk, db
+from app import app as flask_app, mp_sdk, db
 from models import (
     User,
     Payment,
@@ -173,7 +173,7 @@ def test_payment_status_updates_from_api(monkeypatch, app):
             def get(self, _):
                 return {"status": 200, "response": {"status": "approved"}}
 
-        monkeypatch.setattr(sdk, 'payment', lambda: FakePaymentAPI())
+        monkeypatch.setattr(app_module, 'mp_sdk', lambda: type('O', (), {'payment': lambda: FakePaymentAPI()})())
 
         response = client.get('/payment_status/1?status=success')
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
- remove global `sdk` from payment routes
- use `mp_sdk()` lazily for checkout and payment status
- update tests to patch `mp_sdk` instead of `sdk`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a42b307c832e9ae7f1cd12a0ed05