### PR TITLE
Fix Mercado Pago example missing item id

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ in the `items.id` field of the preference payload. The checkout process
 already does this by using the product's ID, which helps improve the
 approval rate of transactions.
 
+The example script in `test.py` now includes this `id` field so you can
+see how the payload should look.
+
 
 
 

--- a/test.py
+++ b/test.py
@@ -13,6 +13,7 @@ sdk = mercadopago.SDK(ACCESS_TOKEN)
 preference_data = {
     "items": [
         {
+            "id": "1",  # unique product code
             "title": "Ração Premium 10 kg",
             "category_id": "others",
             "quantity": 1,


### PR DESCRIPTION
## Summary
- add missing `items.id` field in payment example script
- document item code usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d8430aac832e804eb328378d80fe