### PR TITLE
Add delivery action toasts

### DIFF
--- a/app.py
+++ b/app.py
@@ -2943,6 +2943,8 @@ def request_delivery(order_id):
 
     session.pop('current_order', None)
     flash('Solicitação de entrega gerada.', 'success')
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(message='Solicitação de entrega gerada.', category='success')
     return redirect(url_for('list_delivery_requests'))
 
 
@@ -3055,6 +3057,8 @@ def accept_delivery(req_id):
     req.accepted_at = datetime.utcnow()
     db.session.commit()
     flash('Entrega aceita.', 'success')
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(message='Entrega aceita.', category='success')
     # ⬇️ redireciona direto ao detalhe unificado
     return redirect(url_for('delivery_detail', req_id=req.id))
 
@@ -3071,6 +3075,8 @@ def complete_delivery(req_id):
     req.completed_at = datetime.utcnow()
     db.session.commit()
     flash('Entrega concluída.', 'success')
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(message='Entrega concluída.', category='success')
     return redirect(url_for('worker_history'))
 
 
@@ -3087,6 +3093,8 @@ def cancel_delivery(req_id):
     req.canceled_by_id = current_user.id
     db.session.commit()
     flash('Entrega cancelada.', 'info')
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(message='Entrega cancelada.', category='info')
     return redirect(url_for('worker_history'))
 
 

--- a/templates/create_order.html
+++ b/templates/create_order.html
@@ -30,7 +30,7 @@
     {% endfor %}
   </ul>
   <div class="alert alert-info">Quantidade total: {{ total_quantity }}</div>
-  <form action="{{ url_for('request_delivery', order_id=order.id) }}" method="post">
+    <form action="{{ url_for('request_delivery', order_id=order.id) }}" method="post" class="js-delivery-form">
     {{ delivery_form.hidden_tag() }}
     {{ delivery_form.submit(class="btn btn-success") }}
   </form>

--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -40,7 +40,7 @@
         {# -------- Botões só para entregador -------- #}
         {% if current_user.worker == 'delivery' %}
           {% if req.status == 'pendente' %}
-            <form action="{{ url_for('accept_delivery', req_id=req.id) }}" method="post">
+            <form action="{{ url_for('accept_delivery', req_id=req.id) }}" method="post" class="js-delivery-form">
               <button class="btn btn-sm btn-primary">Aceitar</button>
             </form>
 
@@ -50,10 +50,10 @@
                  class="btn btn-sm btn-outline-primary me-2">
                  Detalhes
               </a>
-              <form action="{{ url_for('complete_delivery', req_id=req.id) }}" method="post" class="me-2">
+              <form action="{{ url_for('complete_delivery', req_id=req.id) }}" method="post" class="me-2 js-delivery-form">
                 <button class="btn btn-sm btn-success">Concluir</button>
               </form>
-              <form action="{{ url_for('cancel_delivery', req_id=req.id) }}" method="post">
+              <form action="{{ url_for('cancel_delivery', req_id=req.id) }}" method="post" class="js-delivery-form">
                 <button class="btn btn-sm btn-outline-danger">Cancelar</button>
               </form>
             </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -440,6 +440,15 @@
         &copy; Lucas Marcelino • PetOrlândia 2025 <i class="fas fa-paw text-primary"></i>
     </footer>
 
+    <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
+        <div id="actionToast" class="toast text-white border-0" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="d-flex">
+                <div class="toast-body"></div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+        </div>
+    </div>
+
     <!-- Script para desaparecer com transição suave -->
     <script>
         document.addEventListener("DOMContentLoaded", () => {
@@ -462,10 +471,35 @@
       const mp = new MercadoPago("{{ MERCADOPAGO_PUBLIC_KEY }}", {locale: 'pt-BR'});
     </script>
     {% endif %}
-    <script>
+  <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('{{ url_for('service_worker') }}');
       }
-    </script>
+  </script>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.js-delivery-form').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          const resp = await fetch(form.action, {method: 'POST', headers: {'Accept': 'application/json'}});
+          if (resp.ok) {
+            const data = await resp.json();
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = data.message || 'Sucesso';
+            toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+            toastEl.classList.add('bg-' + (data.category || 'success'));
+            new bootstrap.Toast(toastEl).show();
+          } else {
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = 'Erro ao processar ação';
+            toastEl.classList.remove('bg-success', 'bg-info');
+            toastEl.classList.add('bg-danger');
+            new bootstrap.Toast(toastEl).show();
+          }
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/templates/worker_history.html
+++ b/templates/worker_history.html
@@ -7,7 +7,7 @@
     {% for r in available %}
     <li class="list-group-item d-flex justify-content-between align-items-center">
       Pedido #{{ r.order_id }}
-      <form action="{{ url_for('accept_delivery', req_id=r.id) }}" method="post">
+      <form action="{{ url_for('accept_delivery', req_id=r.id) }}" method="post" class="js-delivery-form">
         <button class="btn btn-sm btn-primary">Aceitar</button>
       </form>
     </li>
@@ -21,10 +21,10 @@
     <li class="list-group-item d-flex justify-content-between align-items-center">
       Pedido #{{ r.order_id }}
       <div>
-        <form action="{{ url_for('complete_delivery', req_id=r.id) }}" method="post" class="d-inline">
+        <form action="{{ url_for('complete_delivery', req_id=r.id) }}" method="post" class="d-inline js-delivery-form">
           <button class="btn btn-sm btn-success">Concluir</button>
         </form>
-        <form action="{{ url_for('cancel_delivery', req_id=r.id) }}" method="post" class="d-inline ms-2">
+        <form action="{{ url_for('cancel_delivery', req_id=r.id) }}" method="post" class="d-inline ms-2 js-delivery-form">
           <button class="btn btn-sm btn-danger">Cancelar</button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- add JSON responses for delivery-related routes
- show toast notifications for delivery operations
- make delivery forms submit via JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f36a3a60832e81fafafcc29abe0a