### PR TITLE
Add payer phone to Mercado Pago preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ request is automatically created for the associated order.
 When creating a payment preference the application now includes the
 `external_reference` field with the ID of the pending payment. This allows
 each Mercado Pago `payment_id` to be correlated with your own records.
+
+Mercado Pago also recommends sending a unique identifier for each product
+in the `items.id` field of the preference payload. The checkout process
+already does this by using the product's ID, which helps improve the
+approval rate of transactions.

--- a/app.py
+++ b/app.py
@@ -3886,6 +3886,8 @@ def checkout():
     db.session.commit()
 
     # 3️⃣ itens do Preference
+    # O Mercado Pago recomenda enviar um código no campo
+    # ``items.id`` para agilizar a verificação antifraude.
     items = [
         {
             "id":          str(it.product.id),
@@ -3900,6 +3902,23 @@ def checkout():
 
     # 4️⃣ payload Preference
     name_parts = current_user.name.split(None, 1)
+    payer_info = {
+        "first_name": name_parts[0] if name_parts else "",
+        "last_name": name_parts[1] if len(name_parts) > 1 else "",
+        "email": current_user.email,
+    }
+    if order.shipping_address:
+        payer_info["address"] = {"street_name": order.shipping_address}
+        m = re.search(r"CEP\s*(\d{5}-?\d{3})", order.shipping_address)
+        if m:
+            payer_info["address"]["zip_code"] = m.group(1)
+    phone_digits = re.sub(r"\D", "", current_user.phone or "")
+    if phone_digits.startswith("55"):
+        phone_digits = phone_digits[2:]
+    if phone_digits:
+        payer_info["phone"] = {"area_code": phone_digits[:2], "number": phone_digits[2:]}
+
+
     preference_data = {
         "items": items,
         "external_reference": payment.external_reference,
@@ -3912,11 +3931,7 @@ def checkout():
             for s in ("success", "failure", "pending")
         },
         "auto_return": "approved",
-        "payer": {
-            "first_name": name_parts[0] if name_parts else "",
-            "last_name": name_parts[1] if len(name_parts) > 1 else "",
-            "email": current_user.email,
-        },
+        "payer": payer_info,
     }
     current_app.logger.debug("MP Preference Payload:\n%s",
                              json.dumps(preference_data, indent=2, ensure_ascii=False))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -304,7 +304,7 @@ def test_cart_quantity_updates(monkeypatch, app):
     with app.app_context():
         db.drop_all()
         db.create_all()
-        user = User(id=1, name='Tester', email='x')
+        user = User(id=1, name='Tester', email='x', phone='11 99999-9999')
         user.set_password('x')
         product = Product(id=1, name='Prod', price=10.0)
         db.session.add_all([user, product])
@@ -873,7 +873,7 @@ def test_checkout_sends_external_reference(monkeypatch, app):
         db.drop_all()
         db.create_all()
         addr = Endereco(cep='11111-000', rua='Rua Tutor', cidade='Cidade', estado='SP')
-        user = User(id=1, name='Tester', email='x')
+        user = User(id=1, name='Tester', email='x', phone='11 99999-9999')
         user.set_password('x')
         user.endereco = addr
         product = Product(id=1, name='Prod', price=10.0, description='Prod desc')
@@ -914,6 +914,8 @@ def test_checkout_sends_external_reference(monkeypatch, app):
         assert payload['external_reference'] == str(payment.id)
         assert payload['payer']['first_name'] == 'Tester'
         assert payload['payer']['last_name'] == ''
+        assert payload['payer']['address']['street_name'] == user.endereco.full
+        assert payload['payer']['phone'] == {'area_code': '11', 'number': '999999999'}
         assert payload['items'][0]['id'] == '1'
         assert payload['items'][0]['description'] == 'Prod desc'
         assert payload['items'][0]['category_id'] == 'others'


### PR DESCRIPTION
## Summary
- merge main and resolve conflicts by integrating phone field into Mercado Pago preference payload
- assert phone value in checkout test
- keep docs about item identifiers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869a91d464832e8c416a1efb6a9f16