### PR TITLE
Add payer data to Mercado Pago example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,5 +92,10 @@ address, phone number and CPF in the `payer` object of the preference payload.
 Providing these fields can help reduce fraud rejections and increase approval
 rates.
 
+The buyer's first and last name are also sent in the `payer` object. If the
+profile has no name saved the application falls back to the email prefix. The
+example script in `test.py` shows how to provide these `payer.first_name` and
+`payer.last_name` values manually.
+
 
 

--- a/test.py
+++ b/test.py
@@ -32,6 +32,11 @@ preference_data = {
     "payment_methods": {
         "installments": 1,                        # 1 parcela (à vista)
         # "default_payment_method_id": "pix"      # força PIX se quiser
+    },
+    "payer": {
+        "first_name": "Fulano",
+        "last_name": "da Silva",
+        "email": "comprador@example.com",
     }
 }
 


### PR DESCRIPTION
## Summary
- update Mercado Pago example script with `payer.first_name` and `payer.last_name`
- document new payer information in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875650b060832e90038dc6baead072