### PR TITLE
Add preview thumbnails for image uploads

### DIFF
--- a/templates/add_animal.html
+++ b/templates/add_animal.html
@@ -98,7 +98,8 @@
 
             <div class="mb-3">
                 {{ form.image.label(class="form-label") }}
-                {{ form.image(class="form-control rounded-pill" + (" is-invalid" if form.image.errors else "")) }}
+                {{ form.image(class="form-control rounded-pill" + (" is-invalid" if form.image.errors else ""), id="animal_image", accept="image/*") }}
+                <img id="animal-preview" class="mt-2 rounded d-none" style="width: 150px; height: 150px; object-fit: cover;">
                 {% for error in form.image.errors %}
                     <div class="invalid-feedback d-block">{{ error }}</div>
                 {% endfor %}
@@ -157,6 +158,20 @@
 
         ageInput.addEventListener('input', calcularDataNascimentoPorIdade);
         dobInput.addEventListener('change', calcularIdadePorDataNascimento);
+
+        const imageInput = document.getElementById('animal_image');
+        const preview = document.getElementById('animal-preview');
+        imageInput?.addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (file && preview) {
+                const reader = new FileReader();
+                reader.onload = (ev) => {
+                    preview.src = ev.target.result;
+                    preview.classList.remove('d-none');
+                };
+                reader.readAsDataURL(file);
+            }
+        });
     });
 </script>
 {% endblock %}

--- a/templates/animals.html
+++ b/templates/animals.html
@@ -71,7 +71,7 @@
       <div class="col">
         <div class="card h-100 shadow-sm border-0 rounded-4 {% if animal.modo == 'perdido' %}border border-danger{% endif %}">
           {% if animal.image %}
-          <img src="{{ animal.image }}" class="card-img-top rounded-top-4" loading="lazy" alt="Imagem de {{ animal.name }}">
+          <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 200px; object-fit: cover;" loading="lazy" alt="Imagem de {{ animal.name }}">
           {% endif %}
           <div class="card-body">
             <h5 class="card-title d-flex justify-content-between align-items-start">

--- a/templates/register.html
+++ b/templates/register.html
@@ -37,7 +37,8 @@
             <!-- Foto de Perfil -->
             <div class="mb-3">
                 {{ form.profile_photo.label(class="form-label") }}
-                {{ form.profile_photo(class="form-control w-100", id="profile_photo") }}
+                {{ form.profile_photo(class="form-control w-100", id="profile_photo", accept="image/*") }}
+                <img id="profile-preview" class="mt-2 rounded-circle d-none" style="width: 120px; height: 120px; object-fit: cover;">
                 <div class="form-text">Envie uma foto do seu pet</div>
                 {% for error in form.profile_photo.errors %}
                     <div class="text-danger">{{ error }}</div>
@@ -123,6 +124,20 @@ document.addEventListener('DOMContentLoaded', () => {
             else bar.classList.add('bg-danger');
         });
     }
+
+    const fileInput = document.getElementById('profile_photo');
+    const preview = document.getElementById('profile-preview');
+    fileInput?.addEventListener('change', (e) => {
+        const file = e.target.files[0];
+        if (file && preview) {
+            const reader = new FileReader();
+            reader.onload = (ev) => {
+                preview.src = ev.target.result;
+                preview.classList.remove('d-none');
+            };
+            reader.readAsDataURL(file);
+        }
+    });
 });
 </script>
 


### PR DESCRIPTION
## Summary
- show preview of profile photo on registration page
- preview animal image when creating an animal
- ensure animal cards crop images correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d907b1c4832eabae5d9249712cb4