### PR TITLE
Improve form validation

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -15,21 +15,40 @@ from flask_wtf.file import FileField, FileAllowed
 
 
 class ResetPasswordRequestForm(FlaskForm):
-    email = StringField('E-mail', validators=[DataRequired(), Email()])
+    email = StringField(
+        'E-mail',
+        validators=[DataRequired(message="Email é obrigatório"), Email()],
+        render_kw={"required": True},
+    )
     submit = SubmitField('Solicitar redefinição de senha')
 
 class ResetPasswordForm(FlaskForm):
-    password = PasswordField('Nova senha', validators=[DataRequired()])
-    confirm_password = PasswordField('Confirme a nova senha', validators=[
-        DataRequired(), EqualTo('password')])
+    password = PasswordField(
+        'Nova senha',
+        validators=[DataRequired(message="Senha é obrigatória")],
+        render_kw={"required": True},
+    )
+    confirm_password = PasswordField(
+        'Confirme a nova senha',
+        validators=[DataRequired(message="Confirmação de senha é obrigatória"), EqualTo('password')],
+        render_kw={"required": True},
+    )
     submit = SubmitField('Redefinir senha')
 
 
 
 
 class RegistrationForm(FlaskForm):
-    name = StringField('Name', validators=[DataRequired(), Length(min=2, max=120)])
-    email = StringField('Email', validators=[DataRequired(), Email()])
+    name = StringField(
+        'Name',
+        validators=[DataRequired(message="Nome é obrigatório"), Length(min=2, max=120)],
+        render_kw={"required": True},
+    )
+    email = StringField(
+        'Email',
+        validators=[DataRequired(message="Email é obrigatório"), Email()],
+        render_kw={"required": True},
+    )
     phone = StringField('Phone', validators=[Optional(), Length(min=8, max=20)])
     address = StringField('Address', validators=[Optional(), Length(max=200)])
 
@@ -38,18 +57,32 @@ class RegistrationForm(FlaskForm):
         FileAllowed(['jpg', 'jpeg', 'png', 'gif'], 'Apenas imagens!')
     ])
 
-    password = PasswordField('Password', validators=[DataRequired(), Length(min=6)])
-    confirm_password = PasswordField('Confirm Password', validators=[
-        DataRequired(), EqualTo('password', message='Passwords must match')
-    ])
+    password = PasswordField(
+        'Password',
+        validators=[DataRequired(message="Senha é obrigatória"), Length(min=6)],
+        render_kw={"required": True},
+    )
+    confirm_password = PasswordField(
+        'Confirm Password',
+        validators=[DataRequired(message="Confirmação de senha é obrigatória"), EqualTo('password', message='Passwords must match')],
+        render_kw={"required": True},
+    )
     submit = SubmitField('Register')
 
 
 
 
 class LoginForm(FlaskForm):
-    email = StringField('Email', validators=[DataRequired(), Email()])
-    password = PasswordField('Senha', validators=[DataRequired()])
+    email = StringField(
+        'Email',
+        validators=[DataRequired(message="Email é obrigatório"), Email()],
+        render_kw={"required": True},
+    )
+    password = PasswordField(
+        'Senha',
+        validators=[DataRequired(message="Senha é obrigatória")],
+        render_kw={"required": True},
+    )
     # Deixa marcada por padrao para que o usuario permaneça logado ao fechar o navegador
     remember = BooleanField('Lembrar de mim', default=True)
     submit = SubmitField('Entrar')


### PR DESCRIPTION
## Summary
- add user-friendly required field messages
- mark form inputs as required for client-side validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ab297d84832ebea9712d585ac1a4