### PR TITLE
Fix access control for admin dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -286,6 +286,8 @@ def reset_password(token):
 @app.route('/painel')
 @login_required
 def painel_dashboard():
+    if not _is_admin():
+        abort(403)
     cards = [
         {"icon": "👤", "title": "Usuários", "description": f"Total: {User.query.count()}"},
         {"icon": "🐶", "title": "Animais", "description": f"Total: {Animal.query.count()}"},


### PR DESCRIPTION
## Summary
- restrict `/painel` route to admins only
- add tests ensuring only admins can access the dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877874d0b4832e86ca69d56f7eb246