### PR TITLE
Hide sensitive options in profile

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -78,26 +78,34 @@
             {% include 'partials/endereco_form.html' %}
           </div>
 
-          <div class="d-flex gap-3 mt-4">
+          <div class="d-flex gap-3 mt-4 align-items-center">
             <button type="button" class="btn btn-outline-dark rounded-pill px-4" onclick="toggleAll()">
               ✏️ Editar Informações
             </button>
             <button type="submit" class="btn btn-success rounded-pill px-4">
               💾 Salvar Alterações
             </button>
+            <div class="dropdown">
+              <button class="btn btn-outline-secondary rounded-circle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="fas fa-cog"></i>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end">
+                <li><a class="dropdown-item" href="{{ url_for('change_password') }}">🔑 Alterar Senha</a></li>
+                <li>
+                  <form method="POST" action="{{ url_for('delete_account') }}" onsubmit="return confirm('Deseja realmente excluir sua conta? Esta ação não poderá ser desfeita.');">
+                    {{ delete_form.hidden_tag() }}
+                    <button type="submit" class="dropdown-item text-danger">🗑 Excluir Conta</button>
+                  </form>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
     </form>
   </div>
 
-  <div class="d-flex gap-3 mb-4">
-    <a href="{{ url_for('change_password') }}" class="btn btn-outline-secondary rounded-pill px-4">🔑 Alterar Senha</a>
-    <form method="POST" action="{{ url_for('delete_account') }}" class="d-inline" onsubmit="return confirm('Deseja realmente excluir sua conta? Esta ação não poderá ser desfeita.');">
-      {{ delete_form.hidden_tag() }}
-      <button type="submit" class="btn btn-danger rounded-pill px-4">🗑 Excluir Conta</button>
-    </form>
-  </div>
+
 
 
   <!-- Meus Animais -->


### PR DESCRIPTION
## Summary
- move **Alterar Senha** and **Excluir Conta** buttons into a dropdown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884dd23c9f0832e906e83741b2c59f1