### PR TITLE
Include MP category in checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ request is automatically created for the associated order.
 When creating a payment preference the application now includes the
 `external_reference` field with the ID of the pending payment. This allows
 each Mercado Pago `payment_id` to be correlated with your own records.
+
+Products now have an optional `mp_category_id` column that stores the
+Mercado Pago category for that item. Checkout payloads populate
+`items.category_id` from this field, defaulting to `"others"` when unset.
+Providing accurate categories can improve fraud analysis and payment
+approval rates.

--- a/app.py
+++ b/app.py
@@ -3524,6 +3524,7 @@ def produto_detail(product_id):
             product.description = update_form.description.data
             product.price = float(update_form.price.data or 0)
             product.stock = update_form.stock.data
+            product.mp_category_id = (update_form.mp_category_id.data or "others").strip()
             if update_form.image_upload.data:
                 file = update_form.image_upload.data
                 filename = secure_filename(file.filename)
@@ -3891,7 +3892,7 @@ def checkout():
             "id":          str(it.product.id),
             "title":       it.product.name,
             "description": it.product.description or it.product.name,
-            "category_id": "others",
+            "category_id": it.product.mp_category_id or "others",
             "quantity":    int(it.quantity),
             "unit_price":  float(it.product.price),
         }

--- a/forms.py
+++ b/forms.py
@@ -248,6 +248,7 @@ class ProductUpdateForm(FlaskForm):
     description = TextAreaField('Descrição')
     price = DecimalField('Preço', validators=[DataRequired()])
     stock = IntegerField('Estoque', validators=[DataRequired()])
+    mp_category_id = StringField('Categoria MP', validators=[Optional(), Length(max=50)])
     image_upload = FileField('Imagem', validators=[FileAllowed(['jpg', 'jpeg', 'png', 'gif'], 'Apenas imagens!')])
     submit = SubmitField('Salvar')
 

--- a/models.py
+++ b/models.py
@@ -646,6 +646,7 @@ class Product(db.Model):
     price = db.Column(db.Float, nullable=False)
     stock = db.Column(db.Integer, default=0)
     image_url = db.Column(db.String(200))
+    mp_category_id = db.Column(db.String(50), default="others")
 
     # Items de pedido associados ao produto. O cascade facilita remover os
     # OrderItem relacionados quando o produto é excluído.

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -45,6 +45,10 @@
         {{ update_form.stock(class="form-control") }}
       </div>
       <div class="col-md-4 mb-3">
+        {{ update_form.mp_category_id.label(class="form-label") }}
+        {{ update_form.mp_category_id(class="form-control") }}
+      </div>
+      <div class="col-md-4 mb-3">
         {{ update_form.image_upload.label(class="form-label") }}
         {{ update_form.image_upload(class="form-control") }}
       </div>


### PR DESCRIPTION
## Summary
- add `mp_category_id` to `Product`
- allow admins to edit `mp_category_id`
- send `category_id` when creating Mercado Pago preferences
- document the new column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869a50edb4832e855e2ffb825d1ca1