### PR TITLE
Fix logout caching issue

### DIFF
--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'petorlandia-cache-v1';
+// Bump the cache name to force old caches to be cleared after updates
+const CACHE_NAME = 'petorlandia-cache-v2';
 // Pages like the home page change based on login state, so we avoid
 // pre-caching them. Only static assets are cached up-front.
 const urlsToCache = [
@@ -6,10 +7,22 @@ const urlsToCache = [
   '/static/favicon.png'
 ];
 
+// Install the service worker and take control immediately
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
   );
+});
+
+// Remove outdated caches when activating the new service worker
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
 });
 
 self.addEventListener('fetch', event => {

--- a/templates/logout.html
+++ b/templates/logout.html
@@ -1,6 +1,0 @@
-@app.route('/logout')
-@login_required
-def logout():
-    logout_user()
-    flash('Você saiu da sua conta com sucesso.', 'success')
-    return redirect(url_for('index'))


### PR DESCRIPTION
## Summary
- clean up stray Python logout file
- update service worker caching policy to ensure fresh content after logout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688370ec2f00832ea5599a37a1c8be22