### PR TITLE
Enable admin controls on delivery overview

### DIFF
--- a/app.py
+++ b/app.py
@@ -2897,6 +2897,50 @@ def delivery_overview():
     )
 
 
+@app.route('/admin/delivery_requests/<int:req_id>/status/<status>', methods=['POST'])
+@login_required
+def admin_set_delivery_status(req_id, status):
+    if not _is_admin():
+        abort(403)
+
+    allowed = ['pendente', 'em_andamento', 'cancelada']
+    if status not in allowed:
+        abort(400)
+
+    req = DeliveryRequest.query.get_or_404(req_id)
+    now = datetime.utcnow()
+    req.status = status
+
+    if status == 'pendente':
+        req.worker_id = None
+        req.accepted_at = None
+        req.canceled_at = None
+        req.canceled_by_id = None
+    elif status == 'em_andamento':
+        if not req.accepted_at:
+            req.accepted_at = now
+    elif status == 'cancelada':
+        req.canceled_at = now
+        req.canceled_by_id = current_user.id
+
+    db.session.commit()
+    flash('Status atualizado.', 'success')
+    return redirect(url_for('delivery_overview'))
+
+
+@app.route('/admin/delivery_requests/<int:req_id>/delete', methods=['POST'])
+@login_required
+def admin_delete_delivery(req_id):
+    if not _is_admin():
+        abort(403)
+
+    req = DeliveryRequest.query.get_or_404(req_id)
+    db.session.delete(req)
+    db.session.commit()
+    flash('Entrega excluída.', 'info')
+    return redirect(url_for('delivery_overview'))
+
+
 
 # ========================================================
 #  PAGAMENTO – Mercado Pago (Checkout Pro PIX) - CORRECTED

--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -40,10 +40,24 @@
           </div>
         </div>
 
-        <a href="{{ url_for('admin_delivery_detail', req_id=r.id) }}"
-           class="btn btn-sm btn-outline-primary mt-2 mt-md-0">
-           Ver detalhes
-        </a>
+        <div class="d-flex flex-wrap gap-1 mt-2 mt-md-0">
+          <a href="{{ url_for('admin_delivery_detail', req_id=r.id) }}"
+             class="btn btn-sm btn-outline-primary">
+             Ver detalhes
+          </a>
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='pendente') }}" method="post">
+            <button class="btn btn-sm btn-warning" title="Marcar como pendente">Pendente</button>
+          </form>
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='em_andamento') }}" method="post">
+            <button class="btn btn-sm btn-info text-dark" title="Marcar em andamento">Em andamento</button>
+          </form>
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='cancelada') }}" method="post">
+            <button class="btn btn-sm btn-danger" title="Cancelar">Cancelar</button>
+          </form>
+          <form action="{{ url_for('admin_delete_delivery', req_id=r.id) }}" method="post" onsubmit="return confirm('Excluir pedido?');">
+            <button class="btn btn-sm btn-outline-danger" title="Excluir">Excluir</button>
+          </form>
+        </div>
       </li>
     {% else %}
       <li class="list-group-item text-muted">Não há registros.</li>


### PR DESCRIPTION
## Summary
- allow admin to set delivery status or delete a request
- expose buttons on delivery overview page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b614dc10832ea934779200ff6af1