### PR TITLE
Show admin talk messages in inbox

### DIFF
--- a/templates/mensagens.html
+++ b/templates/mensagens.html
@@ -6,7 +6,7 @@
     <ul class="list-group mt-4">
         {% set shown_keys = [] %}
         {% for msg in mensagens %}
-            {% set key = msg.sender.id ~ "-" ~ msg.animal.id %}
+            {% set key = msg.sender.id ~ "-" ~ (msg.animal.id if msg.animal else 'admin') %}
             {% if key not in shown_keys %}
                 {% set _ = shown_keys.append(key) %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
@@ -23,15 +23,22 @@
                             <strong>{{ msg.sender.name }}</strong><br>
                             {% if msg.animal %}
                                 <small class="text-muted">Sobre o animal: {{ msg.animal.name }}</small><br>
+                            {% else %}
+                                <small class="text-muted">Conversa geral</small><br>
                             {% endif %}
                             <small class="text-muted">{{ msg.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }}</small>
                         </div>
                     </div>
-                    {% set unread_count = msg.sender.sent_messages | selectattr("animal_id", "equalto", msg.animal.id)
-                                                                    | selectattr("receiver_id", "equalto", current_user.id)
-                                                                    | selectattr("lida", "equalto", false)
+                    {% set conversation_animal = msg.animal.id if msg.animal else none %}
+                    {% set unread_count = msg.sender.sent_messages | selectattr('animal_id', 'equalto', conversation_animal)
+                                                                    | selectattr('receiver_id', 'equalto', current_user.id)
+                                                                    | selectattr('lida', 'equalto', false)
                                                                     | list | length %}
+                    {% if msg.animal %}
                     <a href="{{ url_for('conversa', animal_id=msg.animal.id, user_id=msg.sender.id) }}" class="btn btn-outline-primary btn-sm">
+                    {% else %}
+                    <a href="{{ url_for('conversa_admin', user_id=msg.sender.id) }}" class="btn btn-outline-primary btn-sm">
+                    {% endif %}
                         Ver Conversa
                         {% if unread_count > 0 %}
                             <span class="badge bg-danger ms-2">{{ unread_count }}</span>


### PR DESCRIPTION
## Summary
- show all received messages in inbox even if they aren't about an animal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fbfdbbf0832e9efc1d3138d6bbd1