### PR TITLE
Enable admin controls on delivery overview

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -36,14 +36,30 @@
               <div>Aceito por {{ r.worker.name if r.worker else "—" }} em {{ r.accepted_at.strftime("%d/%m/%Y %H:%M") if r.accepted_at else "—" }}</div>
             {% elif r.status == "concluida" %}
               <div>Concluído em {{ r.completed_at.strftime("%d/%m/%Y %H:%M") if r.completed_at else "—" }}</div>
+            {% elif r.status == "cancelada" %}
+              <div>Cancelado em {{ r.canceled_at.strftime("%d/%m/%Y %H:%M") if r.canceled_at else "—" }}</div>
             {% endif %}
           </div>
         </div>
 
-        <a href="{{ url_for('admin_delivery_detail', req_id=r.id) }}"
-           class="btn btn-sm btn-outline-primary mt-2 mt-md-0">
-           Ver detalhes
-        </a>
+        <div class="d-flex flex-wrap gap-1 mt-2 mt-md-0">
+          <a href="{{ url_for('admin_delivery_detail', req_id=r.id) }}"
+             class="btn btn-sm btn-outline-primary">
+             Ver detalhes
+          </a>
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='pendente') }}" method="post">
+            <button class="btn btn-sm btn-warning" title="Marcar como pendente">Pendente</button>
+          </form>
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='em_andamento') }}" method="post">
+            <button class="btn btn-sm btn-info text-dark" title="Marcar em andamento">Em andamento</button>
+          </form>
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='cancelada') }}" method="post">
+            <button class="btn btn-sm btn-danger" title="Cancelar">Cancelar</button>
+          </form>
+          <form action="{{ url_for('admin_delete_delivery', req_id=r.id) }}" method="post" onsubmit="return confirm('Excluir pedido?');">
+            <button class="btn btn-sm btn-outline-danger" title="Excluir">Excluir</button>
+          </form>
+        </div>
       </li>
     {% else %}
       <li class="list-group-item text-muted">Não há registros.</li>
@@ -55,6 +71,7 @@
   {{ lista(open_requests, "🟡 Solicitações Abertas",   "bg-warning text-dark", "Pendente") }}
   {{ lista(in_progress,   "🔵 Em Andamento",          "bg-info text-dark",   "Em andamento") }}
   {{ lista(completed,     "✅ Concluídas",            "bg-success",          "Concluída") }}
+  {{ lista(canceled,      "❌ Canceladas",            "bg-danger",           "Cancelada") }}
 
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow admin to set delivery status or delete a request
- expose buttons on delivery overview page
- show canceled deliveries list for admins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882b614dc10832ea934779200ff6af1