### PR TITLE
Fix service worker caching of home page

### DIFF
--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,6 +1,7 @@
 const CACHE_NAME = 'petorlandia-cache-v1';
+// Pages like the home page change based on login state, so we avoid
+// pre-caching them. Only static assets are cached up-front.
 const urlsToCache = [
-  '/',
   '/static/logo_pet.png',
   '/static/favicon.png'
 ];
@@ -12,9 +13,23 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('fetch', event => {
+  // For navigation requests (like visiting "/"), prefer the network so
+  // users always see the latest authenticated content. Fall back to cache
+  // when offline.
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then(response => {
-      return response || fetch(event.request);
-    })
+    caches.match(event.request).then(response => response || fetch(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- avoid caching `/` in the service worker
- fetch navigation requests from network first so login state updates correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836b8d8a38832e9bc42f2915ea76e3