### PR TITLE
Implement product detail page with admin options

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -120,3 +120,17 @@ class CheckoutForm(FlaskForm):
     # phone  = StringField('Telefone (WhatsApp)', validators=[Optional(), Length(max=20)])
 
     submit = SubmitField('Finalizar Compra')
+
+
+class ProductUpdateForm(FlaskForm):
+    name = StringField('Nome', validators=[DataRequired()])
+    description = TextAreaField('Descrição')
+    price = DecimalField('Preço', validators=[DataRequired()])
+    stock = IntegerField('Estoque', validators=[DataRequired()])
+    image_upload = FileField('Imagem', validators=[FileAllowed(['jpg', 'jpeg', 'png', 'gif'], 'Apenas imagens!')])
+    submit = SubmitField('Salvar')
+
+
+class ProductPhotoForm(FlaskForm):
+    image = FileField('Foto do Produto', validators=[DataRequired(), FileAllowed(['jpg', 'jpeg', 'png', 'gif'], 'Apenas imagens!')])
+    submit = SubmitField('Adicionar Foto')

--- a/migrations/versions/59ba2d1f5928_add_product_photo_model.py
+++ b/migrations/versions/59ba2d1f5928_add_product_photo_model.py
@@ -1,0 +1,21 @@
+"""Add ProductPhoto table"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '59ba2d1f5928'
+down_revision = 'e8aff173e0fe'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'product_photo',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('product_id', sa.Integer(), sa.ForeignKey('product.id'), nullable=False),
+        sa.Column('image_url', sa.String(length=200), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_table('product_photo')

--- a/models.py
+++ b/models.py
@@ -535,6 +535,15 @@ class Product(db.Model):
         return f"{self.name} (R$ {self.price})"
 
 
+class ProductPhoto(db.Model):
+    """Fotos adicionais para produtos."""
+    id = db.Column(db.Integer, primary_key=True)
+    product_id = db.Column(db.Integer, db.ForeignKey('product.id'), nullable=False)
+    image_url = db.Column(db.String(200))
+
+    product = db.relationship('Product', backref='extra_photos')
+
+
 
 
 

--- a/templates/loja.html
+++ b/templates/loja.html
@@ -34,15 +34,15 @@
     <div class="col">
       <div class="card h-100 border-0 shadow-sm overflow-hidden product-card">
         <!-- Product Image -->
-        <div class="position-relative overflow-hidden" style="height: 220px;">
+        <a href="{{ url_for('produto_detail', product_id=product.id) }}" class="position-relative overflow-hidden d-block" style="height: 220px;">
           {% if product.image_url %}
             {% if 'http' in product.image_url %}
-              <img src="{{ product.image_url }}" 
-                   class="img-fluid w-100 h-100 object-fit-cover" 
+              <img src="{{ product.image_url }}"
+                   class="img-fluid w-100 h-100 object-fit-cover"
                    alt="{{ product.name }}">
             {% else %}
-              <img src="{{ url_for('static', filename=product.image_url) }}" 
-                   class="img-fluid w-100 h-100 object-fit-cover" 
+              <img src="{{ url_for('static', filename=product.image_url) }}"
+                   class="img-fluid w-100 h-100 object-fit-cover"
                    alt="{{ product.name }}">
             {% endif %}
           {% else %}
@@ -53,7 +53,7 @@
           <div class="product-badge position-absolute top-0 end-0 bg-danger text-white p-2 small">
             <i class="bi bi-tag"></i> Novo
           </div>
-        </div>
+        </a>
         
         <!-- Product Info -->
         <div class="card-body d-flex flex-column pb-0">

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -1,0 +1,64 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container py-4">
+  <div class="row">
+    <div class="col-md-6">
+      {% if product.image_url %}
+      <img src="{{ product.image_url }}" class="img-fluid mb-3" alt="{{ product.name }}">
+      {% endif %}
+      {% for photo in product.extra_photos %}
+        <img src="{{ photo.image_url }}" class="img-thumbnail me-2 mb-2" style="height:100px" alt="Foto extra">
+      {% endfor %}
+    </div>
+    <div class="col-md-6">
+      <h2>{{ product.name }}</h2>
+      <p>{{ product.description }}</p>
+      <p class="h4 text-success">R$ {{ '%.2f'|format(product.price)|replace('.', ',') }}</p>
+      <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}" method="post" class="d-flex align-items-center gap-2">
+        {{ cart_form.hidden_tag() }}
+        {{ cart_form.quantity(class="form-control w-auto", min="1") }}
+        <button type="submit" class="btn btn-primary">Adicionar ao Carrinho</button>
+      </form>
+    </div>
+  </div>
+
+  {% if is_admin %}
+  <hr>
+  <h4>Editar Produto</h4>
+  <form method="post" enctype="multipart/form-data">
+    {{ update_form.hidden_tag() }}
+    <div class="mb-3">
+      {{ update_form.name.label(class="form-label") }}
+      {{ update_form.name(class="form-control") }}
+    </div>
+    <div class="mb-3">
+      {{ update_form.description.label(class="form-label") }}
+      {{ update_form.description(class="form-control") }}
+    </div>
+    <div class="row">
+      <div class="col-md-4 mb-3">
+        {{ update_form.price.label(class="form-label") }}
+        {{ update_form.price(class="form-control") }}
+      </div>
+      <div class="col-md-4 mb-3">
+        {{ update_form.stock.label(class="form-label") }}
+        {{ update_form.stock(class="form-control") }}
+      </div>
+      <div class="col-md-4 mb-3">
+        {{ update_form.image_upload.label(class="form-label") }}
+        {{ update_form.image_upload(class="form-control") }}
+      </div>
+    </div>
+    <button type="submit" class="btn btn-success" name="upd-submit">{{ update_form.submit.label.text }}</button>
+  </form>
+
+  <hr>
+  <h4>Adicionar Foto</h4>
+  <form method="post" enctype="multipart/form-data">
+    {{ photo_form.hidden_tag() }}
+    {{ photo_form.image(class="form-control mb-2") }}
+    <button type="submit" class="btn btn-primary" name="photo-submit">{{ photo_form.submit.label.text }}</button>
+  </form>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `ProductPhoto` model and migration
- add forms for product editing and photos
- implement `/produto/<id>` route for product details
- link product images in store to the new detail page
- add template for product details with admin controls
- extend tests for new route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b5c2d0f0832ebc42f69420fe842a