### PR TITLE
Allow shipping address selection in cart

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -210,7 +210,8 @@ class CheckoutForm(FlaskForm):
     # email  = StringField('E‑mail', validators=[DataRequired(), Email()])
     # phone  = StringField('Telefone (WhatsApp)', validators=[Optional(), Length(max=20)])
 
-    shipping_address = TextAreaField('Outro Endere\u00e7o', validators=[Optional(), Length(max=200)])
+    address_id = SelectField('Endereço salvo', coerce=int, validators=[Optional()])
+    shipping_address = TextAreaField('Novo Endereço', validators=[Optional(), Length(max=200)])
     submit = SubmitField('Finalizar Compra')
 
 

--- a/models.py
+++ b/models.py
@@ -610,6 +610,20 @@ class OrderItem(db.Model):
         return f"{self.product.name if self.product else self.item_name} x{self.quantity}"
 
 
+class SavedAddress(db.Model):
+    """Endereços extras salvos pelo usuário."""
+    __tablename__ = 'saved_address'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, index=True)
+    address = db.Column(db.String(200), nullable=False)
+
+    user = db.relationship('User', backref='saved_addresses')
+
+    def __repr__(self):
+        return self.address
+
+
 class DeliveryRequest(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     order_id = db.Column(db.Integer, db.ForeignKey('order.id'), nullable=False)

--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -29,8 +29,28 @@
     <strong>Total:&nbsp;R$ {{ '%.2f'|format(order.total_value()) }}</strong>
   </div>
 
-  <form action="{{ url_for('checkout_confirm') }}" method="post" class="text-end">
+  <form action="{{ url_for('checkout') }}" method="post" class="text-end">
     {{ form.hidden_tag() }}
+
+    {% if default_address or saved_addresses %}
+    <div class="mb-3 text-start">
+      <label class="form-label">Endereço de entrega</label>
+      <select name="address_id" class="form-select mb-2">
+        {% if default_address %}
+        <option value="0">{{ default_address }}</option>
+        {% endif %}
+        {% for addr in saved_addresses %}
+        <option value="{{ addr.id }}">{{ addr.address }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    {% endif %}
+
+    <div class="mb-3 text-start">
+      {{ form.shipping_address(class="form-control", rows="2", placeholder="Novo endereço") }}
+      <small class="text-muted">Se informado, será salvo para próximas compras.</small>
+    </div>
+
     <button type="submit" class="btn btn-lg btn-success shadow-sm">
       <i class="bi bi-cash-stack"></i> {{ form.submit.label.text }}
     </button>


### PR DESCRIPTION
## Summary
- store multiple shipping addresses with new `SavedAddress` model
- extend `CheckoutForm` with `address_id` select
- show saved addresses and new address field in cart
- populate address options in cart view
- save selected/entered address during checkout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e3ab571c832e9a065721cd20b143