### PR TITLE
Fix datetime filter in delivery pages

### DIFF
--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -28,11 +28,11 @@
             {% if req.status == 'pendente'      %}
               Solicitado {{ req.requested_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}
             {% elif req.status == 'em_andamento' %}
-              Aceito {{ format_datetime_brazil(req.accepted_at, '%d/%m/%Y %H:%M') if req.accepted_at else '' }}
+              Aceito {{ req.accepted_at|format_datetime_brazil('%d/%m/%Y %H:%M') if req.accepted_at else '' }}
             {% elif req.status == 'concluida'    %}
-              Concluído {{ format_datetime_brazil(req.completed_at, '%d/%m/%Y %H:%M') if req.completed_at else '' }}
+              Concluído {{ req.completed_at|format_datetime_brazil('%d/%m/%Y %H:%M') if req.completed_at else '' }}
             {% elif req.status == 'cancelada'    %}
-              Cancelado {{ format_datetime_brazil(req.canceled_at, '%d/%m/%Y %H:%M') if req.canceled_at else '' }}
+              Cancelado {{ req.canceled_at|format_datetime_brazil('%d/%m/%Y %H:%M') if req.canceled_at else '' }}
             {% endif %}
           </div>
         </div>

--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -116,7 +116,7 @@
     {% for v in animal.vacinas|sort(attribute='data', reverse=True) %}
     <li class="list-group-item d-flex justify-content-between align-items-center">
       <div>
-        <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ format_datetime_brazil(v.data, '%d/%m/%Y') if v.data else 'Data não registrada' }}
+        <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.data|format_datetime_brazil('%d/%m/%Y') if v.data else 'Data não registrada' }}
         {% if v.observacoes %}
           <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
         {% endif %}


### PR DESCRIPTION
## Summary
- call the Jinja filter correctly in delivery requests
- fix same usage in ficha animal template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688370158964832ebf8ae0663be1721a