### PR TITLE
Handle postgres prefix in DB URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ When using a remote PostgreSQL database (e.g., on Heroku or AWS RDS) make sure
 the `SQLALCHEMY_DATABASE_URI` includes `sslmode=require` so the connection uses
 TLS.
 
+Heroku may still provide a `DATABASE_URL` starting with `postgres://`. The
+application now automatically converts this to `postgresql://` so SQLAlchemy can
+load the correct dialect.
+
 ## Local Development
 
 By default the application enforces HTTPS using Flask‑Talisman. When running

--- a/config.py
+++ b/config.py
@@ -6,6 +6,14 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-key")
     SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
 
+    # Heroku historically provides the DATABASE_URL with a "postgres://" prefix
+    # which SQLAlchemy does not recognise. Convert it to "postgresql://" if
+    # necessary so the correct dialect plugin is loaded.
+    if SQLALCHEMY_DATABASE_URI and SQLALCHEMY_DATABASE_URI.startswith("postgres://"):
+        SQLALCHEMY_DATABASE_URI = SQLALCHEMY_DATABASE_URI.replace(
+            "postgres://", "postgresql://", 1
+        )
+
     # Ensure SSL is used when connecting to PostgreSQL if no sslmode is provided
     if SQLALCHEMY_DATABASE_URI and SQLALCHEMY_DATABASE_URI.startswith("postgresql"):
         if "sslmode=" not in SQLALCHEMY_DATABASE_URI:


### PR DESCRIPTION
## Summary
- normalize `postgres://` URLs so SQLAlchemy loads the right dialect
- mention automatic conversion in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887972634bc832ea1949042aaa32914