### PR TITLE
Add signature button

### DIFF
--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -111,6 +111,7 @@
 <!-- Botões -->
 <div class="no-print" style="margin-bottom: 1em;">
   <button onclick="window.print()">🖨️ Imprimir</button>
+  <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
   <a href="{{ url_for('consulta_direct', animal_id=bloco.animal.id) }}" style="margin-left: 15px;">← Voltar</a>
 </div>
 
@@ -193,11 +194,11 @@
 </footer>
 
 <script>
-  window.addEventListener('afterprint', function(){
+  function abrirAssinatura() {
     if (confirm('Abrir página de assinatura agora?')) {
-      window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+      window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
     }
-  });
+  }
 </script>
 
 </body>

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -72,6 +72,7 @@
 
   <div class="no-print" style="margin-bottom: 1em;">
     <button onclick="window.print()">🖨️ Imprimir</button>
+    <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" style="margin-left: 15px;">← Voltar</a>
   </div>
 
@@ -131,11 +132,11 @@
   </footer>
   {% endif %}
   <script>
-  window.addEventListener('afterprint', function(){
+    function abrirAssinatura() {
       if (confirm('Abrir página de assinatura agora?')) {
-          window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+        window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
       }
-  });
+    }
   </script>
 </body>
 </html>

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -110,6 +110,7 @@
   <!-- Botões -->
   <div class="no-print" style="margin-bottom: 1em;">
     <button onclick="window.print()">🖨️ Imprimir</button>
+    <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
   </div>
@@ -202,11 +203,11 @@
   </footer>
 
   <script>
-  window.addEventListener('afterprint', function(){
+    function abrirAssinatura() {
       if (confirm('Abrir página de assinatura agora?')) {
-          window.location.href = 'https://assinador.iti.br/assinatura/index.xhtml';
+        window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
       }
-    });
+    }
   </script>
 
 </body>


### PR DESCRIPTION
## Summary
- add dedicated digital signature button on print pages
- stop auto-opening signature site after printing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688806f41778832ebc91d1a2bd0d3b2b