### PR TITLE
Fix login recognition after authentication

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -68,7 +68,7 @@ class MyModelView(ModelView):
 
     def inaccessible_callback(self, name, **kwargs):
         flash("Acesso restrito à administração.", "danger")
-        return redirect(url_for('login'))
+        return redirect(url_for('login_view'))
 
 # --------------------------------------------------------------------------
 # Dashboard (será a página inicial do painel)
@@ -79,7 +79,7 @@ class AdminDashboard(BaseView):
 
     def inaccessible_callback(self, name, **kwargs):
         flash("Acesso restrito à administração.", "danger")
-        return redirect(url_for('login'))
+        return redirect(url_for('login_view'))
 
     @expose('/')
     @login_required

--- a/app.py
+++ b/app.py
@@ -130,7 +130,7 @@ from models import User   # noqa: E402  (import depois de alias)
 def load_user(user_id):
     return User.query.get(int(user_id))
 
-login.login_view = "login"
+login.login_view = "login_view"
 serializer = URLSafeTimedSerializer(app.config["SECRET_KEY"])
 
 # ----------------------------------------------------------------
@@ -211,7 +211,7 @@ def reset_password_request():
             )
             mail.send(msg)
             flash('Um e-mail foi enviado com instruções para redefinir sua senha.', 'info')
-            return redirect(url_for('login'))
+            return redirect(url_for('login_view'))
         flash('E-mail não encontrado.', 'danger')
     return render_template('reset_password_request.html', form=form)
 
@@ -232,7 +232,7 @@ def reset_password(token):
             user.set_password(form.password.data)  # Your User model must have set_password method
             db.session.commit()
             flash('Sua senha foi redefinida. Você já pode entrar!', 'success')
-            return redirect(url_for('login'))
+            return redirect(url_for('login_view'))
     return render_template('reset_password.html', form=form)
 
 
@@ -391,7 +391,7 @@ def add_animal():
 
 
 @app.route('/login', methods=['GET', 'POST'])
-def login():
+def login_view():
     form = LoginForm()
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data).first()

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,7 +72,7 @@
                 
                 <a href="{{ url_for('register') }}" class="btn btn-outline-success rounded-pill px-4 py-2">🧑 Criar Conta</a>
                
-                <a href="{{ url_for('login') }}" class="btn btn-outline-primary rounded-pill px-4 py-2">🔐 Entrar</a>
+                <a href="{{ url_for('login_view') }}" class="btn btn-outline-primary rounded-pill px-4 py-2">🔐 Entrar</a>
             </div>
         </div>
     {% endif %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -398,7 +398,7 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('login') }}">
+                            <a class="nav-link" href="{{ url_for('login_view') }}">
                             <i class="fas fa-sign-in-alt me-1 text-primary"></i> Entrar
                             </a>
                         </li>

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -28,7 +28,7 @@
             </div>
 
             <div class="text-center mt-3">
-                <a href="{{ url_for('login') }}" class="text-decoration-none">🔙 Voltar para o login</a>
+                <a href="{{ url_for('login_view') }}" class="text-decoration-none">🔙 Voltar para o login</a>
             </div>
         </form>
     </div>

--- a/templates/reset_password_request.html
+++ b/templates/reset_password_request.html
@@ -20,7 +20,7 @@
             </div>
 
             <div class="text-center mt-3">
-                <a href="{{ url_for('login') }}" class="text-decoration-none">🔙 Voltar para o login</a>
+                <a href="{{ url_for('login_view') }}" class="text-decoration-none">🔙 Voltar para o login</a>
             </div>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- avoid variable conflict with login manager
- rename route function to `login_view`
- update redirects and templates to use `login_view` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836e8b1764832ea9033551337c5eeb