### PR TITLE
Fix Mercado Pago item category example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,11 @@ approval rate of transactions.
 To improve the approval rate, every item sent to Mercado Pago now also
 includes a `description` taken from our product database.
 
+It is also recommended to provide a valid `category_id` for each item. The
+application stores this identifier in the `Product.mp_category_id` field and the
+example script in `test.py` sends the value "others" by default. Update it with
+the category that best represents your product to further reduce the chance of
+fraud detection issues.
+
 
 

--- a/test.py
+++ b/test.py
@@ -14,6 +14,7 @@ preference_data = {
     "items": [
         {
             "title": "Ração Premium 10 kg",
+            "category_id": "others",
             "quantity": 1,
             "unit_price": 149.90
         }


### PR DESCRIPTION
## Summary
- include `category_id` in `test.py` example
- document Mercado Pago item categories in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d599e48c832eac8c1206f472e2bc