### PR TITLE
Enable PWA features

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo
 
 
 from dotenv import load_dotenv
-from flask import Flask, session
+from flask import Flask, session, send_from_directory
 from itsdangerous import URLSafeTimedSerializer
 
 # ----------------------------------------------------------------
@@ -260,6 +260,11 @@ def painel_dashboard():
 @app.route('/')
 def index():
     return render_template('index.html')
+
+
+@app.route('/service-worker.js')
+def service_worker():
+    return send_from_directory(app.static_folder, 'service-worker.js')
 
 
 @app.route('/register', methods=['GET', 'POST'])
@@ -3771,3 +3776,5 @@ def teste_endereco():
         return redirect(url_for('teste_endereco'))
 
     return render_template('teste_endereco.html', endereco=endereco)
+
+

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "PetOrlândia",
+  "short_name": "PetOrlândia",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#4e73df",
+  "icons": [
+    {
+      "src": "logo_pet.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "logo_pet.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,20 @@
+const CACHE_NAME = 'petorlandia-cache-v1';
+const urlsToCache = [
+  '/',
+  '/static/logo_pet.png',
+  '/static/favicon.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});

--- a/templates/base_consulta.html
+++ b/templates/base_consulta.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <title>{% block title %}Consulta - PetOrlândia{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    <meta name="theme-color" content="#4e73df">
 
     <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -159,6 +161,11 @@
 
     {% block scripts %}
     {% endblock %}
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('{{ url_for('service_worker') }}');
+      }
+    </script>
 
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,6 +8,8 @@
     <meta charset="UTF-8">
     <title>PetOrlândia 🐶</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    <meta name="theme-color" content="#4e73df">
 
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -449,5 +451,10 @@
       const mp = new MercadoPago("{{ MERCADOPAGO_PUBLIC_KEY }}", {locale: 'pt-BR'});
     </script>
     {% endif %}
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('{{ url_for('service_worker') }}');
+      }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create web app manifest and service worker
- register service worker in base templates
- expose `/service-worker.js` route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688362268f90832e8ee5d397acac75c4