### PR TITLE
Handle missing sender in mensagem listing

### DIFF
--- a/app.py
+++ b/app.py
@@ -623,7 +623,7 @@ def aceitar_interesse(message_id):
 @app.route('/mensagens')
 @login_required
 def mensagens():
-    mensagens_recebidas = current_user.received_messages
+    mensagens_recebidas = [m for m in current_user.received_messages if m.sender is not None]
     return render_template('mensagens.html', mensagens=mensagens_recebidas)
 
 


### PR DESCRIPTION
## Summary
- guard against messages without a valid sender

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a933d594832ebc3884442e3d85c1