### PR TITLE
Fix offline form submission validation

### DIFF
--- a/static/offline.js
+++ b/static/offline.js
@@ -63,6 +63,12 @@
   document.addEventListener('submit', async ev => {
     const form = ev.target;
     if (!form.matches('form[data-sync]')) return;
+    if (!form.checkValidity()) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      form.classList.add('was-validated');
+      return;
+    }
     ev.preventDefault();
     const data = new FormData(form);
     const resp = await window.fetchOrQueue(form.action, {method: form.method || 'POST', headers: {'Accept': 'application/json'}, body: data});


### PR DESCRIPTION
## Summary
- validate forms before queuing submission in offline.js

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887d0d846a0832ea235eb4baf942a62