### PR TITLE
Enable offline queue for vet forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ This project is a Flask application for managing pets. The repository now includ
 
 The tests run without needing external services or a database connection.
 
+## Offline Usage
+
+PetOrlândia can operate with limited connectivity thanks to a small service worker
+and an offline queue. Forms marked with `data-sync="true"` will save their data
+locally whenever the network is unavailable. Once the device goes back online the
+queued requests are automatically sent to the server.
+
+The file `static/offline.js` implements this behaviour and is cached by the
+service worker.
+
 ## Mercado Pago
 
 To enable payment integration you must provide credentials from your Mercado

--- a/static/offline.js
+++ b/static/offline.js
@@ -1,0 +1,76 @@
+(function(){
+  const KEY = 'offline-queue';
+
+  function loadQueue(){
+    try { return JSON.parse(localStorage.getItem(KEY)) || []; }
+    catch(e){ return []; }
+  }
+  function saveQueue(q){
+    localStorage.setItem(KEY, JSON.stringify(q));
+  }
+
+  async function sendQueued(){
+    if(!navigator.onLine) return;
+    const q = loadQueue();
+    while(q.length){
+      const item = q[0];
+      let body;
+      if(item.body && item.body.form){
+        body = new FormData();
+        item.body.form.forEach(([k,v])=>body.append(k,v));
+      } else if(item.body && item.body.json){
+        body = JSON.stringify(item.body.json);
+      } else if(item.body && item.body.text){
+        body = item.body.text;
+      }
+      try {
+        const resp = await fetch(item.url, {method:item.method, headers:item.headers, body});
+        if(!resp.ok) throw new Error('fail');
+        q.shift();
+      } catch(err){
+        break;
+      }
+    }
+    saveQueue(q);
+  }
+
+  window.fetchOrQueue = async function(url, opts={}){
+    const method = opts.method || 'POST';
+    const headers = opts.headers || {};
+    let bodyData = null;
+    if(opts.body instanceof FormData){
+      bodyData = {form:[...opts.body.entries()]};
+    } else if(typeof opts.body === 'string'){
+      bodyData = {text: opts.body};
+    } else if(opts.body){
+      bodyData = {json: opts.body};
+    }
+    if(navigator.onLine){
+      try {
+        const resp = await fetch(url, opts);
+        if(resp.ok) return resp;
+      } catch(e){ /* fallthrough */ }
+    }
+    const q = loadQueue();
+    q.push({url, method, headers, body:bodyData});
+    saveQueue(q);
+    return null;
+  };
+
+  window.addEventListener('online', sendQueued);
+  document.addEventListener('DOMContentLoaded', sendQueued);
+
+  document.addEventListener('submit', async ev => {
+    const form = ev.target;
+    if (!form.matches('form[data-sync]')) return;
+    ev.preventDefault();
+    const data = new FormData(form);
+    const resp = await window.fetchOrQueue(form.action, {method: form.method || 'POST', headers: {'Accept': 'application/json'}, body: data});
+    if (resp) {
+      try { await resp.json(); } catch(e) {}
+      location.reload();
+    } else {
+      alert('Ação salva offline e será sincronizada quando possível.');
+    }
+  });
+})();

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -4,6 +4,7 @@ const CACHE_NAME = 'petorlandia-cache-v3';
 // pre-caching them. Only static assets are cached up-front.
 const urlsToCache = [
   '/static/pastorgato.png'
+  ,'/static/offline.js'
 ];
 
 // Install the service worker and take control immediately

--- a/templates/base_consulta.html
+++ b/templates/base_consulta.html
@@ -166,6 +166,7 @@
         navigator.serviceWorker.register('{{ url_for('service_worker') }}');
       }
     </script>
+    <script src="{{ url_for('static', filename='offline.js') }}"></script>
 
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -476,6 +476,7 @@
         navigator.serviceWorker.register('{{ url_for('service_worker') }}');
       }
   </script>
+  <script src="{{ url_for('static', filename='offline.js') }}"></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/templates/partials/animal_form.html
+++ b/templates/partials/animal_form.html
@@ -1,6 +1,6 @@
 <form method="POST" action="{{ url_for('update_animal', animal_id=animal.id) }}"
       enctype="multipart/form-data" onsubmit="return validarCadastroAnimal();"
-      class="needs-validation" novalidate>
+      class="needs-validation" novalidate data-sync="true">
 
   <h5 class="mb-3">🐾 Cadastro do Animal</h5>
 

--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -1,5 +1,5 @@
 <!-- templates/partials/animal_register_form.html -->
-<form method="POST" action="{{ url_for('novo_animal') }}" onsubmit="return validarTutor();">
+<form method="POST" action="{{ url_for('novo_animal') }}" onsubmit="return validarTutor();" data-sync="true">
     <h5 class="mb-3">🐾 Cadastro do Animal</h5>
 
     {% if not tutor %}

--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -6,9 +6,9 @@
   </div>
 {% endif %}
 
-<form method="POST" 
+<form method="POST"
       action="{{ url_for('update_consulta', consulta_id=consulta.id) }}{% if edit_mode %}?edit=1{% endif %}"
-      class="needs-validation" novalidate>
+      class="needs-validation" novalidate data-sync="true">
 
   <!-- Seção de Queixa Principal -->
   <div class="mb-3">

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -144,7 +144,7 @@
     });
   }
 
-  function finalizarBlocoExames() {
+  async function finalizarBlocoExames() {
     if (exames.length === 0) {
       alert('Adicione pelo menos um exame antes de finalizar.');
       return;
@@ -152,29 +152,25 @@
 
     const obsGerais = document.getElementById('observacoes-exames')?.value || '';
 
-    fetch(`/animal/{{ animal.id }}/bloco_exames`, {
+    const resp = await fetchOrQueue(`/animal/{{ animal.id }}/bloco_exames`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         exames: exames,
         observacoes_gerais: obsGerais
       })
-    })
-    .then(res => res.json())
-    .then(data => {
+    });
+    if (resp) {
+      const data = await resp.json();
       if (data.success) {
         alert('Solicitação de exames salva com sucesso!');
         location.reload();
       } else {
         alert('Erro ao salvar exames.');
       }
-    })
-    .catch(err => {
-      console.error('Erro na requisição:', err);
-      alert('Erro ao salvar exames.');
-    });
+    } else {
+      alert('Solicitação salva offline e será enviada quando possível.');
+    }
   }
 </script>
 

--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -255,7 +255,7 @@
 
     try {
       const instrucoes = document.getElementById('instrucoes-medicamentos')?.value || '';
-      const response = await fetch(`/consulta/{{ consulta.id }}/bloco_prescricao`, {
+      const response = await fetchOrQueue(`/consulta/{{ consulta.id }}/bloco_prescricao`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -264,13 +264,15 @@
         })
       });
 
-      const data = await response.json();
-      
-      if (!response.ok) throw new Error(data.message || 'Erro ao salvar prescrição');
-      
-      mostrarFeedback('Prescrição salva com sucesso!', 'success');
-      setTimeout(() => location.reload(), 1500);
-      
+      if (response) {
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.message || 'Erro ao salvar prescrição');
+        mostrarFeedback('Prescrição salva com sucesso!', 'success');
+        setTimeout(() => location.reload(), 1500);
+      } else {
+        mostrarFeedback('Prescrição salva offline. Sincronizaremos em breve.', 'info');
+      }
+
     } catch (err) {
       console.error('Erro:', err);
       mostrarFeedback(err.message || 'Erro ao salvar prescrição', 'danger');

--- a/templates/partials/tutor_form.html
+++ b/templates/partials/tutor_form.html
@@ -20,9 +20,9 @@
 </div>
 
 <!-- 👤 Formulário de Tutor - Aprimorado com validação e organização -->
-<form id="tutor-form" method="POST" enctype="multipart/form-data" 
+<form id="tutor-form" method="POST" enctype="multipart/form-data"
       {% if has_tutor %}action="{{ url_for('update_tutor', user_id=tutor.id) }}"{% endif %}
-      class="needs-validation" novalidate>
+      class="needs-validation" novalidate data-sync="true">
   
   <h5 class="mb-4 d-flex align-items-center gap-2">
     <i class="bi bi-person-fill"></i> Cadastro do Tutor

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -138,7 +138,7 @@
       });
     }
 
-    function finalizarBlocoVacinas() {
+    async function finalizarBlocoVacinas() {
       const obs = document.getElementById('observacoes-vacinas').value.trim();
 
       if (vacinas.length === 0) {
@@ -146,26 +146,24 @@
         return;
       }
 
-      fetch(`/animal/{{ animal.id }}/vacinas`, {
+      const resp = await fetchOrQueue(`/animal/{{ animal.id }}/vacinas`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           vacinas,
           observacoes_gerais: obs
         })
-      })
-      .then(res => res.json())
-      .then(data => {
+      });
+      if (resp) {
+        const data = await resp.json();
         if (data.success) {
           alert('Vacinas registradas com sucesso!');
           location.reload();
         } else {
           alert('Erro ao salvar vacinas.');
         }
-      })
-      .catch(err => {
-        console.error('❌ Erro na requisição:', err);
-        alert('Erro técnico ao salvar vacinas.');
-      });
+      } else {
+        alert('Vacinas salvas offline e serão enviadas quando possível.');
+      }
     }
   </script>


### PR DESCRIPTION
## Summary
- add offline.js with queueing logic and form handler
- cache offline.js in service-worker
- load offline.js in base templates
- mark vet forms with `data-sync` and sync fetch-based actions
- document offline usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688687a465e0832e935c491b844e0cbb