### PR TITLE
Update consulta partial saves

### DIFF
--- a/app.py
+++ b/app.py
@@ -2198,6 +2198,13 @@ def salvar_vacinas(animal_id):
         return jsonify({"success": False, "error": "Erro técnico ao salvar vacinas"}), 500
 
 
+@app.route('/animal/<int:animal_id>/historico_vacinas')
+@login_required
+def historico_vacinas_view(animal_id):
+    animal = Animal.query.get_or_404(animal_id)
+    return render_template('partials/historico_vacinas.html', animal=animal)
+
+
 
 
 @app.route("/animal/<int:animal_id>/vacinas/imprimir")
@@ -2454,6 +2461,14 @@ def salvar_bloco_prescricao(consulta_id):
     return jsonify({'success': True, 'message': 'Prescrições salvas com sucesso!'})
 
 
+@app.route('/consulta/<int:consulta_id>/historico_prescricoes')
+@login_required
+def historico_prescricoes_view(consulta_id):
+    consulta = Consulta.query.get_or_404(consulta_id)
+    animal = consulta.animal
+    return render_template('partials/historico_prescricoes.html', animal=animal)
+
+
 @app.route('/bloco_prescricao/<int:bloco_id>/deletar', methods=['POST'])
 @login_required
 def deletar_bloco_prescricao(bloco_id):
@@ -2673,6 +2688,14 @@ def atualizar_bloco_exames(bloco_id):
 
     db.session.commit()
     return jsonify(success=True)
+
+
+@app.route('/consulta/<int:consulta_id>/historico_exames')
+@login_required
+def historico_exames_view(consulta_id):
+    consulta = Consulta.query.get_or_404(consulta_id)
+    animal = consulta.animal
+    return render_template('partials/historico_exames.html', animal=animal)
 
 
 

--- a/static/offline.js
+++ b/static/offline.js
@@ -65,10 +65,16 @@
     if (!form.matches('form[data-sync]')) return;
     ev.preventDefault();
     const data = new FormData(form);
-    const resp = await window.fetchOrQueue(form.action, {method: form.method || 'POST', headers: {'Accept': 'application/json'}, body: data});
+    const resp = await window.fetchOrQueue(form.action, {
+      method: form.method || 'POST',
+      headers: {'Accept': 'application/json'},
+      body: data
+    });
     if (resp) {
       try { await resp.json(); } catch(e) {}
-      location.reload();
+      if (!form.hasAttribute('data-no-reload')) {
+        location.reload();
+      }
     } else {
       alert('Ação salva offline e será sincronizada quando possível.');
     }

--- a/templates/partials/animal_form.html
+++ b/templates/partials/animal_form.html
@@ -1,6 +1,6 @@
 <form method="POST" action="{{ url_for('update_animal', animal_id=animal.id) }}"
       enctype="multipart/form-data" onsubmit="return validarCadastroAnimal();"
-      class="needs-validation" novalidate data-sync="true">
+      class="needs-validation" novalidate data-sync="true" data-no-reload="true">
 
   <h5 class="mb-3">🐾 Cadastro do Animal</h5>
 

--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -1,5 +1,5 @@
 <!-- templates/partials/animal_register_form.html -->
-<form method="POST" action="{{ url_for('novo_animal') }}" onsubmit="return validarTutor();" data-sync="true">
+<form method="POST" action="{{ url_for('novo_animal') }}" onsubmit="return validarTutor();" data-sync="true" data-no-reload="true">
     <h5 class="mb-3">🐾 Cadastro do Animal</h5>
 
     {% if not tutor %}

--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -8,7 +8,7 @@
 
 <form method="POST"
       action="{{ url_for('update_consulta', consulta_id=consulta.id) }}{% if edit_mode %}?edit=1{% endif %}"
-      class="needs-validation" novalidate data-sync="true">
+      class="needs-validation" novalidate data-sync="true" data-no-reload="true">
 
   <!-- Seção de Queixa Principal -->
   <div class="mb-3">

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -30,8 +30,8 @@
   <button type="button" class="btn btn-primary mt-2" onclick="finalizarBlocoExames()">💾 Finalizar Solicitação</button>
 </form>
 
-<!-- Histórico de prescrições -->
-<div id="historico-prescricoes" class="mt-5">
+<!-- Histórico de exames -->
+<div id="historico-exames" class="mt-5">
   {% include 'partials/historico_exames.html' %}
 </div>
 
@@ -164,7 +164,14 @@
       const data = await resp.json();
       if (data.success) {
         alert('Solicitação de exames salva com sucesso!');
-        location.reload();
+        const htmlResp = await fetch(`/consulta/{{ consulta.id }}/historico_exames`);
+        if (htmlResp.ok) {
+          const html = await htmlResp.text();
+          document.getElementById('historico-exames').innerHTML = html;
+        }
+        exames = [];
+        renderExamesTemp();
+        document.getElementById('observacoes-exames').value = '';
       } else {
         alert('Erro ao salvar exames.');
       }

--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -268,7 +268,15 @@
         const data = await response.json();
         if (!response.ok) throw new Error(data.message || 'Erro ao salvar prescrição');
         mostrarFeedback('Prescrição salva com sucesso!', 'success');
-        setTimeout(() => location.reload(), 1500);
+
+        const htmlResp = await fetch(`/consulta/{{ consulta.id }}/historico_prescricoes`);
+        if (htmlResp.ok) {
+          const html = await htmlResp.text();
+          document.getElementById('historico-prescricoes').innerHTML = html;
+        }
+        prescricoes = [];
+        renderPrescricoesTemp();
+        document.getElementById('instrucoes-medicamentos').value = '';
       } else {
         mostrarFeedback('Prescrição salva offline. Sincronizaremos em breve.', 'info');
       }

--- a/templates/partials/tutor_form.html
+++ b/templates/partials/tutor_form.html
@@ -22,7 +22,7 @@
 <!-- 👤 Formulário de Tutor - Aprimorado com validação e organização -->
 <form id="tutor-form" method="POST" enctype="multipart/form-data"
       {% if has_tutor %}action="{{ url_for('update_tutor', user_id=tutor.id) }}"{% endif %}
-      class="needs-validation" novalidate data-sync="true">
+      class="needs-validation" novalidate data-sync="true" data-no-reload="true">
   
   <h5 class="mb-4 d-flex align-items-center gap-2">
     <i class="bi bi-person-fill"></i> Cadastro do Tutor

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -158,7 +158,14 @@
         const data = await resp.json();
         if (data.success) {
           alert('Vacinas registradas com sucesso!');
-          location.reload();
+          const htmlResp = await fetch(`/animal/{{ animal.id }}/historico_vacinas`);
+          if (htmlResp.ok) {
+            const html = await htmlResp.text();
+            document.getElementById('historico-vacinas').innerHTML = html;
+          }
+          vacinas = [];
+          renderVacinasTemp();
+          document.getElementById('observacoes-vacinas').value = '';
         } else {
           alert('Erro ao salvar vacinas.');
         }


### PR DESCRIPTION
## Summary
- avoid reloading after offline form submission
- add partial history routes for prescriptions, exams and vaccines
- refresh histories via JavaScript instead of full reloads

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688755d80444832eb8bf49057a5773b7