### PR TITLE
Add optional Mercado Pago preference settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ application:
 export MERCADOPAGO_ACCESS_TOKEN="<your access token>"
 export MERCADOPAGO_PUBLIC_KEY="<your public key>"
 export MERCADOPAGO_WEBHOOK_SECRET="<random secret>"
+export MERCADOPAGO_STATEMENT_DESCRIPTOR="PETORLANDIA"
+export MERCADOPAGO_BINARY_MODE=0
 ```
 
 `MERCADOPAGO_WEBHOOK_SECRET` **must** be set so webhook signatures can be

--- a/app.py
+++ b/app.py
@@ -3905,6 +3905,8 @@ def checkout():
         "external_reference": payment.external_reference,
         "notification_url":   url_for("notificacoes_mercado_pago", _external=True),
         "payment_methods":    {"installments": 1},
+        "statement_descriptor": current_app.config.get("MERCADOPAGO_STATEMENT_DESCRIPTOR"),
+        "binary_mode": current_app.config.get("MERCADOPAGO_BINARY_MODE", False),
         "back_urls": {
             s: url_for("payment_status", payment_id=payment.id, _external=True)
             for s in ("success", "failure", "pending")
@@ -3913,6 +3915,7 @@ def checkout():
         "payer": {
             "first_name": name_parts[0] if name_parts else "",
             "last_name": name_parts[1] if len(name_parts) > 1 else "",
+            "email": current_user.email,
         },
     }
     current_app.logger.debug("MP Preference Payload:\n%s",

--- a/config.py
+++ b/config.py
@@ -27,6 +27,10 @@ class Config:
     MERCADOPAGO_PUBLIC_KEY = os.environ.get("MERCADOPAGO_PUBLIC_KEY", "APP_USR-2b9a9bff-692b-4de8-9b90-ce9aa758ca14")
     MERCADOPAGO_WEBHOOK_SECRET = os.environ.get("MERCADOPAGO_WEBHOOK_SECRET", "add6cb517c10e98c1decbe37a4290a41b45a9b3b1d04a5d368babd18a2969d44")
 
+    # Opções adicionais de integração com o Mercado Pago
+    MERCADOPAGO_STATEMENT_DESCRIPTOR = os.environ.get("MERCADOPAGO_STATEMENT_DESCRIPTOR", "PETORLANDIA")
+    MERCADOPAGO_BINARY_MODE = bool(int(os.environ.get("MERCADOPAGO_BINARY_MODE", "0")))
+
     # Endereço de retirada padrão (usado se não houver PickupLocation no banco)
     DEFAULT_PICKUP_ADDRESS = os.environ.get("DEFAULT_PICKUP_ADDRESS", "Rua Nove, 990")
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -71,6 +71,14 @@ def test_mp_token_in_config(app):
 
 def test_mp_webhook_secret_in_config(app):
     assert 'MERCADOPAGO_WEBHOOK_SECRET' in app.config
+
+
+def test_mp_statement_descriptor_in_config(app):
+    assert 'MERCADOPAGO_STATEMENT_DESCRIPTOR' in app.config
+
+
+def test_mp_binary_mode_in_config(app):
+    assert 'MERCADOPAGO_BINARY_MODE' in app.config
 from models import Animal
 
 


### PR DESCRIPTION
## Summary
- expose new Mercado Pago config options for statement descriptor and binary mode
- include `statement_descriptor`, `binary_mode`, and `payer.email` when creating a preference
- document the new variables in the README
- test that the new config options exist

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886935ba41c832eb82c56f0ab7cf843