### PR TITLE
Handle full surname in Mercado Pago preference

### DIFF
--- a/app.py
+++ b/app.py
@@ -3933,7 +3933,7 @@ def checkout():
     parts = name.split()
     if parts:
         first_name = parts[0]
-        last_name = parts[-1] if len(parts) > 1 else first_name
+        last_name = " ".join(parts[1:]) if len(parts) > 1 else first_name
     else:
         # Quando o usuário não tem um nome salvo, usa o prefixo do e‑mail
         first_name = current_user.email.split("@")[0]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -969,6 +969,54 @@ def test_checkout_falls_back_to_email_when_name_missing(monkeypatch, app):
         assert payload['payer']['first_name'] == 'buyer'
         assert payload['payer']['last_name'] == 'buyer'
 
+
+def test_checkout_uses_full_last_name(monkeypatch, app):
+    client = app.test_client()
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        addr = Endereco(cep='11111-000', rua='Rua Tutor', cidade='Cidade', estado='SP')
+        user = User(id=1, name='Maria da Silva Souza', email='x')
+        user.set_password('x')
+        user.endereco = addr
+        product = Product(id=1, name='Prod', price=10.0, description='Prod desc')
+        db.session.add_all([addr, user, product])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+        monkeypatch.setattr(app_module, '_is_admin', lambda: False)
+
+        for idx, fn in enumerate(flask_app.template_context_processors[None]):
+            if fn.__name__ == 'inject_unread_count':
+                flask_app.template_context_processors[None][idx] = lambda: {'unread_messages': 0}
+
+        client.post('/carrinho/adicionar/1', data={'quantity': 1})
+
+        captured = {}
+        class FakePrefService:
+            def create(self, data):
+                captured['payload'] = data
+                return {'status': 201, 'response': {'id': '123', 'init_point': 'http://mp'}}
+
+        class FakeSDK:
+            def preference(self):
+                return FakePrefService()
+
+        monkeypatch.setattr(app_module, 'mp_sdk', lambda: FakeSDK())
+        class TestCheckoutForm(app_module.CheckoutForm):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.address_id.choices = [(0, 'addr')]
+
+        monkeypatch.setattr(app_module, 'CheckoutForm', TestCheckoutForm)
+
+        client.post('/checkout', data={'address_id': 0})
+        payload = captured['payload']
+        assert payload['payer']['first_name'] == 'Maria'
+        assert payload['payer']['last_name'] == 'da Silva Souza'
+
 def test_checkout_confirm_renders(monkeypatch, app):
     client = app.test_client()
 


### PR DESCRIPTION
## Summary
- capture all surname tokens when building Mercado Pago preference
- test last name extraction with multi-part names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d49f8490832eab1945f6e23e8114