### PR TITLE
Add "continue shopping" button on purchases page

### DIFF
--- a/templates/minhas_compras.html
+++ b/templates/minhas_compras.html
@@ -35,6 +35,11 @@
       </tbody>
     </table>
   </div>
+  <div class="text-center mt-3">
+    <a href="{{ url_for('loja') }}" class="btn btn-outline-primary">
+      <i class="bi bi-shop-window"></i> Continuar comprando
+    </a>
+  </div>
   {% else %}
   <div class="text-center text-muted mt-5">
     <p class="mt-4 fs-5">Nenhuma compra registrada.</p>


### PR DESCRIPTION
## Summary
- add Continue Shopping button when orders exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f89058d0832ebd3c68b35b2bc4c2