### PR TITLE
Handle string session address id

### DIFF
--- a/app.py
+++ b/app.py
@@ -3559,6 +3559,12 @@ def ver_carrinho():
 
     selected = session.get("last_address_id")
     available = [c[0] for c in form.address_id.choices]
+    try:
+        selected = int(selected)
+    except (TypeError, ValueError):
+        selected = None
+    if selected not in available:
+        selected = None
     if selected in available:
         form.address_id.data = selected
     elif available:


### PR DESCRIPTION
## Summary
- normalize `last_address_id` in cart view
- test that `last_address_id` string still selects address

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f6c74234832e8b9c0e30e64cfc9f