### PR TITLE
Update local HTTPS logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,8 @@ MAIL_DEFAULT_SENDER_EMAIL=your-email@example.com
 
 # Default pickup address
 DEFAULT_PICKUP_ADDRESS="Rua Nove 990 - Orlândia"
+
+# Disable HTTPS redirects when running with `flask run`
+FORCE_HTTPS=0
+# Allow cookies over HTTP during development
+SESSION_COOKIE_SECURE=0

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ When using a remote PostgreSQL database (e.g., on Heroku or AWS RDS) make sure
 the `SQLALCHEMY_DATABASE_URI` includes `sslmode=require` so the connection uses
 TLS.
 
+## Local Development
+
+By default the application enforces HTTPS using Flask‑Talisman. When running
+with the built-in development server there is no TLS support, so you should
+disable the redirect and use an SQLite database:
+
+```bash
+cp .env.example .env
+echo "SQLALCHEMY_DATABASE_URI=sqlite:///instance/dev.db" >> .env
+echo "FORCE_HTTPS=0" >> .env
+echo "SESSION_COOKIE_SECURE=0" >> .env
+flask run
+```
+
 ## Offline Usage
 
 PetOrlândia can operate with limited connectivity thanks to a small service worker

--- a/app.py
+++ b/app.py
@@ -77,7 +77,12 @@ babel.init_app(app)
 
 @app.before_request
 def _update_talisman_force_https():
-    talisman.force_https = not app.testing
+    force_env = os.getenv("FORCE_HTTPS")
+    if force_env is None:
+        force = not os.getenv("FLASK_RUN_FROM_CLI")
+    else:
+        force = force_env.lower() not in ("0", "false", "no")
+    talisman.force_https = not app.testing and force
 
 talisman.init_app(app)
 app.config.setdefault("BABEL_DEFAULT_LOCALE", "pt_BR")


### PR DESCRIPTION
## Summary
- disable HTTPS redirect in development when running via `flask run`
- document how to run locally without HTTPS
- expose FORCE_HTTPS and SESSION_COOKIE_SECURE options in `.env.example`

## Testing
- `pytest -q`
- `flask run --port=5000 --host=127.0.0.1` (manual)

------
https://chatgpt.com/codex/tasks/task_e_68878f580f08832e873a15e0858ab0b1