### PR TITLE
Add payer address to Mercado Pago preference

### DIFF
--- a/app.py
+++ b/app.py
@@ -3900,6 +3900,17 @@ def checkout():
 
     # 4️⃣ payload Preference
     name_parts = current_user.name.split(None, 1)
+    payer_info = {
+        "first_name": name_parts[0] if name_parts else "",
+        "last_name": name_parts[1] if len(name_parts) > 1 else "",
+        "email": current_user.email,
+    }
+    if order.shipping_address:
+        payer_info["address"] = {"street_name": order.shipping_address}
+        m = re.search(r"CEP\s*(\d{5}-?\d{3})", order.shipping_address)
+        if m:
+            payer_info["address"]["zip_code"] = m.group(1)
+
     preference_data = {
         "items": items,
         "external_reference": payment.external_reference,
@@ -3912,11 +3923,7 @@ def checkout():
             for s in ("success", "failure", "pending")
         },
         "auto_return": "approved",
-        "payer": {
-            "first_name": name_parts[0] if name_parts else "",
-            "last_name": name_parts[1] if len(name_parts) > 1 else "",
-            "email": current_user.email,
-        },
+        "payer": payer_info,
     }
     current_app.logger.debug("MP Preference Payload:\n%s",
                              json.dumps(preference_data, indent=2, ensure_ascii=False))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -914,6 +914,7 @@ def test_checkout_sends_external_reference(monkeypatch, app):
         assert payload['external_reference'] == str(payment.id)
         assert payload['payer']['first_name'] == 'Tester'
         assert payload['payer']['last_name'] == ''
+        assert payload['payer']['address']['street_name'] == user.endereco.full
         assert payload['items'][0]['id'] == '1'
         assert payload['items'][0]['description'] == 'Prod desc'
         assert payload['items'][0]['category_id'] == 'others'


### PR DESCRIPTION
## Summary
- include buyer address in Mercado Pago preferences
- check address is sent in checkout test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869a76acc0832eb9badb2a70a383f4