### PR TITLE
Async animal status forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -2796,8 +2796,16 @@ def marcar_como_falecido(animal_id):
         animal.is_alive = False
         db.session.commit()
         flash(f'{animal.name} foi marcado como falecido.', 'success')
+        if 'application/json' in request.headers.get('Accept', ''):
+            return jsonify(
+                message=f'{animal.name} foi marcado como falecido.',
+                category='success',
+                redirect=url_for('ficha_animal', animal_id=animal.id)
+            )
     except Exception as e:
         flash(f'Erro ao marcar como falecido: {str(e)}', 'danger')
+        if 'application/json' in request.headers.get('Accept', ''):
+            return jsonify(message=f'Erro ao marcar como falecido: {str(e)}', category='danger'), 400
 
     return redirect(url_for('ficha_animal', animal_id=animal.id))
 
@@ -2815,6 +2823,12 @@ def reverter_falecimento(animal_id):
     animal.falecido_em = None
     db.session.commit()
     flash('Falecimento revertido com sucesso.', 'success')
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(
+            message='Falecimento revertido com sucesso.',
+            category='success',
+            redirect=url_for('ficha_animal', animal_id=animal.id)
+        )
     return redirect(url_for('ficha_animal', animal_id=animal.id))
 
 
@@ -2834,9 +2848,17 @@ def arquivar_animal(animal_id):
         db.session.delete(animal)
         db.session.commit()
         flash(f'Animal {animal.name} excluído permanentemente.', 'success')
+        if 'application/json' in request.headers.get('Accept', ''):
+            return jsonify(
+                message=f'Animal {animal.name} excluído permanentemente.',
+                category='success',
+                redirect=url_for('ficha_tutor', tutor_id=animal.user_id)
+            )
     except Exception as e:
         db.session.rollback()
         flash(f'Erro ao excluir: {str(e)}', 'danger')
+        if 'application/json' in request.headers.get('Accept', ''):
+            return jsonify(message=f'Erro ao excluir: {str(e)}', category='danger'), 400
 
     return redirect(url_for('ficha_tutor', tutor_id=animal.user_id))
 

--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -165,13 +165,13 @@
       <div id="opcoes-falecimento" class="mt-3 d-none">
 
         <!-- Falecido agora -->
-        <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}" class="mb-2">
+        <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}" class="mb-2 js-animal-status">
           <input type="hidden" name="falecimento_em" value="">
           <button class="btn btn-dark btn-sm" type="submit">✅ Falecido agora</button>
         </form>
 
         <!-- Escolher data -->
-        <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}">
+        <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}" class="js-animal-status">
           <div class="mb-2">
             <label for="falecimento_em" class="form-label mb-1">Data e hora do falecimento:</label>
             <input type="datetime-local" name="falecimento_em" id="falecimento_em" class="form-control form-control-sm">
@@ -183,7 +183,7 @@
       <!-- Botão: Arquivar definitivamente -->
       <form method="POST" action="{{ url_for('arquivar_animal', animal_id=animal.id) }}"
             onsubmit="return confirm('Tem certeza que deseja excluir este animal permanentemente?');"
-            class="mt-3">
+            class="mt-3 js-animal-status">
         <button class="btn btn-outline-danger btn-sm" type="submit">
           🗑️ Deletar definitivamente
         </button>
@@ -201,14 +201,14 @@
     </div>
 
     {% if current_user.worker == 'veterinario' %}
-      <form method="POST" action="{{ url_for('reverter_falecimento', animal_id=animal.id) }}">
+      <form method="POST" action="{{ url_for('reverter_falecimento', animal_id=animal.id) }}" class="js-animal-status">
         <button class="btn btn-sm btn-outline-success">↩️ Reverter Falecimento</button>
       </form>
 
       <!-- Botão: Arquivar definitivamente -->
       <form method="POST" action="{{ url_for('arquivar_animal', animal_id=animal.id) }}"
             onsubmit="return confirm('Tem certeza que deseja excluir este animal permanentemente?');"
-            class="ms-2">
+            class="ms-2 js-animal-status">
         <button class="btn btn-outline-danger btn-sm" type="submit">
           🗑️ Deletar definitivamente
         </button>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -505,5 +505,37 @@
       });
     });
   </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.js-animal-status').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          const resp = await fetch(form.action, {
+            method: 'POST',
+            headers: {'Accept': 'application/json'},
+            body: new FormData(form)
+          });
+          if (resp.ok) {
+            const data = await resp.json();
+            if (data.redirect) {
+              window.location.href = data.redirect;
+              return;
+            }
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = data.message || 'Sucesso';
+            toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+            toastEl.classList.add('bg-' + (data.category || 'success'));
+            new bootstrap.Toast(toastEl).show();
+          } else {
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = 'Erro ao processar ação';
+            toastEl.classList.remove('bg-success', 'bg-info');
+            toastEl.classList.add('bg-danger');
+            new bootstrap.Toast(toastEl).show();
+          }
+        });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support JSON responses for `marcar_como_falecido`, `reverter_falecimento` and `arquivar_animal`
- mark life status forms with `js-animal-status`
- submit animal status forms asynchronously with toast feedback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855cdf2be0832e86875eac7daa2ffa