### PR TITLE
Add payer phone to Mercado Pago preferences

### DIFF
--- a/app.py
+++ b/app.py
@@ -3900,6 +3900,9 @@ def checkout():
 
     # 4️⃣ payload Preference
     name_parts = current_user.name.split(None, 1)
+    phone_digits = re.sub(r"\D", "", current_user.phone or "")
+    if phone_digits.startswith("55"):
+        phone_digits = phone_digits[2:]
     preference_data = {
         "items": items,
         "external_reference": payment.external_reference,
@@ -3916,6 +3919,7 @@ def checkout():
             "first_name": name_parts[0] if name_parts else "",
             "last_name": name_parts[1] if len(name_parts) > 1 else "",
             "email": current_user.email,
+            **({"phone": {"area_code": phone_digits[:2], "number": phone_digits[2:]}} if phone_digits else {}),
         },
     }
     current_app.logger.debug("MP Preference Payload:\n%s",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -873,7 +873,7 @@ def test_checkout_sends_external_reference(monkeypatch, app):
         db.drop_all()
         db.create_all()
         addr = Endereco(cep='11111-000', rua='Rua Tutor', cidade='Cidade', estado='SP')
-        user = User(id=1, name='Tester', email='x')
+        user = User(id=1, name='Tester', email='x', phone='11 99999-9999')
         user.set_password('x')
         user.endereco = addr
         product = Product(id=1, name='Prod', price=10.0, description='Prod desc')
@@ -914,6 +914,7 @@ def test_checkout_sends_external_reference(monkeypatch, app):
         assert payload['external_reference'] == str(payment.id)
         assert payload['payer']['first_name'] == 'Tester'
         assert payload['payer']['last_name'] == ''
+        assert payload['payer']['phone'] == {'area_code': '11', 'number': '999999999'}
         assert payload['items'][0]['id'] == '1'
         assert payload['items'][0]['description'] == 'Prod desc'
         assert payload['items'][0]['category_id'] == 'others'


### PR DESCRIPTION
## Summary
- include buyer phone number when building Mercado Pago preferences
- test that checkout sends phone in preference payload

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869a91d464832e8c416a1efb6a9f16