### PR TITLE
Add missing Mercado Pago docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ request is automatically created for the associated order.
 When creating a payment preference the application now includes the
 `external_reference` field with the ID of the pending payment. This allows
 each Mercado Pago `payment_id` to be correlated with your own records.
+
+Mercado Pago also recommends sending a unique identifier for each product
+in the `items.id` field of the preference payload. The checkout process
+already does this by using the product's ID, which helps improve the
+approval rate of transactions.
+
+To improve the approval rate, every item sent to Mercado Pago now also
+includes a `description` taken from our product database.


### PR DESCRIPTION
## Summary
- restore mention of Mercado Pago item `id`
- keep risk analysis note when building items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68869a5b9344832ebae19bb79bbe72a6