### PR TITLE
Improve offline UX and async deletions

### DIFF
--- a/app.py
+++ b/app.py
@@ -991,8 +991,7 @@ def deletar_animal(animal_id):
 
     animal.removido_em = datetime.utcnow()
     db.session.commit()
-    flash('Animal marcado como removido. Histórico preservado.', 'success')
-    return redirect(url_for('list_animals'))
+    return jsonify({"success": True})
 
 
 @app.route('/termo/interesse/<int:animal_id>/<int:user_id>', methods=['GET', 'POST'])
@@ -1435,8 +1434,7 @@ def deletar_consulta(consulta_id):
 
     db.session.delete(consulta)
     db.session.commit()
-    flash('Consulta excluída!', 'info')
-    return redirect(url_for('consulta_direct', animal_id=animal_id))
+    return jsonify({"success": True, "animal_id": animal_id})
 
 
 @app.route('/imprimir_consulta/<int:consulta_id>')
@@ -1633,13 +1631,11 @@ def deletar_tutor(tutor_id):
 
         db.session.delete(tutor)
         db.session.commit()
-        flash('Tutor e todos os seus dados foram excluídos com sucesso.', 'success')
+        return jsonify({"success": True})
 
     except Exception as e:
         db.session.rollback()
-        flash(f'Erro ao excluir tutor: {str(e)}', 'danger')
-
-    return redirect(url_for('tutores'))
+        return jsonify({"success": False, "error": str(e)}), 500
 
 
 
@@ -2218,7 +2214,7 @@ def deletar_vacina(vacina_id):
     vacina = Vacina.query.get_or_404(vacina_id)
     db.session.delete(vacina)
     db.session.commit()
-    return redirect(request.referrer or url_for("index"))
+    return jsonify({"success": True})
 
 
 
@@ -2291,6 +2287,7 @@ from flask import request, jsonify
 @login_required
 def deletar_prescricao(prescricao_id):
     prescricao = Prescricao.query.get_or_404(prescricao_id)
+    consulta = prescricao.consulta
     consulta_id = prescricao.consulta_id
 
     if current_user.worker != 'veterinario':
@@ -2299,8 +2296,7 @@ def deletar_prescricao(prescricao_id):
 
     db.session.delete(prescricao)
     db.session.commit()
-    flash('Prescrição removida com sucesso!', 'info')
-    return redirect(url_for('consulta_qr', animal_id=consulta.animal_id))
+    return jsonify({"success": True, "animal_id": consulta.animal_id})
 
 
 @app.route('/importar_medicamentos')
@@ -2466,7 +2462,7 @@ def salvar_bloco_prescricao(consulta_id):
 def historico_prescricoes_view(consulta_id):
     consulta = Consulta.query.get_or_404(consulta_id)
     animal = consulta.animal
-    return render_template('partials/historico_prescricoes.html', animal=animal)
+    return render_template('partials/historico_prescricoes.html', animal=animal, consulta=consulta)
 
 
 @app.route('/bloco_prescricao/<int:bloco_id>/deletar', methods=['POST'])
@@ -2481,8 +2477,7 @@ def deletar_bloco_prescricao(bloco_id):
     animal_id = bloco.animal_id
     db.session.delete(bloco)
     db.session.commit()
-    flash('Bloco de prescrição excluído com sucesso!', 'info')
-    return redirect(url_for('consulta_direct', animal_id=animal_id))
+    return jsonify({"success": True, "animal_id": animal_id})
 
 
 @app.route('/bloco_prescricao/<int:bloco_id>/editar', methods=['GET'])
@@ -2613,8 +2608,7 @@ def deletar_bloco_exames(bloco_id):
     db.session.delete(bloco)
     db.session.commit()
 
-    flash('Bloco de exames excluído com sucesso!', 'info')
-    return redirect(url_for('consulta_direct', animal_id=animal_id))
+    return jsonify({"success": True, "animal_id": animal_id})
 
 
 

--- a/templates/partials/animal_form.html
+++ b/templates/partials/animal_form.html
@@ -120,7 +120,8 @@
 
 <!-- Botão de deletar -->
 <form method="POST" action="{{ url_for('deletar_animal', animal_id=animal.id) }}"
-      onsubmit="return confirm('Tem certeza que deseja remover permanentemente este animal? Esta ação não pode ser desfeita.');" 
+      data-sync="true" data-no-reload="true"
+      onsubmit="return confirm('Tem certeza que deseja remover permanentemente este animal? Esta ação não pode ser desfeita.');"
       class="mt-2">
   <button type="submit" class="btn btn-outline-danger">
     <i class="bi bi-trash me-1"></i> Remover Animal

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -72,6 +72,27 @@
   });
 
   renderExamesTemp(); // Inicializa a lista se já houver dados
+
+  const pend = JSON.parse(localStorage.getItem('pending_exames_{{ animal.id }}') || '[]');
+  if(pend.length){
+    const container = document.getElementById('historico-exames');
+    if(container){
+      pend.forEach(b => {
+        const div = document.createElement('div');
+        div.className = 'border p-3 mb-4 bg-light rounded text-muted';
+        let items = '<ul class="list-group list-group-flush">';
+        b.exames.forEach(e => {
+          items += `<li class="list-group-item">🧪 <strong>${e.nome}</strong><br><em>${e.justificativa}</em></li>`;
+        });
+        items += '</ul>';
+        if(b.observacoes_gerais){
+          items += `<div class="mt-3"><strong>Observações:</strong><br><em>${b.observacoes_gerais}</em></div>`;
+        }
+        div.innerHTML = `<strong>Bloco de exames pendente</strong>${items}<span class="badge bg-secondary">Pendente</span>`;
+        container.prepend(div);
+      });
+    }
+  }
   });
 
   function adicionarExame() {
@@ -177,6 +198,26 @@
       }
     } else {
       alert('Solicitação salva offline e será enviada quando possível.');
+      const pending = JSON.parse(localStorage.getItem('pending_exames_{{ animal.id }}') || '[]');
+      pending.push({exames, observacoes_gerais: obsGerais});
+      localStorage.setItem('pending_exames_{{ animal.id }}', JSON.stringify(pending));
+      const container = document.getElementById('historico-exames');
+      if (container) {
+        const div = document.createElement('div');
+        div.className = 'border p-3 mb-4 bg-light rounded text-muted';
+        let items = '<ul class="list-group list-group-flush">';
+        exames.forEach(e => {
+          items += `<li class="list-group-item">🧪 <strong>${e.nome}</strong><br><em>${e.justificativa}</em></li>`;
+        });
+        items += '</ul>';
+        if(obsGerais){
+          items += `<div class="mt-3"><strong>Observações:</strong><br><em>${obsGerais}</em></div>`;
+        }
+        div.innerHTML = `<strong>Bloco de exames pendente</strong>${items}<span class="badge bg-secondary">Pendente</span>`;
+        container.prepend(div);
+      }
+      exames = [];
+      renderExamesTemp();
     }
   }
 </script>

--- a/templates/partials/historico_consultas.html
+++ b/templates/partials/historico_consultas.html
@@ -35,6 +35,7 @@
              class="btn btn-outline-dark btn-sm">🖨️ Imprimir</a>
           <form action="{{ url_for('deletar_consulta', consulta_id=c.id) }}"
                 method="POST" class="d-inline"
+                data-sync="true" data-no-reload="true" data-remove-closest="tr"
                 onsubmit="return confirm('Excluir esta consulta?');">
             <button class="btn btn-outline-danger btn-sm">🗑️</button>
           </form>

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -11,7 +11,9 @@
         <strong>Exames solicitados em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</strong>
       </div>
       <div class="d-flex gap-2">
-        <form method="POST" action="{{ url_for('deletar_bloco_exames', bloco_id=bloco.id) }}" onsubmit="return confirm('Deseja realmente excluir este bloco de exames?');">
+        <form method="POST" action="{{ url_for('deletar_bloco_exames', bloco_id=bloco.id) }}"
+              data-sync="true" data-no-reload="true" data-remove-target="#bloco-{{ bloco.id }}"
+              onsubmit="return confirm('Deseja realmente excluir este bloco de exames?');">
           <button type="submit" class="btn btn-danger btn-sm">
             <i class="bi bi-trash"></i> Excluir
           </button>
@@ -231,5 +233,43 @@ function salvarBlocoExames(blocoId, consultaId) {
     alert('Erro na requisição.');
   });
 }
+
+const EXAMES_KEY = 'pending_exames_{{ animal.id }}';
+
+function loadPendingExames(){
+  try { return JSON.parse(localStorage.getItem(EXAMES_KEY)) || []; } catch(e){ return []; }
+}
+
+function renderPendingExames(){
+  const pend = loadPendingExames();
+  if(!pend.length) return;
+  const container = document.querySelector('#historico-exames');
+  if(!container) return;
+  pend.forEach(b => {
+    const div = document.createElement('div');
+    div.className = 'border p-3 mb-4 bg-light rounded text-muted';
+    let items = '<ul class="list-group list-group-flush">';
+    b.exames.forEach(e => {
+      items += `<li class="list-group-item">🧪 <strong>${e.nome}</strong><br><em>${e.justificativa}</em></li>`;
+    });
+    items += '</ul>';
+    if(b.observacoes_gerais){
+      items += `<div class="mt-3"><strong>Observações:</strong><br><em>${b.observacoes_gerais}</em></div>`;
+    }
+    div.innerHTML = `<strong>Bloco de exames pendente</strong>${items}<span class="badge bg-secondary">Pendente</span>`;
+    container.prepend(div);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', renderPendingExames);
+
+document.addEventListener('queueSynced', async () => {
+  const resp = await fetch(`/consulta/{{ consulta.id }}/historico_exames`);
+  if(resp.ok){
+    const html = await resp.text();
+    document.getElementById('historico-exames').innerHTML = html;
+  }
+  localStorage.removeItem(EXAMES_KEY);
+});
 </script>
 {% endblock %}

--- a/templates/partials/historico_prescricoes.html
+++ b/templates/partials/historico_prescricoes.html
@@ -4,7 +4,7 @@
     <h5 class="card-title">📜 Histórico de Prescrições</h5>
 
     {% for bloco in animal.blocos_prescricao|reverse %}
-    <div class="border rounded p-3 mb-3">
+    <div class="border rounded p-3 mb-3" id="bloco-prescricao-{{ bloco.id }}">
       <h6 class="text-muted">Prescrição feita em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</h6>
 
       <ul class="list-group list-group-flush mb-2">
@@ -28,6 +28,7 @@
         <form method="POST"
               action="{{ url_for('deletar_bloco_prescricao', bloco_id=bloco.id) }}"
               class="d-inline"
+              data-sync="true" data-no-reload="true" data-remove-target="#bloco-prescricao-{{ bloco.id }}"
               onsubmit="return confirm('Deseja mesmo excluir este bloco de prescrições?');">
           <button class="btn btn-danger btn-sm">🗑 Excluir</button>
         </form>
@@ -49,3 +50,40 @@
 {% else %}
 <p class="text-muted">Nenhuma prescrição registrada ainda para esta consulta.</p>
 {% endif %}
+
+<script>
+const PRESC_KEY = 'pending_prescricoes_{{ animal.id }}';
+
+function loadPendingPrescricoes(){
+  try { return JSON.parse(localStorage.getItem(PRESC_KEY)) || []; } catch(e){ return []; }
+}
+
+function renderPendingPrescricoes(){
+  const pend = loadPendingPrescricoes();
+  if(!pend.length) return;
+  const container = document.querySelector('#historico-prescricoes .card-body');
+  if(!container) return;
+  pend.forEach(b => {
+    const div = document.createElement('div');
+    div.className = 'border rounded p-3 mb-3 text-muted';
+    let items = '<ul class="list-group list-group-flush mb-2">';
+    b.prescricoes.forEach(p => {
+      items += `<li class="list-group-item"><strong>${p.medicamento}</strong></li>`;
+    });
+    items += '</ul>';
+    div.innerHTML = `<h6 class="text-muted">Prescrição pendente</h6>${items}<span class="badge bg-secondary">Pendente</span>`;
+    container.prepend(div);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', renderPendingPrescricoes);
+
+document.addEventListener('queueSynced', async () => {
+  const resp = await fetch(`/consulta/{{ consulta.id }}/historico_prescricoes`);
+  if(resp.ok){
+    const html = await resp.text();
+    document.getElementById('historico-prescricoes').innerHTML = html;
+  }
+  localStorage.removeItem(PRESC_KEY);
+});
+</script>

--- a/templates/partials/historico_vacinas.html
+++ b/templates/partials/historico_vacinas.html
@@ -21,6 +21,7 @@
 
         <div class="mt-2 d-flex gap-2">
           <form method="POST" action="{{ url_for('deletar_vacina', vacina_id=vacina.id) }}"
+                data-sync="true" data-no-reload="true" data-remove-closest="li"
                 onsubmit="return confirm('Deseja mesmo remover esta vacina?')">
             <button class="btn btn-sm btn-danger">🗑️ Remover</button>
           </form>
@@ -93,4 +94,34 @@ function salvarEdicaoVacina(id) {
     alert("Erro na requisição.");
   });
 }
+
+const PENDING_KEY = 'pending_vacinas_{{ animal.id }}';
+
+function loadPendingVacinas(){
+  try { return JSON.parse(localStorage.getItem(PENDING_KEY)) || []; } catch(e){ return []; }
+}
+
+function renderPendingVacinas(){
+  const pend = loadPendingVacinas();
+  if(!pend.length) return;
+  const ul = document.querySelector('#historico-vacinas ul.list-group');
+  if(!ul) return;
+  pend.forEach(v => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item text-muted';
+    li.innerHTML = `<strong>${v.nome}</strong>${v.tipo? ' — '+v.tipo:''}${v.data? ' em '+v.data:''}${v.observacoes? '<br><em>'+v.observacoes+'</em>':''} <span class="badge bg-secondary ms-2">Pendente</span>`;
+    ul.prepend(li);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', renderPendingVacinas);
+
+document.addEventListener('queueSynced', async () => {
+  const resp = await fetch(`/animal/{{ animal.id }}/historico_vacinas`);
+  if(resp.ok){
+    const html = await resp.text();
+    document.getElementById('historico-vacinas').innerHTML = html;
+  }
+  localStorage.removeItem(PENDING_KEY);
+});
 </script>

--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -279,6 +279,23 @@
         document.getElementById('instrucoes-medicamentos').value = '';
       } else {
         mostrarFeedback('Prescrição salva offline. Sincronizaremos em breve.', 'info');
+        const pending = JSON.parse(localStorage.getItem('pending_prescricoes_{{ animal.id }}') || '[]');
+        pending.push({prescricoes, instrucoes});
+        localStorage.setItem('pending_prescricoes_{{ animal.id }}', JSON.stringify(pending));
+        const container = document.querySelector('#historico-prescricoes .card-body');
+        if (container) {
+          const div = document.createElement('div');
+          div.className = 'border rounded p-3 mb-3 text-muted';
+          let items = '<ul class="list-group list-group-flush mb-2">';
+          prescricoes.forEach(p => {
+            items += `<li class="list-group-item"><strong>${p.medicamento}</strong></li>`;
+          });
+          items += '</ul>';
+          div.innerHTML = `<h6 class="text-muted">Prescrição pendente</h6>${items}<span class="badge bg-secondary">Pendente</span>`;
+          container.prepend(div);
+        }
+        prescricoes = [];
+        renderPrescricoesTemp();
       }
 
     } catch (err) {
@@ -351,6 +368,25 @@
     // Botões
     document.getElementById('btn-adicionar').addEventListener('click', adicionarMedicamento);
     document.getElementById('btn-finalizar').addEventListener('click', finalizarBlocoPrescricoes);
+
+    // render pendentes
+    const pend = JSON.parse(localStorage.getItem('pending_prescricoes_{{ animal.id }}') || '[]');
+    if (pend.length) {
+      const container = document.querySelector('#historico-prescricoes .card-body');
+      if (container) {
+        pend.forEach(b => {
+          const div = document.createElement('div');
+          div.className = 'border rounded p-3 mb-3 text-muted';
+          let items = '<ul class="list-group list-group-flush mb-2">';
+          b.prescricoes.forEach(p => {
+            items += `<li class="list-group-item"><strong>${p.medicamento}</strong></li>`;
+          });
+          items += '</ul>';
+          div.innerHTML = `<h6 class="text-muted">Prescrição pendente</h6>${items}<span class="badge bg-secondary">Pendente</span>`;
+          container.prepend(div);
+        });
+      }
+    }
   });
 </script>
 

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -98,6 +98,21 @@
       });
 
       renderVacinasTemp();
+
+      const pend = JSON.parse(localStorage.getItem('pending_vacinas_{{ animal.id }}') || '[]');
+      if (pend.length) {
+        const ul = document.querySelector('#historico-vacinas ul.list-group');
+        if(ul){
+          pend.forEach(block => {
+            block.vacinas.forEach(v => {
+              const li = document.createElement('li');
+              li.className = 'list-group-item text-muted';
+              li.innerHTML = `<strong>${v.nome}</strong> — ${v.tipo} em ${v.data}<span class="badge bg-secondary ms-2">Pendente</span>`;
+              ul.prepend(li);
+            });
+          });
+        }
+      }
     });
 
     function adicionarVacina() {
@@ -171,6 +186,20 @@
         }
       } else {
         alert('Vacinas salvas offline e serão enviadas quando possível.');
+        const pending = JSON.parse(localStorage.getItem('pending_vacinas_{{ animal.id }}') || '[]');
+        pending.push({vacinas, observacoes: obs, data: new Date().toISOString().slice(0,10)});
+        localStorage.setItem('pending_vacinas_{{ animal.id }}', JSON.stringify(pending));
+        const htmlList = document.querySelector('#historico-vacinas ul.list-group');
+        if (htmlList) {
+          vacinas.forEach(v => {
+            const li = document.createElement('li');
+            li.className = 'list-group-item text-muted';
+            li.innerHTML = `<strong>${v.nome}</strong>${v.tipo? ' — '+v.tipo:''} em ${v.data}<span class="badge bg-secondary ms-2">Pendente</span>`;
+            htmlList.prepend(li);
+          });
+        }
+        vacinas = [];
+        renderVacinasTemp();
       }
     }
   </script>

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -10,6 +10,7 @@
     <div class="card-body position-relative">
       <!-- Botão de excluir tutor no topo direito -->
       <form method="POST" action="{{ url_for('deletar_tutor', tutor_id=tutor.id) }}"
+            data-sync="true" data-no-reload="true" data-remove-target=".card"
             onsubmit="return confirm('Tem certeza que deseja excluir este tutor e todos os seus dados permanentemente?');"
             class="position-absolute top-0 end-0 m-2">
         <button type="submit" class="btn btn-sm btn-danger" title="Excluir Tutor">
@@ -129,7 +130,9 @@
             <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#modalEditarAnimal{{ a.id }}">
               ✏️ Editar
             </button>
-            <form action="{{ url_for('deletar_animal', animal_id=a.id) }}" method="POST" onsubmit="return confirm('Tem certeza que deseja remover este animal?')" style="display:inline;">
+            <form action="{{ url_for('deletar_animal', animal_id=a.id) }}" method="POST"
+                  data-sync="true" data-no-reload="true" data-remove-closest="li"
+                  onsubmit="return confirm('Tem certeza que deseja remover este animal?')" style="display:inline;">
               <button type="submit" class="btn btn-outline-danger btn-sm">
                 🗑️ Remover
               </button>
@@ -159,7 +162,9 @@
           {% for r in removidos %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
             <span><strong>{{ r.name }}</strong> — {{ r.species }} / {{ r.breed }}</span>
-            <form action="{{ url_for('deletar_animal', animal_id=r.id) }}" method="POST" onsubmit="return confirm('Excluir permanentemente {{ r.name }}?')">
+            <form action="{{ url_for('deletar_animal', animal_id=r.id) }}" method="POST"
+                  data-sync="true" data-no-reload="true" data-remove-closest="li"
+                  onsubmit="return confirm('Excluir permanentemente {{ r.name }}?')">
               <button type="submit" class="btn btn-sm btn-danger">❌ Excluir Definitivamente</button>
             </form>
           </li>


### PR DESCRIPTION
## Summary
- add queueSynced event and removal helpers in `offline.js`
- return JSON from deletion routes
- load pending blocks from `localStorage` for exams, vaccines and prescriptions
- insert pending items into DOM when offline
- refresh partials when queue syncs
- allow deleting items without reload via `data-sync` forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875f6546ac832e87caf3887dd4fc88