### PR TITLE
Add back button to checkout confirm

### DIFF
--- a/templates/checkout_confirm.html
+++ b/templates/checkout_confirm.html
@@ -36,6 +36,11 @@
       Continuar para Pagamento
     </button>
   </form>
+  <div class="mt-3 text-start">
+    <a href="{{ url_for('ver_carrinho') }}" class="btn btn-outline-secondary">
+      <i class="bi bi-arrow-left-circle"></i> Voltar ao carrinho
+    </a>
+  </div>
   <script>
     function toggleAltAddr() {
       document.getElementById('alt-address').classList.toggle('d-none');


### PR DESCRIPTION
## Summary
- add missing navigation on the checkout confirmation page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855436dd40832e920a4bb747a874e0