### PR TITLE
Fix account deletion after logout

### DIFF
--- a/app.py
+++ b/app.py
@@ -537,7 +537,9 @@ def change_password():
 def delete_account():
     form = DeleteAccountForm()
     if form.validate_on_submit():
-        user = current_user
+        # Capture the actual user object before logging out because
+        # `current_user` becomes `AnonymousUserMixin` after logout.
+        user = current_user._get_current_object()
         logout_user()
         db.session.delete(user)
         db.session.commit()


### PR DESCRIPTION
## Summary
- ensure account deletion removes logged out user

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885571bf854832e99bac60edd972c75