### PR TITLE
Improve cart quantity handling

### DIFF
--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -29,7 +29,7 @@
     <strong>Total:&nbsp;R$ {{ '%.2f'|format(order.total_value()) }}</strong>
   </div>
 
-  <form action="{{ url_for('checkout') }}" method="post" class="text-end">
+  <form action="{{ url_for('checkout_confirm') }}" method="post" class="text-end">
     {{ form.hidden_tag() }}
     <button type="submit" class="btn btn-lg btn-success shadow-sm">
       <i class="bi bi-cash-stack"></i> {{ form.submit.label.text }}

--- a/templates/checkout_confirm.html
+++ b/templates/checkout_confirm.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container py-4">
+  <h2 class="text-center mb-4">Confirmar Compra</h2>
+  <ul class="list-group mb-3">
+    {% for item in order.items %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <span>{{ item.item_name }}</span>
+      <span>{{ item.quantity }} x R$ {{ '%.2f'|format(item.product.price or 0) }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+  <div class="d-flex justify-content-end mb-3">
+    <strong>Total:&nbsp;R$ {{ '%.2f'|format(order.total_value()) }}</strong>
+  </div>
+  <form action="{{ url_for('checkout') }}" method="post" class="text-end">
+    {{ form.hidden_tag() }}
+    <button type="submit" class="btn btn-success">
+      Continuar para Pagamento
+    </button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- combine duplicate items when adding to cart
- display a checkout confirmation page before external redirect
- allow quantity decrease to inform user when item is removed
- update templates and tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d93eb4ac832e822f8c45ed2d104b