### PR TITLE
Add Flask-Talisman headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ queued requests are automatically sent to the server.
 The file `static/offline.js` implements this behaviour and is cached by the
 service worker.
 
+## Segurança
+
+Este projeto utiliza o [Flask‑Talisman](https://github.com/GoogleCloudPlatform/flask-talisman) para
+definir cabeçalhos HTTP importantes como HSTS e Content‑Security‑Policy. Todas as
+requisições são redirecionadas para HTTPS em ambientes de produção.
+
 ## Mercado Pago
 
 To enable payment integration you must provide credentials from your Mercado

--- a/app.py
+++ b/app.py
@@ -55,7 +55,15 @@ app.config.update(SESSION_PERMANENT=True, SESSION_TYPE="filesystem")
 def date_now(format_string='%Y-%m-%d'):
     return datetime.now(BR_TZ).strftime(format_string)
 # já existe no topo, logo depois das extensões:
-from extensions import db, migrate, mail, login, session as session_ext, babel
+from extensions import (
+    db,
+    migrate,
+    mail,
+    login,
+    session as session_ext,
+    babel,
+    talisman,
+)
 from flask_login import login_user, logout_user, current_user, login_required
 from flask_mail import Message as MailMessage      #  ←  adicione esta linha
 from werkzeug.utils import secure_filename
@@ -66,6 +74,12 @@ mail.init_app(app)
 login.init_app(app)
 session_ext.init_app(app)
 babel.init_app(app)
+
+@app.before_request
+def _update_talisman_force_https():
+    talisman.force_https = not app.testing
+
+talisman.init_app(app)
 app.config.setdefault("BABEL_DEFAULT_LOCALE", "pt_BR")
 
 # ----------------------------------------------------------------

--- a/extensions.py
+++ b/extensions.py
@@ -4,6 +4,7 @@ from flask_mail import Mail
 from flask_login import LoginManager
 from flask_session import Session
 from flask_babel import Babel
+from flask_talisman import Talisman
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -11,3 +12,4 @@ mail = Mail()
 login = LoginManager()
 session = Session()
 babel = Babel()
+talisman = Talisman()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ Flask-Session==0.8.0
 Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.2.2
 Flask-Babel==4.0.0
+Flask-Talisman==0.4.0
 frozenlist==1.7.0
 greenlet==3.2.3
 gunicorn==23.0.0


### PR DESCRIPTION
## Summary
- configure Flask-Talisman extension
- include dependency and document security headers

## Testing
- `pip install flask-talisman==0.4.0 -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688778598ac0832eb6d57947075cc4f3