### PR TITLE
Fix checkout button blocked by address validation

### DIFF
--- a/templates/partials/endereco_form.html
+++ b/templates/partials/endereco_form.html
@@ -229,8 +229,15 @@ document.addEventListener("DOMContentLoaded", function() {
 
   // Define campos obrigatórios
   const requiredFields = ['rua', 'cidade', 'estado'];
-  
+
+  const addressSelect = document.getElementById('addressSelect');
+
   form.addEventListener("submit", function(e) {
+    if (addressSelect && addressSelect.value !== '-1') {
+      // usando endereço salvo - não valida campos vazios
+      return;
+    }
+
     let isValid = true;
     
     requiredFields.forEach(id => {


### PR DESCRIPTION
## Summary
- avoid validating blank address fields when user chooses a saved address

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884f9f7a67c832eb1b1bb75908826b0