### PR TITLE
Relax CSP for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ service worker.
 
 ## Segurança
 
-Este projeto utiliza o [Flask‑Talisman](https://github.com/GoogleCloudPlatform/flask-talisman) para
-definir cabeçalhos HTTP importantes como HSTS e Content‑Security‑Policy. Todas as
-requisições são redirecionadas para HTTPS em ambientes de produção.
+Este projeto utiliza o [Flask‑Talisman](https://github.com/GoogleCloudPlatform/flask-talisman)
+para definir cabeçalhos HTTP importantes como HSTS e Content‑Security‑Policy.
+Quando executado com `flask run`, a política de segurança de conteúdo (CSP)
+fica desativada para permitir estilos inline e recursos hospedados em CDNs.
+Em produção você pode configurar o `Talisman` para aplicar uma CSP mais
+restrita.
+Todas as requisições são redirecionadas para HTTPS em ambientes de produção.
 
 ## Mercado Pago
 

--- a/app.py
+++ b/app.py
@@ -84,7 +84,12 @@ def _update_talisman_force_https():
         force = force_env.lower() not in ("0", "false", "no")
     talisman.force_https = not app.testing and force
 
-talisman.init_app(app)
+if os.getenv("FLASK_RUN_FROM_CLI"):
+    # Disable the default CSP when running via `flask run` so inline styles
+    # and CDN assets work during development.
+    talisman.init_app(app, content_security_policy=None)
+else:
+    talisman.init_app(app)
 app.config.setdefault("BABEL_DEFAULT_LOCALE", "pt_BR")
 
 # ----------------------------------------------------------------

--- a/extensions.py
+++ b/extensions.py
@@ -12,4 +12,7 @@ mail = Mail()
 login = LoginManager()
 session = Session()
 babel = Babel()
-talisman = Talisman()
+# Allow inline styles and external resources by disabling the default
+# Content-Security-Policy. Production deployments can override this
+# using a custom configuration if stricter policies are desired.
+talisman = Talisman(content_security_policy=None)


### PR DESCRIPTION
## Summary
- disable CSP when running with `flask run`
- update docs to mention the relaxed policy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68879264925c832e94553cce427ea879