### PR TITLE
Send more buyer data to Mercado Pago

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,11 @@ example script in `test.py` sends the value "others" by default. Update it with
 the category that best represents your product to further reduce the chance of
 fraud detection issues.
 
+Mercado Pago also suggests sending additional buyer information to improve
+security checks. Whenever available the application now includes the buyer's
+address, phone number and CPF in the `payer` object of the preference payload.
+Providing these fields can help reduce fraud rejections and increase approval
+rates.
+
 
 

--- a/app.py
+++ b/app.py
@@ -3944,6 +3944,22 @@ def checkout():
 
         "email": current_user.email,
     }
+    if current_user.phone:
+        digits = re.sub(r"\D", "", current_user.phone)
+        if digits.startswith("55") and len(digits) > 11:
+            digits = digits[2:]
+        if len(digits) >= 10:
+            payer_info["phone"] = {
+                "area_code": digits[:2],
+                "number": digits[2:],
+            }
+        else:
+            payer_info["phone"] = {"number": digits}
+    if current_user.cpf:
+        payer_info["identification"] = {
+            "type": "CPF",
+            "number": re.sub(r"\D", "", current_user.cpf),
+        }
     if order.shipping_address:
         payer_info["address"] = {"street_name": order.shipping_address}
         m = re.search(r"CEP\s*(\d{5}-?\d{3})", order.shipping_address)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1017,6 +1017,61 @@ def test_checkout_uses_full_last_name(monkeypatch, app):
         assert payload['payer']['first_name'] == 'Maria'
         assert payload['payer']['last_name'] == 'da Silva Souza'
 
+
+def test_checkout_includes_phone_and_cpf(monkeypatch, app):
+    client = app.test_client()
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        addr = Endereco(cep='11111-000', rua='Rua Tutor', cidade='Cidade', estado='SP')
+        user = User(
+            id=1,
+            name='Tester',
+            email='u@test',
+            phone='11 91234-5678',
+            cpf='123.456.789-09',
+        )
+        user.set_password('x')
+        user.endereco = addr
+        product = Product(id=1, name='Prod', price=10.0)
+        db.session.add_all([addr, user, product])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+        monkeypatch.setattr(app_module, '_is_admin', lambda: False)
+
+        for idx, fn in enumerate(flask_app.template_context_processors[None]):
+            if fn.__name__ == 'inject_unread_count':
+                flask_app.template_context_processors[None][idx] = lambda: {'unread_messages': 0}
+
+        client.post('/carrinho/adicionar/1', data={'quantity': 1})
+
+        captured = {}
+        class FakePrefService:
+            def create(self, data):
+                captured['payload'] = data
+                return {'status': 201, 'response': {'id': '123', 'init_point': 'http://mp'}}
+
+        class FakeSDK:
+            def preference(self):
+                return FakePrefService()
+
+        monkeypatch.setattr(app_module, 'mp_sdk', lambda: FakeSDK())
+        class TestCheckoutForm(app_module.CheckoutForm):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.address_id.choices = [(0, 'addr')]
+
+        monkeypatch.setattr(app_module, 'CheckoutForm', TestCheckoutForm)
+
+        client.post('/checkout', data={'address_id': 0})
+        payload = captured['payload']
+        assert payload['payer']['phone']['area_code'] == '11'
+        assert payload['payer']['phone']['number'] == '912345678'
+        assert payload['payer']['identification']['number'] == '12345678909'
+
 def test_checkout_confirm_renders(monkeypatch, app):
     client = app.test_client()
 


### PR DESCRIPTION
## Summary
- send buyer phone and CPF in Mercado Pago preferences
- add regression test covering phone/CPF fields
- document new practice in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d8f6eb88832ea7056bcadc9f9f1e