### PR TITLE
Fix cart checkout action

### DIFF
--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -29,7 +29,7 @@
     <strong>Total:&nbsp;R$ {{ '%.2f'|format(order.total_value()) }}</strong>
   </div>
 
-  <form action="{{ url_for('checkout') }}" method="post" class="text-end">
+  <form action="{{ url_for('checkout_confirm') }}" method="post" class="text-end">
     {{ form.hidden_tag() }}
 
     <div class="mb-3 text-start">


### PR DESCRIPTION
## Summary
- point the cart's finalize purchase button to the checkout confirmation route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885125eed58832e9d5dd03aa670655d