### PR TITLE
Enable AJAX update for consulta history

### DIFF
--- a/app.py
+++ b/app.py
@@ -1928,7 +1928,8 @@ def update_consulta(consulta_id):
     # Se estiver editando uma consulta antiga
     if request.args.get('edit') == '1':
         db.session.commit()
-        flash('Consulta atualizada com sucesso!', 'success')
+        message = 'Consulta atualizada com sucesso!'
+        flash(message, 'success')
 
     else:
         # Salva, finaliza e cria nova automaticamente
@@ -1943,7 +1944,22 @@ def update_consulta(consulta_id):
         db.session.add(nova)
         db.session.commit()
 
-        flash('Consulta salva e movida para o histórico!', 'success')
+        message = 'Consulta salva e movida para o histórico!'
+        flash(message, 'success')
+
+    if 'application/json' in request.headers.get('Accept', ''):
+        historico = (
+            Consulta.query
+            .filter_by(animal_id=consulta.animal_id, status='finalizada')
+            .order_by(Consulta.created_at.desc())
+            .all()
+        )
+        html = render_template(
+            'partials/historico_consultas.html',
+            animal=consulta.animal,
+            historico_consultas=historico,
+        )
+        return jsonify(success=True, message=message, html=html)
 
     return redirect(url_for('consulta_direct', animal_id=consulta.animal_id))
 

--- a/static/offline.js
+++ b/static/offline.js
@@ -67,8 +67,13 @@
     const data = new FormData(form);
     const resp = await window.fetchOrQueue(form.action, {method: form.method || 'POST', headers: {'Accept': 'application/json'}, body: data});
     if (resp) {
-      try { await resp.json(); } catch(e) {}
-      location.reload();
+      let json = null;
+      try { json = await resp.json(); } catch(e) {}
+      const evt = new CustomEvent('form-sync-success', {detail: {form, data: json}, cancelable: true});
+      document.dispatchEvent(evt);
+      if (!evt.defaultPrevented) {
+        location.reload();
+      }
     } else {
       alert('Ação salva offline e será sincronizada quando possível.');
     }

--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -117,7 +117,9 @@
         <div class="card shadow-sm">
           <div class="card-body">
             {% include 'partials/consulta_form.html' %}
-            {% include 'partials/historico_consultas.html' %}
+            <div id="historico-consultas">
+              {% include 'partials/historico_consultas.html' %}
+            </div>
           </div>
         </div>
       </div>
@@ -202,6 +204,24 @@ document.addEventListener('DOMContentLoaded', function() {
       if (medInput) medInput.dispatchEvent(new Event('input'));
     }
   });
+});
+
+document.addEventListener('form-sync-success', function(ev) {
+  const {form, data} = ev.detail || {};
+  if (form && form.id === 'consulta-form') {
+    ev.preventDefault();
+    if (data && data.html) {
+      const container = document.getElementById('historico-consultas');
+      if (container) container.innerHTML = data.html;
+    }
+    const toastEl = document.getElementById('actionToast');
+    if (toastEl) {
+      toastEl.querySelector('.toast-body').textContent = (data && data.message) || 'Consulta salva com sucesso!';
+      toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+      toastEl.classList.add('bg-success');
+      bootstrap.Toast.getOrCreateInstance(toastEl).show();
+    }
+  }
 });
 
 </script>

--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -6,7 +6,7 @@
   </div>
 {% endif %}
 
-<form method="POST"
+<form id="consulta-form" method="POST"
       action="{{ url_for('update_consulta', consulta_id=consulta.id) }}{% if edit_mode %}?edit=1{% endif %}"
       class="needs-validation" novalidate data-sync="true">
 


### PR DESCRIPTION
## Summary
- avoid page reload in offline.js and emit `form-sync-success`
- return updated consulta history as JSON
- update consulta form markup and add history container
- refresh history and show toast on consulta save

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cce8d1f0832e8793700c8dce99d8