### PR TITLE
Implement dynamic delivery counts

### DIFF
--- a/app.py
+++ b/app.py
@@ -3015,6 +3015,34 @@ def list_delivery_requests():
     )
 
 
+@app.route("/api/delivery_counts")
+@login_required
+def api_delivery_counts():
+    """Return delivery counts for the current user."""
+    base = DeliveryRequest.query
+    if current_user.worker == "delivery":
+        available_total = base.filter_by(status="pendente").count()
+        doing = base.filter_by(worker_id=current_user.id,
+                              status="em_andamento").count()
+        done = base.filter_by(worker_id=current_user.id,
+                             status="concluida").count()
+        canceled = base.filter_by(worker_id=current_user.id,
+                                 status="cancelada").count()
+    else:
+        base = base.filter_by(requested_by_id=current_user.id)
+        available_total = 0
+        doing = base.filter_by(status="em_andamento").count()
+        done = base.filter_by(status="concluida").count()
+        canceled = base.filter_by(status="cancelada").count()
+
+    return jsonify(
+        available_total=available_total,
+        doing=doing,
+        done=done,
+        canceled=canceled,
+    )
+
+
 
 # --- Compatibilidade admin ---------------------------------
 @app.route("/admin/delivery/<int:req_id>")

--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -73,7 +73,7 @@
         <h2 class="accordion-header" id="headPend">
           <button class="accordion-button" type="button"
                   data-bs-toggle="collapse" data-bs-target="#panePend">
-            🟡 Disponíveis ({{ available_total }})
+            🟡 Disponíveis (<span id="available-count">{{ available_total }}</span>)
           </button>
         </h2>
         <div id="panePend" class="accordion-collapse collapse show"
@@ -94,7 +94,7 @@
       <h2 class="accordion-header" id="headDoing">
         <button class="accordion-button collapsed" type="button"
                 data-bs-toggle="collapse" data-bs-target="#paneDoing">
-          🔵 Em Andamento ({{ doing|length }})
+          🔵 Em Andamento (<span id="doing-count">{{ doing|length }}</span>)
         </button>
       </h2>
       <div id="paneDoing" class="accordion-collapse collapse"
@@ -114,7 +114,7 @@
       <h2 class="accordion-header" id="headDone">
         <button class="accordion-button collapsed" type="button"
                 data-bs-toggle="collapse" data-bs-target="#paneDone">
-          ✅ Concluídos ({{ done|length }})
+          ✅ Concluídos (<span id="done-count">{{ done|length }}</span>)
         </button>
       </h2>
       <div id="paneDone" class="accordion-collapse collapse"
@@ -134,7 +134,7 @@
       <h2 class="accordion-header" id="headCancel">
         <button class="accordion-button collapsed" type="button"
                 data-bs-toggle="collapse" data-bs-target="#paneCancel">
-          ❌ Cancelados ({{ canceled|length }})
+          ❌ Cancelados (<span id="canceled-count">{{ canceled|length }}</span>)
         </button>
       </h2>
       <div id="paneCancel" class="accordion-collapse collapse"
@@ -151,4 +151,23 @@
 
   </div><!-- /accordion -->
 </div>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    async function refreshCounts() {
+      try {
+        const resp = await fetch('/api/delivery_counts');
+        if (!resp.ok) return;
+        const data = await resp.json();
+        document.getElementById('available-count').textContent = data.available_total;
+        document.getElementById('doing-count').textContent = data.doing;
+        document.getElementById('done-count').textContent = data.done;
+        document.getElementById('canceled-count').textContent = data.canceled;
+      } catch (err) {
+        console.error('Failed to update counts', err);
+      }
+    }
+    refreshCounts();
+    setInterval(refreshCounts, 10000);
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add API endpoint to report delivery counts for the current user
- update delivery request page to show live counts and auto-refresh badges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f37a0274832e8c402ce6530075a6