### PR TITLE
Add account management features

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -161,6 +161,23 @@ class EditProfileForm(FlaskForm):
     submit = SubmitField('Salvar Alterações')
 
 
+class ChangePasswordForm(FlaskForm):
+    current_password = PasswordField('Senha Atual', validators=[DataRequired()])
+    new_password = PasswordField(
+        'Nova Senha',
+        validators=[DataRequired(), Length(min=6)]
+    )
+    confirm_password = PasswordField(
+        'Confirme a Nova Senha',
+        validators=[DataRequired(), EqualTo('new_password')]
+    )
+    submit = SubmitField('Alterar Senha')
+
+
+class DeleteAccountForm(FlaskForm):
+    submit = SubmitField('Excluir Conta')
+
+
 
 class MessageForm(FlaskForm):
     content = TextAreaField('Mensagem', validators=[DataRequired(), Length(max=1000)])

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container d-flex justify-content-center align-items-center mt-5">
+    <div class="card shadow-lg p-4 rounded-4" style="width: 100%; max-width: 450px;">
+        <h3 class="mb-4 text-center">🔑 Alterar Senha</h3>
+        <form method="POST">
+            {{ form.hidden_tag() }}
+            <div class="mb-3">
+                {{ form.current_password.label(class="form-label") }}
+                {{ form.current_password(class="form-control rounded-pill") }}
+                {% for error in form.current_password.errors %}
+                    <div class="text-danger">{{ error }}</div>
+                {% endfor %}
+            </div>
+            <div class="mb-3">
+                {{ form.new_password.label(class="form-label") }}
+                {{ form.new_password(class="form-control rounded-pill") }}
+                {% for error in form.new_password.errors %}
+                    <div class="text-danger">{{ error }}</div>
+                {% endfor %}
+            </div>
+            <div class="mb-3">
+                {{ form.confirm_password.label(class="form-label") }}
+                {{ form.confirm_password(class="form-control rounded-pill") }}
+                {% for error in form.confirm_password.errors %}
+                    <div class="text-danger">{{ error }}</div>
+                {% endfor %}
+            </div>
+            <div class="d-grid">
+                {{ form.submit(class="btn btn-success rounded-pill py-2") }}
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -91,6 +91,14 @@
     </form>
   </div>
 
+  <div class="d-flex gap-3 mb-4">
+    <a href="{{ url_for('change_password') }}" class="btn btn-outline-secondary rounded-pill px-4">🔑 Alterar Senha</a>
+    <form method="POST" action="{{ url_for('delete_account') }}" class="d-inline" onsubmit="return confirm('Deseja realmente excluir sua conta? Esta ação não poderá ser desfeita.');">
+      {{ delete_form.hidden_tag() }}
+      <button type="submit" class="btn btn-danger rounded-pill px-4">🗑 Excluir Conta</button>
+    </form>
+  </div>
+
 
   <!-- Meus Animais -->
   <div class="mb-5">


### PR DESCRIPTION
## Summary
- add ChangePasswordForm and DeleteAccountForm
- show options to change password or delete account on profile page
- implement /change_password and /delete_account routes
- add confirmation toast when profile info is saved
- test new account management features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d9979a34832e98051b0a6180df40