### PR TITLE
Fix admin conversation messages visibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -700,7 +700,7 @@ def conversa_admin(user_id=None):
         participant_id = interlocutor.id
     else:
         interlocutor = admin_user
-        admin_ids = [admin_user.id]
+        admin_ids = [u.id for u in User.query.filter_by(role='admin').all()]
         participant_id = current_user.id
 
     mensagens = (


### PR DESCRIPTION
## Summary
- ensure users see messages from any admin, not only the first one

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884475635f4832ea77d75b265144be6