### PR TITLE
Add confirmation before signing page redirect

### DIFF
--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -192,7 +192,9 @@
 
 <script>
   window.addEventListener('afterprint', function(){
-    window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+    if (confirm('Abrir página de assinatura agora?')) {
+      window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+    }
   });
 </script>
 

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -129,9 +129,11 @@
   </footer>
   {% endif %}
   <script>
-    window.addEventListener('afterprint', function(){
-      window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
-    });
+  window.addEventListener('afterprint', function(){
+      if (confirm('Abrir página de assinatura agora?')) {
+          window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+      }
+  });
   </script>
 </body>
 </html>

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -200,8 +200,10 @@
   </footer>
 
   <script>
-    window.addEventListener('afterprint', function(){
-      window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+  window.addEventListener('afterprint', function(){
+      if (confirm('Abrir página de assinatura agora?')) {
+          window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+      }
     });
   </script>
 


### PR DESCRIPTION
## Summary
- ask users before redirecting to the digital signature portal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688690948974832e9bee51822b64d840