### PR TITLE
Implement redirect to purchases

### DIFF
--- a/app.py
+++ b/app.py
@@ -3608,9 +3608,11 @@ def payment_status(payment_id):
     # endpoint a usar
     endpoint = "delivery_detail"  # agora é um só
 
-    # redireciona direto se já aprovado
-    if delivery_req and result in {"success", "completed", "approved", "approved"}:
-        return redirect(url_for(endpoint, req_id=delivery_req.id))
+    # Redireciona para lista de compras quando o pagamento foi concluído
+    if result in {"success", "completed", "approved"}:
+        if delivery_req:
+            return redirect(url_for(endpoint, req_id=delivery_req.id))
+        return redirect(url_for("minhas_compras"))
 
     return render_template(
         "payment_status.html",

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -388,6 +388,7 @@
                             </a>
                             <ul class="dropdown-menu dropdown-menu-end">
                                 <li><a class="dropdown-item" href="{{ url_for('profile') }}"><i class="fas fa-user me-2 text-primary"></i> Meu Perfil</a></li>
+                                <li><a class="dropdown-item" href="{{ url_for('minhas_compras') }}"><i class="fas fa-box me-2 text-warning"></i> Minhas Compras</a></li>
                                 <li><a class="dropdown-item" href="{{ url_for('logout') }}"><i class="fas fa-sign-out-alt me-2 text-danger"></i> Sair</a></li>
                             </ul>
                         </li>


### PR DESCRIPTION
## Summary
- show link for purchases next to Profile and Logout
- redirect to purchases after completing payment
- adapt tests for new redirect logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f2be68e8832ea614a4a6b92665b5