### PR TITLE
Reduce offline fetch timeout

### DIFF
--- a/static/offline.js
+++ b/static/offline.js
@@ -2,7 +2,7 @@
   const KEY = 'offline-queue';
 
   // Abort fetch requests if no response within given timeout (ms)
-  async function fetchWithTimeout(url, opts={}, timeout=8000){
+  async function fetchWithTimeout(url, opts={}, timeout=2000){
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeout);
     try {


### PR DESCRIPTION
## Summary
- tighten offline queue request timeout to 2 seconds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d55ec910832e911a480b6257ff4f