### PR TITLE
Mostrar mensagens gerais de usuarios para admin

### DIFF
--- a/app.py
+++ b/app.py
@@ -744,14 +744,21 @@ def mensagens_admin():
         .all()
     )
 
-    latest = {}
+    latest_animais = {}
+    latest_geral = {}
     for m in all_msgs:
         other_id = m.sender_id if m.sender_id != admin_id else m.receiver_id
-        if other_id not in latest:
-            latest[other_id] = m
-    mensagens = list(latest.values())
+        if m.animal_id:
+            if other_id not in latest_animais:
+                latest_animais[other_id] = m
+        else:
+            if other_id not in latest_geral:
+                latest_geral[other_id] = m
 
-    for m in mensagens:
+    mensagens_animais = list(latest_animais.values())
+    mensagens_gerais = list(latest_geral.values())
+
+    for m in mensagens_animais + mensagens_gerais:
         if m.sender_id == admin_id:
             m.sender = m.receiver
             m.sender_id = m.receiver_id
@@ -764,7 +771,12 @@ def mensagens_admin():
     )
     unread_counts = {u[0]: u[1] for u in unread}
 
-    return render_template('mensagens_admin.html', mensagens=mensagens, unread_counts=unread_counts)
+    return render_template(
+        'mensagens_admin.html',
+        mensagens_animais=mensagens_animais,
+        mensagens_gerais=mensagens_gerais,
+        unread_counts=unread_counts
+    )
 
 
 @app.context_processor

--- a/templates/mensagens_admin.html
+++ b/templates/mensagens_admin.html
@@ -1,10 +1,43 @@
 {% extends "layout.html" %}
 {% block main %}
-<h2>Mensagens dos Usuários</h2>
+<h2>Mensagens sobre Animais</h2>
 
-{% if mensagens %}
+{% if mensagens_animais %}
     <ul class="list-group mt-4">
-    {% for msg in mensagens %}
+    {% for msg in mensagens_animais %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+            <div class="d-flex align-items-center">
+                {% if msg.sender.profile_photo %}
+                    <img src="{{ msg.sender.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
+                {% else %}
+                    <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width:50px;height:50px;color:white;">
+                        {{ msg.sender.name[0] }}
+                    </div>
+                {% endif %}
+                <div>
+                    <strong>{{ msg.sender.name }}</strong><br>
+                    <small class="text-muted">Sobre o animal: {{ msg.animal.name }}</small><br>
+                    <small class="text-muted">{{ msg.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }}</small>
+                </div>
+            </div>
+            <a href="{{ url_for('conversa_admin', user_id=msg.sender.id) }}" class="btn btn-outline-primary btn-sm">
+                Ver Conversa
+                {% if unread_counts.get(msg.sender.id) %}
+                    <span class="badge bg-danger ms-2">{{ unread_counts[msg.sender.id] }}</span>
+                {% endif %}
+            </a>
+        </li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <p>Nenhuma mensagem recebida.</p>
+{% endif %}
+
+<h2 class="mt-5">Mensagens Gerais</h2>
+
+{% if mensagens_gerais %}
+    <ul class="list-group mt-4">
+    {% for msg in mensagens_gerais %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <div class="d-flex align-items-center">
                 {% if msg.sender.profile_photo %}


### PR DESCRIPTION
## Summary
- categorizar mensagens na rota `/mensagens_admin`
- exibir mensagens sobre animais e mensagens gerais em seções distintas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884041d0238832e93e66958215a8c44