### PR TITLE
Document item IDs for Mercado Pago

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ request is automatically created for the associated order.
 When creating a payment preference the application now includes the
 `external_reference` field with the ID of the pending payment. This allows
 each Mercado Pago `payment_id` to be correlated with your own records.
+
+Mercado Pago also recommends sending a unique identifier for each product
+in the `items.id` field of the preference payload. The checkout process
+already does this by using the product's ID, which helps improve the
+approval rate of transactions.

--- a/app.py
+++ b/app.py
@@ -3886,6 +3886,8 @@ def checkout():
     db.session.commit()
 
     # 3️⃣ itens do Preference
+    # O Mercado Pago recomenda enviar um código no campo
+    # ``items.id`` para agilizar a verificação antifraude.
     items = [
         {
             "id":          str(it.product.id),


### PR DESCRIPTION
## Summary
- note that each product ID is sent in `items.id`
- clarify recommended anti-fraud field in checkout code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869a625498832eb0ad5c0e456315af