### PR TITLE
Fix service worker error on POST navigation

### DIFF
--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -33,8 +33,10 @@ self.addEventListener('fetch', event => {
     event.respondWith(
       fetch(event.request)
         .then(response => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          if (event.request.method === 'GET') {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          }
           return response;
         })
         .catch(() => caches.match(event.request))


### PR DESCRIPTION
## Summary
- avoid caching POST navigation requests in the service worker

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887b4db7e00832ea6bb5c5e45dcd026