### PR TITLE
Fix None placeholders in tutor address forms

### DIFF
--- a/templates/partials/endereco_form.html
+++ b/templates/partials/endereco_form.html
@@ -11,8 +11,8 @@
         <i class="bi bi-question-circle ms-1" data-bs-toggle="tooltip" title="Digite o CEP para autopreencher o endereço"></i>
       </label>
       <div class="input-group">
-        <input type="text" class="form-control" name="cep" id="cep" 
-               value="{{ endereco.cep if endereco else '' }}" 
+        <input type="text" class="form-control" name="cep" id="cep"
+               value="{{ endereco.cep|default('', true) if endereco else '' }}"
                placeholder="00000-000" 
                data-mask="00000-000"
                onblur="buscarCep()">
@@ -29,8 +29,8 @@
     <!-- Rua -->
     <div class="col-md-7">
       <label for="rua" class="form-label fw-semibold">Logradouro <span class="text-danger">*</span></label>
-      <input type="text" class="form-control" name="rua" id="rua" 
-             value="{{ endereco.rua if endereco else '' }}"
+      <input type="text" class="form-control" name="rua" id="rua"
+             value="{{ endereco.rua|default('', true) if endereco else '' }}"
              placeholder="Nome da rua, avenida, etc.">
       <div class="invalid-feedback">Por favor, informe o logradouro</div>
     </div>
@@ -38,32 +38,32 @@
     <!-- Número -->
     <div class="col-md-2">
       <label for="numero" class="form-label fw-semibold">Número</label>
-      <input type="text" class="form-control" name="numero" id="numero" 
-             value="{{ endereco.numero if endereco else '' }}"
+      <input type="text" class="form-control" name="numero" id="numero"
+             value="{{ endereco.numero|default('', true) if endereco else '' }}"
              placeholder="Nº">
     </div>
 
     <!-- Complemento -->
     <div class="col-md-4">
       <label for="complemento" class="form-label fw-semibold">Complemento</label>
-      <input type="text" class="form-control" name="complemento" id="complemento" 
-             value="{{ endereco.complemento if endereco else '' }}"
+      <input type="text" class="form-control" name="complemento" id="complemento"
+             value="{{ endereco.complemento|default('', true) if endereco else '' }}"
              placeholder="Apto, bloco, etc.">
     </div>
 
     <!-- Bairro -->
     <div class="col-md-4">
       <label for="bairro" class="form-label fw-semibold">Bairro</label>
-      <input type="text" class="form-control" name="bairro" id="bairro" 
-             value="{{ endereco.bairro if endereco else '' }}"
+      <input type="text" class="form-control" name="bairro" id="bairro"
+             value="{{ endereco.bairro|default('', true) if endereco else '' }}"
              placeholder="Nome do bairro">
     </div>
 
     <!-- Cidade -->
     <div class="col-md-3">
       <label for="cidade" class="form-label fw-semibold">Cidade <span class="text-danger">*</span></label>
-      <input type="text" class="form-control" name="cidade" id="cidade" 
-             value="{{ endereco.cidade if endereco else '' }}"
+      <input type="text" class="form-control" name="cidade" id="cidade"
+             value="{{ endereco.cidade|default('', true) if endereco else '' }}"
              placeholder="Nome da cidade">
       <div class="invalid-feedback">Por favor, informe a cidade</div>
     </div>

--- a/templates/partials/tutor_form.html
+++ b/templates/partials/tutor_form.html
@@ -48,8 +48,8 @@
         <div class="flex-grow-1">
           <input id="profile_photo" name="profile_photo" type="file" accept="image/*" 
                  class="form-control d-none">
-          <input type="text" name="name" class="form-control" placeholder="Nome completo do tutor" 
-                 value="{{ tutor.name if has_tutor else '' }}" required minlength="3" maxlength="100">
+          <input type="text" name="name" class="form-control" placeholder="Nome completo do tutor"
+                 value="{{ tutor.name|default('', true) if has_tutor else '' }}" required minlength="3" maxlength="100">
           <div class="invalid-feedback">Por favor, insira um nome válido (3-100 caracteres)</div>
         </div>
       </div>
@@ -61,7 +61,7 @@
       <input type="tel" id="tutor-phone" name="phone" class="form-control" 
              placeholder="Apenas números (ex: 99999999999)" 
              pattern="[0-9]{10,11}"
-             value="{{ tutor.phone if has_tutor else '' }}">
+             value="{{ tutor.phone|default('', true) if has_tutor else '' }}">
       <div class="invalid-feedback">Por favor, insira um telefone válido (10 ou 11 dígitos)</div>
     </div>
 
@@ -71,7 +71,7 @@
       <input type="text" id="tutor-cpf" name="cpf" class="form-control" 
              placeholder="Apenas números (ex: 12345678901)" 
              pattern="[0-9]{11}"
-             value="{{ tutor.cpf if has_tutor else '' }}">
+             value="{{ tutor.cpf|default('', true) if has_tutor else '' }}">
       <div class="invalid-feedback">Por favor, insira um CPF válido (11 dígitos)</div>
     </div>
 
@@ -79,7 +79,7 @@
       <label for="tutor-rg" class="form-label">RG</label>
       <input type="text" id="tutor-rg" name="rg" class="form-control" 
              placeholder="00.000.000-0" pattern="[0-9]{2}\.?[0-9]{3}\.?[0-9]{3}-?[0-9]{1}"
-             value="{{ tutor.rg if has_tutor else '' }}">
+             value="{{ tutor.rg|default('', true) if has_tutor else '' }}">
       <div class="invalid-feedback">Por favor, insira um RG válido</div>
     </div>
     
@@ -103,7 +103,7 @@
       <label for="tutor-email" class="form-label">E-mail</label>
       <input type="email" id="tutor-email" name="email" class="form-control" 
              placeholder="exemplo@email.com" required
-             value="{{ tutor.email if has_tutor else '' }}">
+             value="{{ tutor.email|default('', true) if has_tutor else '' }}">
       <div class="invalid-feedback">Por favor, insira um e-mail válido</div>
     </div>
 


### PR DESCRIPTION
## Summary
- ensure tutor form displays blank fields when data is missing
- avoid displaying `None` in address fields

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884adcf4cdc832ebed7f6f15c36b866