### PR TITLE
Redirect print pages to gov.br signer

### DIFF
--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -190,5 +190,11 @@
   {% if clinica.cnpj %}CNPJ: {{ clinica.cnpj }}{% endif %}
 </footer>
 
+<script>
+  window.addEventListener('afterprint', function(){
+    window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+  });
+</script>
+
 </body>
 </html>

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -128,5 +128,10 @@
     {% if clinica.cnpj %}CNPJ: {{ clinica.cnpj }}{% endif %}
   </footer>
   {% endif %}
+  <script>
+    window.addEventListener('afterprint', function(){
+      window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+    });
+  </script>
 </body>
 </html>

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -199,6 +199,12 @@
     Telefone: {{ clinica.telefone }} – Email: {{ clinica.email }} – CNPJ: {{ clinica.cnpj }}
   </footer>
 
+  <script>
+    window.addEventListener('afterprint', function(){
+      window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+    });
+  </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- redirect printable documents to the gov.br signing page after the browser's print dialog closes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868afe9ba8832ea99517ce977d2d61