### PR TITLE
Enable JSON cart actions & fetch

### DIFF
--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -11,12 +11,12 @@
         <h6 class="mb-0 fw-bold">{{ item.item_name }}</h6>
       </div>
       <div class="d-flex align-items-center">
-        <form action="{{ url_for('diminuir_item_carrinho', item_id=item.id) }}" method="post" class="me-2">
+        <form action="{{ url_for('diminuir_item_carrinho', item_id=item.id) }}" method="post" class="me-2 js-cart-form">
           {{ form.csrf_token }}
           <button type="submit" class="btn btn-outline-secondary btn-sm">-</button>
         </form>
         <span class="mx-1">{{ item.quantity }}</span>
-        <form action="{{ url_for('aumentar_item_carrinho', item_id=item.id) }}" method="post" class="ms-2">
+        <form action="{{ url_for('aumentar_item_carrinho', item_id=item.id) }}" method="post" class="ms-2 js-cart-form">
           {{ form.csrf_token }}
           <button type="submit" class="btn btn-outline-secondary btn-sm">+</button>
         </form>
@@ -26,7 +26,7 @@
   </ul>
 
   <div class="d-flex justify-content-end mb-3">
-    <strong>Total:&nbsp;R$ {{ '%.2f'|format(order.total_value()) }}</strong>
+    <strong id="cartTotal">Total:&nbsp;R$ {{ '%.2f'|format(order.total_value()) }}</strong>
   </div>
 
   <div id="new-address-form" class="d-none mb-4">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -503,6 +503,39 @@
           }
         });
       });
+
+      document.querySelectorAll('.js-cart-form').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          const resp = await fetch(form.action, {
+            method: form.method,
+            body: new FormData(form),
+            headers: {'Accept': 'application/json'}
+          });
+          if (resp.ok) {
+            const data = await resp.json();
+            const span = form.parentElement.querySelector('span');
+            if (span && data.item_quantity !== undefined) {
+              span.textContent = data.item_quantity;
+            }
+            const totalEl = document.getElementById('cartTotal');
+            if (totalEl && data.order_total_formatted) {
+              totalEl.textContent = 'Total:\u00A0' + data.order_total_formatted;
+            }
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = data.message || 'Sucesso';
+            toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+            toastEl.classList.add('bg-' + (data.category || 'success'));
+            new bootstrap.Toast(toastEl).show();
+          } else {
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = 'Erro ao processar ação';
+            toastEl.classList.remove('bg-success', 'bg-info');
+            toastEl.classList.add('bg-danger');
+            new bootstrap.Toast(toastEl).show();
+          }
+        });
+      });
     });
   </script>
 </body>

--- a/templates/loja.html
+++ b/templates/loja.html
@@ -67,8 +67,8 @@
               R$ {{ '%.2f'|format(product.price)|replace('.', ',') }}
             </span>
             
-            <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}" 
-                  method="post" class="ms-2">
+            <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}"
+                  method="post" class="ms-2 js-cart-form">
               {{ form.hidden_tag() }}
               <div class="d-flex align-items-center">
                 <div class="quantity-selector me-2">

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -14,7 +14,7 @@
       <h2>{{ product.name }}</h2>
       <p>{{ product.description }}</p>
       <p class="h4 text-success">R$ {{ '%.2f'|format(product.price)|replace('.', ',') }}</p>
-      <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}" method="post" class="d-flex align-items-center gap-2">
+      <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}" method="post" class="d-flex align-items-center gap-2 js-cart-form">
         {{ cart_form.hidden_tag() }}
         {{ cart_form.quantity(class="form-control w-auto", min="1") }}
         <button type="submit" class="btn btn-primary">Adicionar ao Carrinho</button>


### PR DESCRIPTION
## Summary
- return JSON when adding or updating cart items if request asks for JSON
- handle `.js-cart-form` via fetch so the cart updates without reloads
- mark cart-related forms with `js-cart-form`
- expose `cartTotal` element for dynamic updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855ce10580832eb0e5a9d1c8a50643