### PR TITLE
Enable multiple saved addresses in cart

### DIFF
--- a/app.py
+++ b/app.py
@@ -3544,6 +3544,7 @@ from forms import CheckoutForm
 def ver_carrinho():
     # 1) Cria o form
     form = CheckoutForm()
+    addr_form = CartAddressForm()
     default_address = _setup_checkout_form(form)
 
     # 2) Verifica se há um pagamento pendente
@@ -3564,7 +3565,8 @@ def ver_carrinho():
         order=order,
         pagamento_pendente=pagamento_pendente,
         default_address=default_address,
-        saved_addresses=current_user.saved_addresses
+        saved_addresses=current_user.saved_addresses,
+        addr_form=addr_form
     )
 
 

--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -29,6 +29,18 @@
     <strong>Total:&nbsp;R$ {{ '%.2f'|format(order.total_value()) }}</strong>
   </div>
 
+  <div id="new-address-form" class="d-none mb-4">
+    <form action="{{ url_for('carrinho_salvar_endereco') }}" method="post">
+      {{ addr_form.hidden_tag() }}
+      {% include 'partials/endereco_form.html' %}
+      <div class="text-end">
+        <button type="submit" class="btn btn-primary">
+          <i class="bi bi-save"></i> Salvar Endereço
+        </button>
+      </div>
+    </form>
+  </div>
+
   <form action="{{ url_for('checkout_confirm') }}" method="post" class="text-end">
     {{ form.hidden_tag() }}
 
@@ -54,7 +66,6 @@
       </div>
     </div>
 
-  /div>
 
     <button type="submit" class="btn btn-lg btn-success shadow-sm">
       <i class="bi bi-cash-stack"></i> {{ form.submit.label.text }}


### PR DESCRIPTION
## Summary
- integrate CartAddressForm in the cart page
- allow saving multiple addresses and showing address form when selecting "Novo endereço"
- pass CartAddressForm to cart view

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885513a2520832e8ab238b23a6c1a01