### PR TITLE
Update Mercado Pago docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ request is automatically created for the associated order.
 When creating a payment preference the application now includes the
 `external_reference` field with the ID of the pending payment. This allows
 each Mercado Pago `payment_id` to be correlated with your own records.
+According to Mercado Pago's documentation this value is mandatory, so make sure
+to send your internal payment identifier in `external_reference` whenever a
+preference is created.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,8 @@ each Mercado Pago `payment_id` to be correlated with your own records.
 According to Mercado Pago's documentation this value is mandatory, so make sure
 to send your internal payment identifier in `external_reference` whenever a
 preference is created.
+
+Mercado Pago also recommends sending a unique identifier for each product
+in the `items.id` field of the preference payload. The checkout process
+already does this by using the product's ID, which helps improve the
+approval rate of transactions.


### PR DESCRIPTION
## Summary
- clarify that external_reference is required when creating a payment preference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869a1e9580832ea0bcbe056814c36b