### PR TITLE
Async admin delivery actions

### DIFF
--- a/app.py
+++ b/app.py
@@ -3280,6 +3280,8 @@ def admin_set_delivery_status(req_id, status):
 
     db.session.commit()
     flash('Status atualizado.', 'success')
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(message='Status atualizado.', category='success', status=status)
     return redirect(url_for('delivery_overview'))
 
 
@@ -3293,6 +3295,8 @@ def admin_delete_delivery(req_id):
     db.session.delete(req)
     db.session.commit()
     flash('Entrega excluída.', 'info')
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(message='Entrega excluída.', category='info', deleted=True)
     return redirect(url_for('delivery_overview'))
 
 

--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -48,28 +48,28 @@
              Ver detalhes
           </a>
           {% if r.status != 'pendente' %}
-          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='pendente') }}" method="post">
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='pendente') }}" method="post" class="js-admin-delivery-form">
             <button class="btn btn-sm btn-warning" title="Marcar como pendente">Pendente</button>
           </form>
           {% endif %}
           {% if r.status != 'em_andamento' %}
-          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='em_andamento') }}" method="post">
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='em_andamento') }}" method="post" class="js-admin-delivery-form">
             <button class="btn btn-sm btn-info text-dark" title="Marcar em andamento">Em andamento</button>
           </form>
 
           {% endif %}
           {% if r.status != 'concluida' %}
-          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='concluida') }}" method="post">
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='concluida') }}" method="post" class="js-admin-delivery-form">
             <button class="btn btn-sm btn-success" title="Marcar como concluída">Concluir</button>
           </form>
           {% endif %}
           {% if r.status != 'cancelada' %}
 
-          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='cancelada') }}" method="post">
+          <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='cancelada') }}" method="post" class="js-admin-delivery-form">
             <button class="btn btn-sm btn-danger" title="Cancelar">Cancelar</button>
           </form>
           {% endif %}
-          <form action="{{ url_for('admin_delete_delivery', req_id=r.id) }}" method="post" onsubmit="return confirm('Excluir pedido?');">
+          <form action="{{ url_for('admin_delete_delivery', req_id=r.id) }}" method="post" onsubmit="return confirm('Excluir pedido?');" class="js-admin-delivery-form">
             <button class="btn btn-sm btn-outline-danger" title="Excluir">Excluir</button>
           </form>
         </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -505,5 +505,33 @@
       });
     });
   </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.js-admin-delivery-form').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          const li = form.closest('li');
+          const resp = await fetch(form.action, {method: 'POST', headers: {'Accept': 'application/json'}});
+          if (resp.ok) {
+            const data = await resp.json();
+            if (data.deleted || data.status) {
+              li?.remove();
+            }
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = data.message || 'Sucesso';
+            toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+            toastEl.classList.add('bg-' + (data.category || 'success'));
+            new bootstrap.Toast(toastEl).show();
+          } else {
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = 'Erro ao processar ação';
+            toastEl.classList.remove('bg-success', 'bg-info');
+            toastEl.classList.add('bg-danger');
+            new bootstrap.Toast(toastEl).show();
+          }
+        });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow admin delivery routes to return JSON when requested
- update delivery overview forms with `js-admin-delivery-form`
- add JS handler for admin delivery forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855ce119b0832eb04e5180612572e8