### PR TITLE
Add missing description in Mercado Pago sample

### DIFF
--- a/test.py
+++ b/test.py
@@ -14,6 +14,7 @@ preference_data = {
     "items": [
         {
             "title": "Ração Premium 10 kg",
+            "description": "Ração para cães sabor carne",  # added description
             "category_id": "others",
             "quantity": 1,
             "unit_price": 149.90


### PR DESCRIPTION
## Summary
- add `description` field in Mercado Pago `test.py` example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d7123700832eb5f3391be3632558