### PR TITLE
Improve shop access and navigation UX

### DIFF
--- a/app.py
+++ b/app.py
@@ -3202,20 +3202,22 @@ from flask_login import login_required
 
 
 @app.route("/loja")
-@login_required
 def loja():
     pagamento_pendente = None
-    payment_id = session.get("last_pending_payment")
-    if payment_id:
-        payment = Payment.query.get(payment_id)
-        if payment and payment.status.name == "PENDING":
-            pagamento_pendente = payment
+    if current_user.is_authenticated:
+        payment_id = session.get("last_pending_payment")
+        if payment_id:
+            payment = Payment.query.get(payment_id)
+            if payment and payment.status.name == "PENDING":
+                pagamento_pendente = payment
 
     produtos = Product.query.all()
     form = AddToCartForm()
 
-    # Verifica se há pedidos anteriores
-    has_orders = Order.query.filter_by(user_id=current_user.id).first() is not None
+    # Verifica se há pedidos anteriores apenas se logado
+    has_orders = False
+    if current_user.is_authenticated:
+        has_orders = Order.query.filter_by(user_id=current_user.id).first() is not None
 
     return render_template(
         "loja.html",
@@ -3227,7 +3229,6 @@ def loja():
 
 
 @app.route('/produto/<int:product_id>', methods=['GET', 'POST'])
-@login_required
 def produto_detail(product_id):
     """Exibe detalhes do produto e permite edições para administradores."""
     product = Product.query.options(db.joinedload(Product.extra_photos)).get_or_404(product_id)

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -336,17 +336,17 @@
                     {% endif %}
                     
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('index') }}">
+                        <a class="nav-link" href="{{ url_for('index') }}" data-bs-toggle="tooltip" title="Início">
                             <i class="fas fa-home me-1 text-primary"></i> Início
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('list_animals') }}">
+                        <a class="nav-link" href="{{ url_for('list_animals') }}" data-bs-toggle="tooltip" title="Animais">
                             <i class="fas fa-paw me-1 text-success"></i> Animais
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('loja') }}">
+                        <a class="nav-link" href="{{ url_for('loja') }}" data-bs-toggle="tooltip" title="Loja">
                             <i class="fas fa-shopping-bag me-1 text-warning"></i> Loja
                         </a>
                     </li>
@@ -354,18 +354,18 @@
                     {% if current_user.is_authenticated %}
                         {% if current_user.worker == 'veterinario' %}
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('tutores') }}">
+                            <a class="nav-link" href="{{ url_for('tutores') }}" data-bs-toggle="tooltip" title="Tutores">
                                     <i class="fas fa-users me-1 text-primary"></i> Tutores
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('add_animal') }}">
+                                <a class="nav-link" href="{{ url_for('add_animal') }}" data-bs-toggle="tooltip" title="Adicionar Animal">
                                     <i class="fas fa-plus-circle me-1 text-success"></i> Animal
                                 </a>
                             </li>
                         {% elif current_user.worker == 'delivery' %}
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('list_delivery_requests') }}">
+                                <a class="nav-link" href="{{ url_for('list_delivery_requests') }}" data-bs-toggle="tooltip" title="Solicitações">
                                     <i class="fas fa-truck me-1 text-warning"></i> Solicitações
                                 </a>
                             </li>
@@ -373,9 +373,9 @@
 
                         <li class="nav-item position-relative">
                             {% if current_user.role == 'admin' %}
-                                <a class="nav-link" href="{{ url_for('mensagens_admin') }}">
+                                <a class="nav-link" href="{{ url_for('mensagens_admin') }}" data-bs-toggle="tooltip" title="Mensagens">
                             {% else %}
-                                <a class="nav-link" href="{{ url_for('mensagens') }}">
+                                <a class="nav-link" href="{{ url_for('mensagens') }}" data-bs-toggle="tooltip" title="Mensagens">
                             {% endif %}
                                 <i class="fas fa-comments me-1 text-info"></i> Mensagens
                                 {% if unread_messages > 0 %}
@@ -398,12 +398,12 @@
                         </li>
                     {% else %}
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('register') }}">
+                            <a class="nav-link" href="{{ url_for('register') }}" data-bs-toggle="tooltip" title="Registrar">
                             <i class="fas fa-user-plus me-1 text-success"></i> Registrar
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('login_view') }}">
+                            <a class="nav-link" href="{{ url_for('login_view') }}" data-bs-toggle="tooltip" title="Entrar">
                             <i class="fas fa-sign-in-alt me-1 text-primary"></i> Entrar
                             </a>
                         </li>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -55,11 +55,17 @@ def test_add_animal_requires_login(app):
     assert response.status_code == 302
     assert '/login' in response.headers['Location']
 
-def test_loja_requires_login(app):
+def test_loja_accessible_to_guests(app):
     client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        db.session.add(Product(id=1, name='Prod', description='d', price=10.0))
+        db.session.commit()
+
     response = client.get('/loja')
-    assert response.status_code == 302
-    assert '/login' in response.headers['Location']
+    # Sem login deve exibir a página
+    assert response.status_code == 200
 
 
 def test_mp_token_in_config(app):
@@ -316,11 +322,14 @@ def test_cart_quantity_updates(monkeypatch, app):
         assert OrderItem.query.get(item.id) is None
 
 
-def test_product_detail_requires_login(app):
+def test_product_detail_missing_product_returns_404(app):
     client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
     response = client.get('/produto/1')
-    assert response.status_code == 302
-    assert '/login' in response.headers['Location']
+    assert response.status_code == 404
 
 
 def test_product_detail_page(monkeypatch, app):


### PR DESCRIPTION
## Summary
- allow guests to browse the shop and product pages
- add tooltip helpers to navbar icons
- update tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ab95f9e0832e93453dd82355c28f