### PR TITLE
Add admin message inbox

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -372,7 +372,11 @@
                         {% endif %}
 
                         <li class="nav-item position-relative">
-                            <a class="nav-link" href="{{ url_for('mensagens') }}">
+                            {% if current_user.role == 'admin' %}
+                                <a class="nav-link" href="{{ url_for('mensagens_admin') }}">
+                            {% else %}
+                                <a class="nav-link" href="{{ url_for('mensagens') }}">
+                            {% endif %}
                                 <i class="fas fa-comments me-1 text-info"></i> Mensagens
                                 {% if unread_messages > 0 %}
                                     <span class="badge rounded-pill bg-danger position-absolute top-0 start-100 translate-middle">

--- a/templates/mensagens_admin.html
+++ b/templates/mensagens_admin.html
@@ -1,0 +1,34 @@
+{% extends "layout.html" %}
+{% block main %}
+<h2>Mensagens dos Usuários</h2>
+
+{% if mensagens %}
+    <ul class="list-group mt-4">
+    {% for msg in mensagens %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+            <div class="d-flex align-items-center">
+                {% if msg.sender.profile_photo %}
+                    <img src="{{ msg.sender.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
+                {% else %}
+                    <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width:50px;height:50px;color:white;">
+                        {{ msg.sender.name[0] }}
+                    </div>
+                {% endif %}
+                <div>
+                    <strong>{{ msg.sender.name }}</strong><br>
+                    <small class="text-muted">{{ msg.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }}</small>
+                </div>
+            </div>
+            <a href="{{ url_for('conversa_admin', user_id=msg.sender.id) }}" class="btn btn-outline-primary btn-sm">
+                Ver Conversa
+                {% if unread_counts.get(msg.sender.id) %}
+                    <span class="badge bg-danger ms-2">{{ unread_counts[msg.sender.id] }}</span>
+                {% endif %}
+            </a>
+        </li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <p>Nenhuma mensagem recebida.</p>
+{% endif %}
+{% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -343,3 +343,10 @@ def test_product_detail_page(monkeypatch, app):
 
         response = client.get('/produto/1')
         assert response.status_code == 200
+
+
+def test_admin_messages_requires_login(app):
+    client = app.test_client()
+    response = client.get('/mensagens_admin')
+    assert response.status_code == 302
+    assert '/login' in response.headers['Location']


### PR DESCRIPTION
## Summary
- handle admin/user conversations in one route
- allow admin-only inbox
- show admin messages link in navbar
- test new admin messages route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f9bd7558832ea3d48622ae4add59