### PR TITLE
Fix checkout button

### DIFF
--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -29,7 +29,7 @@
     <strong>Total:&nbsp;R$ {{ '%.2f'|format(order.total_value()) }}</strong>
   </div>
 
-  <form action="{{ url_for('checkout_confirm') }}" method="post" class="text-end">
+  <form action="{{ url_for('checkout') }}" method="post" class="text-end">
     {{ form.hidden_tag() }}
 
     <div class="mb-3 text-start">


### PR DESCRIPTION
## Summary
- fix Finalizar Compra button to send data to `/checkout`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688504f7e58c832ebd13194c1210c03f