### PR TITLE
Fix SubscribePlanForm validation choices

### DIFF
--- a/app.py
+++ b/app.py
@@ -1089,11 +1089,15 @@ def contratar_plano(animal_id):
         return redirect(url_for("planosaude_animal", animal_id=animal.id))
 
     form = SubscribePlanForm()
+    from models import HealthPlan
+    plans = HealthPlan.query.all()
+    form.plan_id.choices = [
+        (p.id, f"{p.name} - R$ {p.price:.2f}") for p in plans
+    ]
     if not form.validate_on_submit():
         flash("Selecione um plano válido.", "danger")
         return redirect(url_for("planosaude_animal", animal_id=animal.id))
 
-    from models import HealthPlan
     plan = HealthPlan.query.get_or_404(form.plan_id.data)
 
     preapproval_data = {


### PR DESCRIPTION
## Summary
- ensure plan options are set before validating SubscribePlanForm

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884c93ef098832e8a980718ec978214