### PR TITLE
Fix checkout confirm address handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -3614,7 +3614,31 @@ def checkout_confirm():
         flash("Seu carrinho está vazio.", "warning")
         return redirect(url_for("ver_carrinho"))
 
-    return render_template("checkout_confirm.html", form=form, order=order)
+    # Determine the address text based on the chosen option
+    selected_address = None
+    if form.address_id.data is not None and form.address_id.data >= 0:
+        if form.address_id.data == 0 and current_user.endereco and current_user.endereco.full:
+            selected_address = current_user.endereco.full
+        else:
+            sa = SavedAddress.query.filter_by(
+                id=form.address_id.data,
+                user_id=current_user.id
+            ).first()
+            if sa:
+                selected_address = sa.address
+
+    if not selected_address and form.shipping_address.data:
+        selected_address = form.shipping_address.data
+
+    if not selected_address and current_user.endereco and current_user.endereco.full:
+        selected_address = current_user.endereco.full
+
+    return render_template(
+        "checkout_confirm.html",
+        form=form,
+        order=order,
+        selected_address=selected_address,
+    )
 
 
 

--- a/templates/checkout_confirm.html
+++ b/templates/checkout_confirm.html
@@ -16,7 +16,9 @@
 
   <div class="mb-4">
     <h5 class="fw-bold">Endereço de Entrega</h5>
-    {% if current_user.endereco and current_user.endereco.full %}
+    {% if selected_address %}
+      <p class="mb-1">{{ selected_address }}</p>
+    {% elif current_user.endereco and current_user.endereco.full %}
       <p class="mb-1">{{ current_user.endereco.full }}</p>
     {% else %}
       <p class="text-danger mb-1">Nenhum endereço cadastrado.</p>
@@ -28,7 +30,8 @@
     </div>
   </div>
   <form action="{{ url_for('checkout') }}" method="post" class="text-end">
-    {{ form.hidden_tag() }}
+    {{ form.csrf_token }}
+    <input type="hidden" name="address_id" value="{{ form.address_id.data }}">
     <button type="submit" class="btn btn-success">
       Continuar para Pagamento
     </button>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -765,6 +765,8 @@ def test_checkout_confirm_renders(monkeypatch, app):
         html = resp.get_data(as_text=True)
         assert 'Confirmar Compra' in html
         assert 'Prod' in html
+        assert 'addr' in html
+        assert 'name="address_id"' in html
 
 
 def test_cart_uses_session_string_address_id(monkeypatch, app):


### PR DESCRIPTION
## Summary
- show selected address on checkout confirmation page
- persist selected address ID when continuing to payment
- test that checkout confirmation renders chosen address

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855a3b8480832eaa723638cbe5fd98