### PR TITLE
Fix tutor address update

### DIFF
--- a/app.py
+++ b/app.py
@@ -1757,8 +1757,13 @@ def update_tutor(user_id):
         upload_profile_photo_async(user.id, photo.read(), photo.content_type, filename)
 
     # 📍 Endereço
-    addr_fields = {k: request.form.get(k) or None for k in ['cep', 'rua', 'numero', 'complemento', 'bairro', 'cidade', 'estado']}
-    if all(addr_fields.values()):
+    addr_fields = {
+        k: request.form.get(k) or None
+        for k in ['cep', 'rua', 'numero', 'complemento', 'bairro', 'cidade', 'estado']
+    }
+    required_fields = ['cep', 'rua', 'cidade', 'estado']
+
+    if all(addr_fields.get(f) for f in required_fields):
         endereco = user.endereco or Endereco()
         for k, v in addr_fields.items():
             setattr(endereco, k, v)
@@ -1767,7 +1772,7 @@ def update_tutor(user_id):
             db.session.flush()
             user.endereco_id = endereco.id
     elif any(addr_fields.values()):
-        flash('Por favor, preencha todos os campos obrigatórios do endereço.', 'warning')
+        flash('Por favor, informe CEP, rua, cidade e estado.', 'warning')
         return redirect(request.referrer or url_for('index'))
 
     # 💾 Commit final


### PR DESCRIPTION
## Summary
- allow optional number/bairro/complemento fields when updating tutor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887fbfb4c90832eaec104d3c85fcf8c