### PR TITLE
Switch all timestamps to Brasília zone

### DIFF
--- a/templates/conversa.html
+++ b/templates/conversa.html
@@ -9,7 +9,7 @@
             <div class="p-2 rounded {% if msg.sender_id == current_user.id %}bg-info-subtle{% else %}bg-light{% endif %}">
                 <small>{{ msg.sender.name }}:</small><br>
                 {{ msg.content }}
-                <div class="text-muted small">{{ msg.timestamp.strftime('%d/%m %H:%M') }}</div>
+                <div class="text-muted small">{{ msg.timestamp|format_datetime_brazil('%d/%m %H:%M') }}</div>
             </div>
         </div>
     {% endfor %}

--- a/templates/delivery_detail.html
+++ b/templates/delivery_detail.html
@@ -104,15 +104,15 @@
     <div class="card-body">
       <h5 class="card-title">📅 Linha do Tempo</h5>
       <ul class="list-group list-group-flush">
-        <li class="list-group-item">🕐 Solicitado: {{ req.requested_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        <li class="list-group-item">🕐 Solicitado: {{ req.requested_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</li>
         {% if req.accepted_at %}
-        <li class="list-group-item">🚚 Aceito: {{ req.accepted_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        <li class="list-group-item">🚚 Aceito: {{ req.accepted_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</li>
         {% endif %}
         {% if req.completed_at %}
-        <li class="list-group-item">✅ Concluído: {{ req.completed_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        <li class="list-group-item">✅ Concluído: {{ req.completed_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</li>
         {% endif %}
         {% if req.canceled_at %}
-        <li class="list-group-item text-danger">❌ Cancelado: {{ req.canceled_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        <li class="list-group-item text-danger">❌ Cancelado: {{ req.canceled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</li>
         {% endif %}
       </ul>
     </div>

--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -26,13 +26,13 @@
             {% if ord %}Valor: R$ {{ ((ord.payment.__dict__.get('amount') if ord.payment else None) or ord.total_value()) | round(2) }}<br>{% endif %}
 
             {% if req.status == 'pendente'      %}
-              Solicitado {{ req.requested_at.strftime('%d/%m/%Y %H:%M') }}
+              Solicitado {{ req.requested_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}
             {% elif req.status == 'em_andamento' %}
-              Aceito {{ req.accepted_at.strftime('%d/%m/%Y %H:%M') if req.accepted_at else '' }}
+              Aceito {{ format_datetime_brazil(req.accepted_at, '%d/%m/%Y %H:%M') if req.accepted_at else '' }}
             {% elif req.status == 'concluida'    %}
-              Concluído {{ req.completed_at.strftime('%d/%m/%Y %H:%M') if req.completed_at else '' }}
+              Concluído {{ format_datetime_brazil(req.completed_at, '%d/%m/%Y %H:%M') if req.completed_at else '' }}
             {% elif req.status == 'cancelada'    %}
-              Cancelado {{ req.canceled_at.strftime('%d/%m/%Y %H:%M') if req.canceled_at else '' }}
+              Cancelado {{ format_datetime_brazil(req.canceled_at, '%d/%m/%Y %H:%M') if req.canceled_at else '' }}
             {% endif %}
           </div>
         </div>

--- a/templates/detalhes_racao.html
+++ b/templates/detalhes_racao.html
@@ -33,7 +33,7 @@
           </td>
           <td>{{ r.animal.owner.name }}</td>
           <td>{{ r.animal.owner.phone or "—" }}</td>
-          <td>{{ r.data_cadastro.strftime('%d/%m/%Y') }}</td>
+          <td>{{ r.data_cadastro|format_datetime_brazil('%d/%m/%Y') }}</td>
 
           {# Cálculo da recomendação diária #}
           {% if r.recomendacao_custom %}

--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -5,7 +5,7 @@
 
   {% if animal.removido_em %}
     <div class="alert alert-warning">
-      Este animal foi removido do sistema em {{ animal.removido_em.strftime('%d/%m/%Y') }}. Histórico preservado.
+      Este animal foi removido do sistema em {{ animal.removido_em|format_datetime_brazil('%d/%m/%Y') }}. Histórico preservado.
     </div>
   {% endif %}
 
@@ -57,7 +57,7 @@
       <div class="card mb-2 shadow-sm">
         <div class="card-body d-flex justify-content-between align-items-center">
           <span class="text-dark">
-            {{ bloco.data_criacao.strftime('%d/%m/%Y') }} — {{ bloco.prescricoes | length }} medicação(ões)
+            {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y') }} — {{ bloco.prescricoes | length }} medicação(ões)
           </span>
           {% if current_user.worker == 'veterinario' %}
             <a href="{{ url_for('imprimir_bloco_prescricao', bloco_id=bloco.id) }}"
@@ -77,7 +77,7 @@
       <div class="card mb-2 shadow-sm">
         <div class="card-body d-flex justify-content-between align-items-center">
           <span class="text-dark">
-            {{ bloco.data_criacao.strftime('%d/%m/%Y') }} — {{ bloco.exames | length }} exame(s)
+            {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y') }} — {{ bloco.exames | length }} exame(s)
           </span>
           {% if current_user.worker == 'veterinario' %}
             <a href="{{ url_for('imprimir_bloco_exames', bloco_id=bloco.id) }}"
@@ -96,7 +96,7 @@
       <ul class="list-group mb-2">
         {% for c in consultas[:3] %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
-          <span>{{ c.created_at.strftime('%d/%m/%Y') }}</span>
+          <span>{{ c.created_at|format_datetime_brazil('%d/%m/%Y') }}</span>
           <span class="text-muted small">{{ c.veterinario.name }}</span>
         </li>
         {% endfor %}
@@ -116,7 +116,7 @@
     {% for v in animal.vacinas|sort(attribute='data', reverse=True) %}
     <li class="list-group-item d-flex justify-content-between align-items-center">
       <div>
-        <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.data.strftime('%d/%m/%Y') if v.data else 'Data não registrada' }}
+        <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ format_datetime_brazil(v.data, '%d/%m/%Y') if v.data else 'Data não registrada' }}
         {% if v.observacoes %}
           <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
         {% endif %}
@@ -196,7 +196,7 @@
     <div>
       Este animal foi marcado como <strong>falecido</strong>.
       {% if animal.falecido_em %}
-        Data do falecimento: {{ animal.falecido_em.strftime('%d/%m/%Y %H:%M') }}
+        Data do falecimento: {{ animal.falecido_em|format_datetime_brazil('%d/%m/%Y %H:%M') }}
       {% endif %}
     </div>
 

--- a/templates/mensagens.html
+++ b/templates/mensagens.html
@@ -24,7 +24,7 @@
                             {% if msg.animal %}
                                 <small class="text-muted">Sobre o animal: {{ msg.animal.name }}</small><br>
                             {% endif %}
-                            <small class="text-muted">{{ msg.timestamp.strftime('%d/%m/%Y %H:%M') }}</small>
+                            <small class="text-muted">{{ msg.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }}</small>
                         </div>
                     </div>
                     {% set unread_count = msg.sender.sent_messages | selectattr("animal_id", "equalto", msg.animal.id)

--- a/templates/minhas_compras.html
+++ b/templates/minhas_compras.html
@@ -18,7 +18,7 @@
         {% for o in orders %}
         <tr>
           <td>{{ o.id }}</td>
-          <td>{{ o.created_at.strftime('%d/%m/%Y') }}</td>
+          <td>{{ o.created_at|format_datetime_brazil('%d/%m/%Y') }}</td>
           <td>R$ {{ '%.2f'|format(((o.payment.__dict__.get('amount') if o.payment else None) or o.total_value())) }}</td>
           <td>
             <span class="badge{% if o.payment and o.payment.status == PaymentStatus.COMPLETED %} bg-success{% elif not o.payment or o.payment.status == PaymentStatus.PENDING %} bg-warning text-dark{% else %} bg-danger{% endif %}">

--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -18,7 +18,7 @@
               <div>
                 <h5 class="card-title">{{ animal.name }}</h5>
                 <p class="mb-1"><strong>Espécie:</strong> {{ animal.species }}</p>
-                <p class="mb-1"><strong>Adicionado em:</strong> {{ animal.date_added.strftime('%d/%m/%Y') }}</p>
+                <p class="mb-1"><strong>Adicionado em:</strong> {{ animal.date_added|format_datetime_brazil('%d/%m/%Y') }}</p>
               </div>
               <div class="d-flex flex-wrap gap-2 mt-3">
                 <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary w-100">🩺 Consulta</a>

--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -1,7 +1,7 @@
 {% if edit_mode %}
   <div class="alert alert-warning d-flex align-items-center">
     <i class="bi bi-pencil-square me-2"></i>
-    Editando consulta de {{ consulta.created_at.strftime('%d/%m/%Y %H:%M') }}.
+    Editando consulta de {{ consulta.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}.
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" class="ms-2">Cancelar edição</a>
   </div>
 {% endif %}

--- a/templates/partials/food_form.html
+++ b/templates/partials/food_form.html
@@ -173,7 +173,7 @@
         <strong>Observações:</strong>
         {{ racao.observacoes_racao or racao.tipo_racao.observacoes or 'Nenhuma' }}<br>
 
-        <small class="text-muted">Registrado em {{ racao.data_cadastro.strftime('%d/%m/%Y') }}</small>
+        <small class="text-muted">Registrado em {{ racao.data_cadastro|format_datetime_brazil('%d/%m/%Y') }}</small>
 
         <div class="mt-2">
           <button class="btn btn-sm btn-outline-primary me-2" onclick="editarRacao({{ racao.id }})">✏️ Editar</button>

--- a/templates/partials/food_formbackup
+++ b/templates/partials/food_formbackup
@@ -64,7 +64,7 @@
         {{ racao.recomendacao_custom or racao.tipo_racao.recomendacao }} g/kg/dia<br>
         <strong>Observações:</strong>
         {{ racao.observacoes_racao or racao.tipo_racao.observacoes or 'Nenhuma' }}<br>
-        <small class="text-muted">Registrado em {{ racao.data_cadastro.strftime('%d/%m/%Y') }}</small>
+        <small class="text-muted">Registrado em {{ racao.data_cadastro|format_datetime_brazil('%d/%m/%Y') }}</small>
       </li>
     {% endfor %}
   </ul>

--- a/templates/partials/historico_consultas.html
+++ b/templates/partials/historico_consultas.html
@@ -23,7 +23,7 @@
     <tbody>
       {% for c in historico_consultas %}
       <tr>
-        <td class="text-nowrap">{{ c.created_at.strftime('%d/%m/%Y %H:%M') }}</td>
+        <td class="text-nowrap">{{ c.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</td>
         <td class="break-word-cell">{{ c.queixa_principal or '—' }}</td>
         <td class="break-word-cell">{{ c.historico_clinico or '—' }}</td>
         <td class="break-word-cell">{{ c.exame_fisico or '—' }}</td>

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -8,7 +8,7 @@
   <div class="border p-3 mb-4 bg-light rounded" id="bloco-{{ bloco.id }}">
     <div class="d-flex justify-content-between align-items-center mb-2">
       <div>
-        <strong>Exames solicitados em {{ bloco.data_criacao.strftime('%d/%m/%Y %H:%M') }}</strong>
+        <strong>Exames solicitados em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</strong>
       </div>
       <div class="d-flex gap-2">
         <form method="POST" action="{{ url_for('deletar_bloco_exames', bloco_id=bloco.id) }}" onsubmit="return confirm('Deseja realmente excluir este bloco de exames?');">

--- a/templates/partials/historico_prescricoes.html
+++ b/templates/partials/historico_prescricoes.html
@@ -5,7 +5,7 @@
 
     {% for bloco in animal.blocos_prescricao|reverse %}
     <div class="border rounded p-3 mb-3">
-      <h6 class="text-muted">Prescrição feita em {{ bloco.data_criacao.strftime('%d/%m/%Y %H:%M') }}</h6>
+      <h6 class="text-muted">Prescrição feita em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</h6>
 
       <ul class="list-group list-group-flush mb-2">
         {% for item in bloco.prescricoes %}

--- a/templates/pedido_detail.html
+++ b/templates/pedido_detail.html
@@ -20,15 +20,15 @@
     <div class="card-body">
       <h5 class="card-title">Linha do Tempo</h5>
       <ul class="list-group list-group-flush">
-        <li class="list-group-item">Criado em {{ order.created_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        <li class="list-group-item">Criado em {{ order.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</li>
         {% if order.payment and order.payment.status == PaymentStatus.COMPLETED %}
-        <li class="list-group-item">Pago em {{ order.payment.created_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        <li class="list-group-item">Pago em {{ order.payment.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</li>
         {% endif %}
         {% if delivery and delivery.accepted_at %}
-        <li class="list-group-item">Em preparo desde {{ delivery.accepted_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        <li class="list-group-item">Em preparo desde {{ delivery.accepted_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</li>
         {% endif %}
         {% if delivery and delivery.completed_at %}
-        <li class="list-group-item">Entregue em {{ delivery.completed_at.strftime('%d/%m/%Y %H:%M') }}</li>
+        <li class="list-group-item">Entregue em {{ delivery.completed_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</li>
         {% endif %}
       </ul>
     </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -128,7 +128,7 @@
       <ul class="list-group">
         {% for animal in user.animals if animal.removido_em %}
         <li class="list-group-item text-muted">
-          {{ animal.name }} — <small>Removido em {{ animal.removido_em.strftime('%d/%m/%Y') }}</small>
+          {{ animal.name }} — <small>Removido em {{ animal.removido_em|format_datetime_brazil('%d/%m/%Y') }}</small>
         </li>
         {% endfor %}
       </ul>
@@ -144,7 +144,7 @@
       <li class="list-group-item transaction-item {% if loop.index > 3 %}d-none{% endif %}">
         <strong>{{ t.animal.name }}</strong><br>
         Tipo: {{ t.type|capitalize }}<br>
-        Data: {{ t.date.strftime('%d/%m/%Y') }}<br>
+        Data: {{ t.date|format_datetime_brazil('%d/%m/%Y') }}<br>
         {% if t.from_user_id == current_user.id %}
         Para: {{ t.to_user.name }}
         {% else %}


### PR DESCRIPTION
## Summary
- use `America/Sao_Paulo` timezone throughout the app
- show template datetimes with new `format_datetime_brazil` filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c53d5e74832e824e1dbd5e09854c