### PR TITLE
Fix offline queue double prompts

### DIFF
--- a/static/offline.js
+++ b/static/offline.js
@@ -54,6 +54,7 @@
     const q = loadQueue();
     q.push({url, method, headers, body:bodyData});
     saveQueue(q);
+    sendQueued();
     return null;
   };
 
@@ -63,6 +64,7 @@
   document.addEventListener('submit', async ev => {
     const form = ev.target;
     if (!form.matches('form[data-sync]')) return;
+    if (ev.defaultPrevented) return;
     ev.preventDefault();
     const data = new FormData(form);
     const resp = await window.fetchOrQueue(form.action, {


### PR DESCRIPTION
## Summary
- update offline script to skip forms already handled and retry queued requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875b5bdeec832eb7fb9f46b9a4bff2