### PR TITLE
Handle date objects in Jinja datetime filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,11 +125,17 @@ def datetime_brazil(value):
 def format_datetime_brazil(value, fmt="%d/%m/%Y %H:%M"):
     if value is None:
         return ""
-    if value.tzinfo is None:
 
-        value = value.replace(tzinfo=timezone.utc)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        value = value.astimezone(BR_TZ)
+        return value.strftime(fmt)
 
-    return value.astimezone(BR_TZ).strftime(fmt)
+    if isinstance(value, date):
+        return value.strftime(fmt)
+
+    return value
 
 # ----------------------------------------------------------------
 # 6)  Forms e helpers

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,18 @@
+import os
+import sys
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from datetime import datetime, date, timezone
+
+from app import format_datetime_brazil
+
+
+def test_format_datetime_brazil_with_date():
+    d = date(2024, 1, 31)
+    assert format_datetime_brazil(d, "%d/%m/%Y") == "31/01/2024"
+
+
+def test_format_datetime_brazil_with_datetime():
+    dt = datetime(2024, 1, 31, 15, 0, tzinfo=timezone.utc)
+    out = format_datetime_brazil(dt, "%d/%m/%Y %H:%M")
+    assert "31/01/2024" in out


### PR DESCRIPTION
## Summary
- support `date` objects in `format_datetime_brazil`
- add tests for the filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887eb3eeb04832e84feb0ec43faa5c9