### PR TITLE
Add map link for admin deliveries

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -47,6 +47,14 @@
              class="btn btn-sm btn-outline-primary">
              Ver detalhes
           </a>
+          {% set origin = r.pickup.endereco.full if r.pickup else DEFAULT_PICKUP_ADDRESS %}
+          {% set destination = ord.shipping_address or (ord.user.endereco.full if ord and ord.user and ord.user.endereco and ord.user.endereco.full else None) %}
+          {% if origin and destination %}
+          <a class="btn btn-sm btn-outline-secondary" target="_blank"
+             href="https://www.google.com/maps/dir/?api=1&origin={{ origin | urlencode }}&destination={{ destination | urlencode }}">
+             Mapa
+          </a>
+          {% endif %}
           {% if r.status != 'pendente' %}
           <form action="{{ url_for('admin_set_delivery_status', req_id=r.id, status='pendente') }}" method="post" class="js-admin-delivery-form">
             <button class="btn btn-sm btn-warning" title="Marcar como pendente">Pendente</button>


### PR DESCRIPTION
## Summary
- let admins open delivery routes from the delivery overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868ad48c18832eb47acf1b382a7a05