### PR TITLE
AJAX update for medical forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -2232,7 +2232,12 @@ def salvar_vacinas(animal_id):
             db.session.add(vacina)
 
         db.session.commit()
-        return jsonify({"success": True})
+        animal = Animal.query.get_or_404(animal_id)
+        historico_html = render_template(
+            'partials/historico_vacinas.html',
+            animal=animal
+        )
+        return jsonify({"success": True, "html": historico_html})
 
     except Exception as e:
         print("Erro ao salvar vacinas:", e)
@@ -2492,7 +2497,15 @@ def salvar_bloco_prescricao(consulta_id):
         db.session.add(nova)
 
     db.session.commit()
-    return jsonify({'success': True, 'message': 'Prescrições salvas com sucesso!'})
+    historico_html = render_template(
+        'partials/historico_prescricoes.html',
+        animal=consulta.animal
+    )
+    return jsonify({
+        'success': True,
+        'message': 'Prescrições salvas com sucesso!',
+        'html': historico_html
+    })
 
 
 @app.route('/bloco_prescricao/<int:bloco_id>/deletar', methods=['POST'])
@@ -2602,7 +2615,12 @@ def salvar_bloco_exames(animal_id):
         db.session.add(exame_modelo)
 
     db.session.commit()
-    return jsonify({'success': True})
+    animal = Animal.query.get_or_404(animal_id)
+    historico_html = render_template(
+        'partials/historico_exames.html',
+        animal=animal
+    )
+    return jsonify({'success': True, 'html': historico_html})
 
 
 

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -1,4 +1,5 @@
 <form>
+  <div id="feedback-exames" class="alert d-none position-fixed" style="top: 20px; right: 20px; z-index: 1000;"></div>
   <h5 class="mb-3">Solicitação de Exames</h5>
 
   <!-- Campo com autocomplete -->
@@ -42,6 +43,12 @@
 
 <script>
   let exames = [];
+  function mostrarFeedback(msg, tipo = 'success') {
+    const fb = document.getElementById('feedback-exames');
+    fb.textContent = msg;
+    fb.className = `alert alert-${tipo} d-block`;
+    setTimeout(() => fb.classList.add('d-none'), 3000);
+  }
 
   document.addEventListener('DOMContentLoaded', function () {
     const inputExame = document.getElementById('nome-exame');
@@ -146,7 +153,7 @@
 
   async function finalizarBlocoExames() {
     if (exames.length === 0) {
-      alert('Adicione pelo menos um exame antes de finalizar.');
+      mostrarFeedback('Adicione pelo menos um exame antes de finalizar.', 'warning');
       return;
     }
 
@@ -154,7 +161,7 @@
 
     const resp = await fetchOrQueue(`/animal/{{ animal.id }}/bloco_exames`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
       body: JSON.stringify({
         exames: exames,
         observacoes_gerais: obsGerais
@@ -163,13 +170,17 @@
     if (resp) {
       const data = await resp.json();
       if (data.success) {
-        alert('Solicitação de exames salva com sucesso!');
-        location.reload();
+        mostrarFeedback('Solicitação de exames salva com sucesso!');
+        if (data.html) {
+          document.getElementById('historico-prescricoes').innerHTML = data.html;
+        }
+        exames = [];
+        renderExamesTemp();
       } else {
-        alert('Erro ao salvar exames.');
+        mostrarFeedback('Erro ao salvar exames.', 'danger');
       }
     } else {
-      alert('Solicitação salva offline e será enviada quando possível.');
+      mostrarFeedback('Solicitação salva offline e será enviada quando possível.', 'info');
     }
   }
 </script>

--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -257,7 +257,7 @@
       const instrucoes = document.getElementById('instrucoes-medicamentos')?.value || '';
       const response = await fetchOrQueue(`/consulta/{{ consulta.id }}/bloco_prescricao`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
         body: JSON.stringify({
           prescricoes,
           instrucoes_gerais: instrucoes
@@ -266,9 +266,13 @@
 
       if (response) {
         const data = await response.json();
-        if (!response.ok) throw new Error(data.message || 'Erro ao salvar prescrição');
+        if (!response.ok || !data.success) throw new Error(data.message || 'Erro ao salvar prescrição');
         mostrarFeedback('Prescrição salva com sucesso!', 'success');
-        setTimeout(() => location.reload(), 1500);
+        if (data.html) {
+          document.getElementById('historico-prescricoes').innerHTML = data.html;
+        }
+        prescricoes = [];
+        renderPrescricoesTemp();
       } else {
         mostrarFeedback('Prescrição salva offline. Sincronizaremos em breve.', 'info');
       }

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -1,4 +1,5 @@
 <form>
+    <div id="feedback-vacinas" class="alert d-none position-fixed" style="top: 20px; right: 20px; z-index: 1000;"></div>
     <h5 class="mb-3">💉 Registro de Vacinas</h5>
 
     <!-- Campo com autocomplete -->
@@ -49,6 +50,12 @@
 
   <script>
     let vacinas = [];
+    function mostrarFeedback(msg, tipo = 'success') {
+      const fb = document.getElementById('feedback-vacinas');
+      fb.textContent = msg;
+      fb.className = `alert alert-${tipo} d-block`;
+      setTimeout(() => fb.classList.add('d-none'), 3000);
+    }
 
     document.addEventListener('DOMContentLoaded', () => {
       const input = document.getElementById('nome-vacina');
@@ -142,13 +149,13 @@
       const obs = document.getElementById('observacoes-vacinas').value.trim();
 
       if (vacinas.length === 0) {
-        alert('Adicione pelo menos uma vacina.');
+        mostrarFeedback('Adicione pelo menos uma vacina.', 'warning');
         return;
       }
 
       const resp = await fetchOrQueue(`/animal/{{ animal.id }}/vacinas`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
         body: JSON.stringify({
           vacinas,
           observacoes_gerais: obs
@@ -157,13 +164,17 @@
       if (resp) {
         const data = await resp.json();
         if (data.success) {
-          alert('Vacinas registradas com sucesso!');
-          location.reload();
+          mostrarFeedback('Vacinas registradas com sucesso!');
+          if (data.html) {
+            document.getElementById('historico-vacinas').innerHTML = data.html;
+          }
+          vacinas = [];
+          renderVacinasTemp();
         } else {
-          alert('Erro ao salvar vacinas.');
+          mostrarFeedback('Erro ao salvar vacinas.', 'danger');
         }
       } else {
-        alert('Vacinas salvas offline e serão enviadas quando possível.');
+        mostrarFeedback('Vacinas salvas offline e serão enviadas quando possível.', 'info');
       }
     }
   </script>


### PR DESCRIPTION
## Summary
- return updated HTML after creating prescription blocks, exams and vaccines
- show success messages client-side and update history sections without page reload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cfe94030832eba1a363b64eb5de4