### PR TITLE
Fix duplicate form and add CSRF tokens

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -36,36 +36,6 @@ class ResetPasswordForm(FlaskForm):
     submit = SubmitField('Redefinir senha')
 
 
-class RegistrationForm(FlaskForm):
-    name = StringField(
-        'Name',
-        validators=[DataRequired(message="Nome é obrigatório"), Length(min=2, max=120)],
-        render_kw={"required": True},
-    )
-    email = StringField(
-        'Email',
-        validators=[DataRequired(message="Email é obrigatório"), Email()],
-        render_kw={"required": True},
-    )
-    phone = StringField('Phone', validators=[Optional(), Length(min=8, max=20)])
-    address = StringField('Address', validators=[Optional(), Length(max=200)])
-    profile_photo = FileField('Foto de Perfil', validators=[
-        Optional(),
-        FileAllowed(['jpg', 'jpeg', 'png', 'gif'], 'Apenas imagens!')
-    ])
-    password = PasswordField(
-        'Password',
-        validators=[DataRequired(message="Senha é obrigatória"), Length(min=6)],
-        render_kw={"required": True},
-    )
-    confirm_password = PasswordField(
-        'Confirm Password',
-        validators=[DataRequired(message="Confirmação de senha é obrigatória"), EqualTo('password', message='Passwords must match')],
-        render_kw={"required": True},
-    )
-    submit = SubmitField('Cadastrar')
-
-
 
 
 
@@ -103,20 +73,6 @@ class RegistrationForm(FlaskForm):
         render_kw={"required": True},
     )
 
-    submit = SubmitField('Cadastrar')
-
-
-
-    password = PasswordField(
-        'Password',
-        validators=[DataRequired(message="Senha é obrigatória"), Length(min=6)],
-        render_kw={"required": True},
-    )
-    confirm_password = PasswordField(
-        'Confirm Password',
-        validators=[DataRequired(message="Confirmação de senha é obrigatória"), EqualTo('password', message='Passwords must match')],
-        render_kw={"required": True},
-    )
     submit = SubmitField('Cadastrar')
 
 

--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -41,6 +41,7 @@
         {% if current_user.worker == 'delivery' %}
           {% if req.status == 'pendente' %}
             <form action="{{ url_for('accept_delivery', req_id=req.id) }}" method="post" class="js-delivery-form">
+              {{ csrf_token() }}
               <button class="btn btn-sm btn-primary">Aceitar</button>
             </form>
 
@@ -51,9 +52,11 @@
                  Detalhes
               </a>
               <form action="{{ url_for('complete_delivery', req_id=req.id) }}" method="post" class="me-2 js-delivery-form">
+                {{ csrf_token() }}
                 <button class="btn btn-sm btn-success">Concluir</button>
               </form>
               <form action="{{ url_for('cancel_delivery', req_id=req.id) }}" method="post" class="js-delivery-form">
+                {{ csrf_token() }}
                 <button class="btn btn-sm btn-outline-danger">Cancelar</button>
               </form>
             </div>

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -12,6 +12,7 @@
       <form method="POST" action="{{ url_for('deletar_tutor', tutor_id=tutor.id) }}"
             onsubmit="return confirm('Tem certeza que deseja excluir este tutor e todos os seus dados permanentemente?');"
             class="position-absolute top-0 end-0 m-2">
+        {{ csrf_token() }}
         <button type="submit" class="btn btn-sm btn-danger" title="Excluir Tutor">
           ❌
         </button>
@@ -31,6 +32,7 @@
 
 
       <form action="{{ url_for('update_tutor', user_id=tutor.id) }}" method="POST" enctype="multipart/form-data" class="row g-3">
+        {{ csrf_token() }}
         <div class="col-md-6">
           <label class="form-label">Nome</label>
           <input name="name" class="form-control" value="{{ tutor.name }}" required>
@@ -130,6 +132,7 @@
               ✏️ Editar
             </button>
             <form action="{{ url_for('deletar_animal', animal_id=a.id) }}" method="POST" onsubmit="return confirm('Tem certeza que deseja remover este animal?')" style="display:inline;">
+              {{ csrf_token() }}
               <button type="submit" class="btn btn-outline-danger btn-sm">
                 🗑️ Remover
               </button>
@@ -160,6 +163,7 @@
           <li class="list-group-item d-flex justify-content-between align-items-center">
             <span><strong>{{ r.name }}</strong> — {{ r.species }} / {{ r.breed }}</span>
             <form action="{{ url_for('deletar_animal', animal_id=r.id) }}" method="POST" onsubmit="return confirm('Excluir permanentemente {{ r.name }}?')">
+              {{ csrf_token() }}
               <button type="submit" class="btn btn-sm btn-danger">❌ Excluir Definitivamente</button>
             </form>
           </li>
@@ -178,6 +182,7 @@
   <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
       <form action="{{ url_for('update_animal', animal_id=a.id) }}" method="POST" enctype="multipart/form-data">
+        {{ csrf_token() }}
         <div class="modal-header">
           <h5 class="modal-title">✏️ Editar {{ a.name }}</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
@@ -297,6 +302,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <form action="{{ url_for('novo_animal') }}" method="POST" enctype="multipart/form-data">
+        {{ csrf_token() }}
         <div class="modal-body">
           <input type="hidden" name="tutor_id" value="{{ tutor.id }}">
 


### PR DESCRIPTION
## Summary
- remove duplicate `RegistrationForm` definition
- include CSRF tokens in delivery request forms
- include CSRF tokens in tutor detail forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688760d40a8c832eab0058f312fabcf4