### PR TITLE
Fix Mercado Pago back URL access

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ These credentials are used when generating checkout preferences and embedding
 payment widgets. Never commit your real keys into version control.
 
 After checkout, Mercado Pago will redirect the buyer back to `/payment_status/<id>`
-with a `status` parameter indicating `success` or `failure`.
+with a `status` parameter indicating `success` or `failure`. This page no
+longer requires authentication so buyers are always redirected correctly.
 
 If for any reason the webhook notification is not delivered, the application now
 checks the payment status directly with Mercado Pago when the buyer visits the


### PR DESCRIPTION
## Summary
- remove login requirements from MercadoPago return URLs
- restrict data shown on `/payment_status` when user not logged in
- document that payment status page is now public

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d1c43900832eb8df8eeac2df044d