### PR TITLE
Enable async conversation message posting

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 
 from dotenv import load_dotenv
-from flask import Flask, session, send_from_directory
+from flask import Flask, session, send_from_directory, abort
 from itsdangerous import URLSafeTimedSerializer
 
 # ----------------------------------------------------------------
@@ -762,6 +762,27 @@ def conversa(animal_id, user_id):
     )
 
 
+@app.route('/api/conversa/<int:animal_id>/<int:user_id>', methods=['POST'])
+@login_required
+def api_conversa_message(animal_id, user_id):
+    """Recebe uma nova mensagem da conversa e retorna o HTML renderizado."""
+    form = MessageForm()
+    Animal.query.get_or_404(animal_id)
+    outro_usuario = User.query.get_or_404(user_id)
+    if form.validate_on_submit():
+        nova_msg = Message(
+            sender_id=current_user.id,
+            receiver_id=outro_usuario.id,
+            animal_id=animal_id,
+            content=form.content.data,
+            lida=False
+        )
+        db.session.add(nova_msg)
+        db.session.commit()
+        return render_template('components/message.html', msg=nova_msg)
+    return '', 400
+
+
 @app.route('/conversa_admin', methods=['GET', 'POST'])
 @app.route('/conversa_admin/<int:user_id>', methods=['GET', 'POST'])
 @login_required
@@ -830,6 +851,36 @@ def conversa_admin(user_id=None):
         form=form,
         admin=interlocutor
     )
+
+
+@app.route('/api/conversa_admin', methods=['POST'])
+@app.route('/api/conversa_admin/<int:user_id>', methods=['POST'])
+@login_required
+def api_conversa_admin_message(user_id=None):
+    """Recebe nova mensagem na conversa com o admin e retorna HTML."""
+    admin_user = User.query.filter_by(role='admin').first()
+    if not admin_user:
+        abort(404)
+
+    if current_user.role == 'admin':
+        if user_id is None:
+            return '', 400
+        interlocutor = User.query.get_or_404(user_id)
+    else:
+        interlocutor = admin_user
+
+    form = MessageForm()
+    if form.validate_on_submit():
+        nova_msg = Message(
+            sender_id=current_user.id,
+            receiver_id=interlocutor.id,
+            content=form.content.data,
+            lida=False,
+        )
+        db.session.add(nova_msg)
+        db.session.commit()
+        return render_template('components/message.html', msg=nova_msg)
+    return '', 400
 
 
 @app.route('/mensagens_admin')
@@ -3975,7 +4026,7 @@ def notificacoes_mercado_pago():
 # 3)  /payment_status/<payment_id>   – página pós‑pagamento
 #      (versão sem QR‑Code)
 # --------------------------------------------------------
-from flask import render_template, abort, request, jsonify
+from flask import render_template, request, jsonify
 
 def _refresh_mp_status(payment: Payment) -> None:
     if payment.status != PaymentStatus.PENDING:

--- a/templates/components/message.html
+++ b/templates/components/message.html
@@ -1,0 +1,7 @@
+<div class="mb-2 {% if msg.sender_id == current_user.id %}text-end{% endif %}">
+    <div class="p-2 rounded {% if msg.sender_id == current_user.id %}bg-info-subtle{% else %}bg-light{% endif %}">
+        <small>{{ msg.sender.name }}:</small><br>
+        {{ msg.content }}
+        <div class="text-muted small">{{ msg.timestamp|format_datetime_brazil('%d/%m %H:%M') }}</div>
+    </div>
+</div>

--- a/templates/conversa.html
+++ b/templates/conversa.html
@@ -16,7 +16,7 @@
 </div>
 
 
-<form method="POST">
+<form method="POST" class="js-msg-form" data-api="{{ url_for('api_conversa_message', animal_id=animal.id, user_id=outro_usuario.id) }}">
     {{ form.hidden_tag() }}
     <div class="input-group">
 

--- a/templates/conversa_admin.html
+++ b/templates/conversa_admin.html
@@ -14,7 +14,7 @@
     {% endfor %}
 </div>
 
-<form method="POST">
+<form method="POST" class="js-msg-form" {% if current_user.role == 'admin' %}data-api="{{ url_for('api_conversa_admin_message', user_id=admin.id) }}"{% else %}data-api="{{ url_for('api_conversa_admin_message') }}"{% endif %}>
     {{ form.hidden_tag() }}
     <div class="input-group">
         {{ form.content(class="form-control", placeholder="Digite sua mensagem...") }}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -505,5 +505,29 @@
       });
     });
   </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.js-msg-form').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          const api = form.dataset.api || form.action;
+          const formData = new FormData(form);
+          const resp = await fetch(api, { method: 'POST', body: formData, headers: { 'Accept': 'text/html' } });
+          if (resp.ok) {
+            const html = await resp.text();
+            const container = document.getElementById('mensagens-container');
+            if (container) {
+              container.insertAdjacentHTML('beforeend', html);
+              container.scrollTop = container.scrollHeight;
+            }
+            const textarea = form.querySelector('textarea');
+            if (textarea) textarea.value = '';
+          } else {
+            form.submit();
+          }
+        });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement `/api/conversa/...` and `/api/conversa_admin` endpoints returning HTML snippets
- add a `js-msg-form` class to message forms
- use a new message partial
- add JS that posts the form via `fetch` and appends the HTML

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855cdf9ff8832eb32b279230174e95