### PR TITLE
Add admin delivery controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -2908,7 +2908,7 @@ def admin_set_delivery_status(req_id, status):
     if not _is_admin():
         abort(403)
 
-    allowed = ['pendente', 'em_andamento', 'cancelada']
+    allowed = ['pendente', 'em_andamento', 'concluida', 'cancelada']
     if status not in allowed:
         abort(400)
 
@@ -2921,12 +2921,24 @@ def admin_set_delivery_status(req_id, status):
         req.accepted_at = None
         req.canceled_at = None
         req.canceled_by_id = None
+        req.completed_at = None
     elif status == 'em_andamento':
         if not req.accepted_at:
             req.accepted_at = now
+        req.canceled_at = None
+        req.canceled_by_id = None
+        req.completed_at = None
+    elif status == 'concluida':
+        if not req.completed_at:
+            req.completed_at = now
+        if not req.accepted_at:
+            req.accepted_at = now
+        req.canceled_at = None
+        req.canceled_by_id = None
     elif status == 'cancelada':
         req.canceled_at = now
         req.canceled_by_id = current_user.id
+        req.completed_at = None
 
     db.session.commit()
     flash('Status atualizado.', 'success')

--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -17,7 +17,7 @@
 
   {% macro lista(reqs, titulo, cls_badge, lbl_badge) %}
   <h4 class="mt-4 {{ cls_badge }}">{{ titulo }}</h4>
-  <ul class="list-group shadow-sm mb-5">
+  <ul class="list-group shadow-sm mb-4">
     {% for r in reqs %}
       {% set ord = r.order %}
       <li class="list-group-item d-flex justify-content-between flex-column flex-md-row align-items-start align-items-md-center">
@@ -47,15 +47,26 @@
              class="btn btn-sm btn-outline-primary">
              Ver detalhes
           </a>
+          {% if r.status != 'pendente' %}
           <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='pendente') }}" method="post">
             <button class="btn btn-sm btn-warning" title="Marcar como pendente">Pendente</button>
           </form>
+          {% endif %}
+          {% if r.status != 'em_andamento' %}
           <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='em_andamento') }}" method="post">
             <button class="btn btn-sm btn-info text-dark" title="Marcar em andamento">Em andamento</button>
           </form>
+          {% endif %}
+          {% if r.status != 'concluida' %}
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='concluida') }}" method="post">
+            <button class="btn btn-sm btn-success" title="Marcar como concluída">Concluir</button>
+          </form>
+          {% endif %}
+          {% if r.status != 'cancelada' %}
           <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='cancelada') }}" method="post">
             <button class="btn btn-sm btn-danger" title="Cancelar">Cancelar</button>
           </form>
+          {% endif %}
           <form action="{{ url_for('admin_delete_delivery', req_id=r.id) }}" method="post" onsubmit="return confirm('Excluir pedido?');">
             <button class="btn btn-sm btn-outline-danger" title="Excluir">Excluir</button>
           </form>
@@ -68,10 +79,20 @@
   {% endmacro %}
 
   <!-- ▸ Listas ----------------------------------------------------------- -->
-  {{ lista(open_requests, "🟡 Solicitações Abertas",   "bg-warning text-dark", "Pendente") }}
-  {{ lista(in_progress,   "🔵 Em Andamento",          "bg-info text-dark",   "Em andamento") }}
-  {{ lista(completed,     "✅ Concluídas",            "bg-success",          "Concluída") }}
-  {{ lista(canceled,      "❌ Canceladas",            "bg-danger",           "Cancelada") }}
+  <div class="row row-cols-1 row-cols-md-4 g-4">
+    <div class="col">
+      {{ lista(open_requests, "🟡 Solicitações Abertas",   "bg-warning text-dark", "Pendente") }}
+    </div>
+    <div class="col">
+      {{ lista(in_progress,   "🔵 Em Andamento",          "bg-info text-dark",   "Em andamento") }}
+    </div>
+    <div class="col">
+      {{ lista(completed,     "✅ Concluídas",            "bg-success",          "Concluída") }}
+    </div>
+    <div class="col">
+      {{ lista(canceled,      "❌ Canceladas",            "bg-danger",           "Cancelada") }}
+    </div>
+  </div>
 
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable admins to mark deliveries as completed
- show canceled deliveries in `delivery_overview`
- display lists side by side in a row
- reset timestamps when status changes
- hide redundant status actions in admin view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882bf8d76c0832e81fd1b5bad610c47