### PR TITLE
Improve persistent login

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo
 
 
 from dotenv import load_dotenv
-from flask import Flask
+from flask import Flask, session
 from itsdangerous import URLSafeTimedSerializer
 
 # ----------------------------------------------------------------
@@ -42,7 +42,7 @@ app = Flask(
 )
 app.config.from_object("config.Config")
 app.config.setdefault("FRONTEND_URL", "http://127.0.0.1:5000")
-app.config.update(SESSION_PERMANENT=False, SESSION_TYPE="filesystem")
+app.config.update(SESSION_PERMANENT=True, SESSION_TYPE="filesystem")
 
 # ----------------------------------------------------------------
 # 3)  Extensões
@@ -392,6 +392,8 @@ def login():
         user = User.query.filter_by(email=form.email.data).first()
         if user and user.check_password(form.password.data):
             login_user(user, remember=form.remember.data)
+            if form.remember.data:
+                session.permanent = True
             flash('Login realizado com sucesso!', 'success')
             return redirect(url_for('index'))
         else:

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 
 
 class Config:
@@ -9,6 +10,8 @@ class Config:
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SESSION_TYPE = "filesystem"
+    SESSION_PERMANENT = True
+    PERMANENT_SESSION_LIFETIME = timedelta(days=365)
 
     # Configurações do Flask-Mail (Gmail)
     MAIL_SERVER = 'smtp.gmail.com'

--- a/forms.py
+++ b/forms.py
@@ -49,7 +49,8 @@ class RegistrationForm(FlaskForm):
 class LoginForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
     password = PasswordField('Senha', validators=[DataRequired()])
-    remember = BooleanField('Lembrar de mim')
+    # Deixa marcada por padrao para que o usuario permaneça logado ao fechar o navegador
+    remember = BooleanField('Lembrar de mim', default=True)
     submit = SubmitField('Entrar')
 
 


### PR DESCRIPTION
## Summary
- keep the user logged in for a year
- mark session as permanent when "Lembrar de mim" is checked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688358868c88832ea2c4073f5bbe8af8