### PR TITLE
Add default pickup address config

### DIFF
--- a/.env
+++ b/.env
@@ -20,3 +20,6 @@ MAIL_USERNAME=gpt.assistente.orlandia@gmail.com
 MAIL_PASSWORD=toso zrgb uuwx nzkp
 MAIL_DEFAULT_SENDER_NAME=PetOrlândia
 MAIL_DEFAULT_SENDER_EMAIL=gpt.assistente.orlandia@gmail.com
+
+# Endereço de retirada padrão (admin)
+DEFAULT_PICKUP_ADDRESS="Rua Nove, 990"

--- a/config.py
+++ b/config.py
@@ -27,3 +27,6 @@ class Config:
     MERCADOPAGO_PUBLIC_KEY = os.environ.get("MERCADOPAGO_PUBLIC_KEY", "APP_USR-2b9a9bff-692b-4de8-9b90-ce9aa758ca14")
     MERCADOPAGO_WEBHOOK_SECRET = os.environ.get("MERCADOPAGO_WEBHOOK_SECRET", "add6cb517c10e98c1decbe37a4290a41b45a9b3b1d04a5d368babd18a2969d44")
 
+    # Endereço de retirada padrão (usado se não houver PickupLocation no banco)
+    DEFAULT_PICKUP_ADDRESS = os.environ.get("DEFAULT_PICKUP_ADDRESS", "Rua Nove, 990")
+

--- a/templates/delivery_detail.html
+++ b/templates/delivery_detail.html
@@ -29,7 +29,7 @@
             {% if req.pickup %}
               {{ req.pickup.nome }} — {{ req.pickup.endereco.full }}
             {% else %}
-              —               {# aparecerá só se, por algum motivo, não houver pickup ligado #}
+              {{ DEFAULT_PICKUP_ADDRESS }}
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- configure a default pickup address
- expose the value to templates
- use default when no pickup location exists
- show default pickup in delivery detail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fa404dd0832e9fbcac4955f2ed2f