### PR TITLE
Fix age saving on animal forms

### DIFF
--- a/templates/components/campo_data_idade.html
+++ b/templates/components/campo_data_idade.html
@@ -16,6 +16,7 @@
       type="number"
       min="0"
       class="form-control"
+      name="{{ nome_idade or 'age' }}"
       id="{{ prefixo }}_age"
       value="{{ valor_idade or '' }}"
       data-age

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -337,10 +337,10 @@
               <label class="form-label">Data de Nascimento</label>
               <input id="animal_dob" name="date_of_birth" type="text" class="form-control">
             </div>
-            <div class="col-md-3">
-              <label class="form-label">Idade</label>
-              <input id="animal_age" type="number" class="form-control" min="0">
-            </div>
+              <div class="col-md-3">
+                <label class="form-label">Idade</label>
+                <input id="animal_age" name="age" type="number" class="form-control" min="0">
+              </div>
             <div class="col-md-3">
               <label class="form-label">Microchip</label>
               <input name="microchip_number" class="form-control">


### PR DESCRIPTION
## Summary
- ensure age value is submitted from `campo_data_idade.html`
- allow age saving from the tutor page's animal modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875e885bc8832eb94c74cb739abd0b