### PR TITLE
Fix admin message listing

### DIFF
--- a/app.py
+++ b/app.py
@@ -764,11 +764,6 @@ def mensagens_admin():
     mensagens_animais = list(latest_animais.values())
     mensagens_gerais = list(latest_geral.values())
 
-    for m in mensagens_animais + mensagens_gerais:
-        if m.sender_id == admin_id:
-            m.sender = m.receiver
-            m.sender_id = m.receiver_id
-
     unread = (
         db.session.query(Message.sender_id, db.func.count())
         .filter_by(receiver_id=admin_id, lida=False)

--- a/templates/mensagens_admin.html
+++ b/templates/mensagens_admin.html
@@ -5,25 +5,26 @@
 {% if mensagens_animais %}
     <ul class="list-group mt-4">
     {% for msg in mensagens_animais %}
+        {% set other_user = msg.sender if msg.sender_id != current_user.id else msg.receiver %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <div class="d-flex align-items-center">
-                {% if msg.sender.profile_photo %}
-                    <img src="{{ msg.sender.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
+                {% if other_user.profile_photo %}
+                    <img src="{{ other_user.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
                 {% else %}
                     <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width:50px;height:50px;color:white;">
-                        {{ msg.sender.name[0] }}
+                        {{ other_user.name[0] }}
                     </div>
                 {% endif %}
                 <div>
-                    <strong>{{ msg.sender.name }}</strong><br>
+                    <strong>{{ other_user.name }}</strong><br>
                     <small class="text-muted">Sobre o animal: {{ msg.animal.name }}</small><br>
                     <small class="text-muted">{{ msg.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }}</small>
                 </div>
             </div>
-            <a href="{{ url_for('conversa_admin', user_id=msg.sender.id) }}" class="btn btn-outline-primary btn-sm">
+            <a href="{{ url_for('conversa_admin', user_id=other_user.id) }}" class="btn btn-outline-primary btn-sm">
                 Ver Conversa
-                {% if unread_counts.get(msg.sender.id) %}
-                    <span class="badge bg-danger ms-2">{{ unread_counts[msg.sender.id] }}</span>
+                {% if unread_counts.get(other_user.id) %}
+                    <span class="badge bg-danger ms-2">{{ unread_counts[other_user.id] }}</span>
                 {% endif %}
             </a>
         </li>
@@ -38,24 +39,25 @@
 {% if mensagens_gerais %}
     <ul class="list-group mt-4">
     {% for msg in mensagens_gerais %}
+        {% set other_user = msg.sender if msg.sender_id != current_user.id else msg.receiver %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <div class="d-flex align-items-center">
-                {% if msg.sender.profile_photo %}
-                    <img src="{{ msg.sender.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
+                {% if other_user.profile_photo %}
+                    <img src="{{ other_user.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
                 {% else %}
                     <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width:50px;height:50px;color:white;">
-                        {{ msg.sender.name[0] }}
+                        {{ other_user.name[0] }}
                     </div>
                 {% endif %}
                 <div>
-                    <strong>{{ msg.sender.name }}</strong><br>
+                    <strong>{{ other_user.name }}</strong><br>
                     <small class="text-muted">{{ msg.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }}</small>
                 </div>
             </div>
-            <a href="{{ url_for('conversa_admin', user_id=msg.sender.id) }}" class="btn btn-outline-primary btn-sm">
+            <a href="{{ url_for('conversa_admin', user_id=other_user.id) }}" class="btn btn-outline-primary btn-sm">
                 Ver Conversa
-                {% if unread_counts.get(msg.sender.id) %}
-                    <span class="badge bg-danger ms-2">{{ unread_counts[msg.sender.id] }}</span>
+                {% if unread_counts.get(other_user.id) %}
+                    <span class="badge bg-danger ms-2">{{ unread_counts[other_user.id] }}</span>
                 {% endif %}
             </a>
         </li>


### PR DESCRIPTION
## Summary
- avoid modifying `Message` objects when listing admin conversations
- adjust `mensagens_admin.html` to compute the other participant in the template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68843a753d4c832e9cf13793e561943f