### PR TITLE
Add photo rotation and zoom controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -501,6 +501,8 @@ def profile():
         current_user.name = form.name.data
         current_user.email = form.email.data
         current_user.phone = form.phone.data
+        current_user.photo_rotation = form.photo_rotation.data
+        current_user.photo_zoom = form.photo_zoom.data
 
         # Atualiza ou cria endereço
         endereco = current_user.endereco

--- a/forms.py
+++ b/forms.py
@@ -175,6 +175,18 @@ class EditProfileForm(FlaskForm):
     Optional(),
     FileAllowed(['jpg', 'jpeg', 'png', 'gif'], 'Somente imagens!')
 ])
+    photo_rotation = SelectField(
+        'Rotação',
+        choices=[(0, '0°'), (90, '90°'), (180, '180°'), (270, '270°')],
+        coerce=int,
+        default=0,
+    )
+    photo_zoom = SelectField(
+        'Zoom',
+        choices=[(1.0, '100%'), (1.25, '125%'), (1.5, '150%'), (1.75, '175%'), (2.0, '200%')],
+        coerce=float,
+        default=1.0,
+    )
     submit = SubmitField('Salvar Alterações')
 
 

--- a/migrations/versions/be9a1dc58c6f_photo_controls.py
+++ b/migrations/versions/be9a1dc58c6f_photo_controls.py
@@ -1,0 +1,26 @@
+"""add photo rotation and zoom to user
+
+Revision ID: be9a1dc58c6f
+Revises: 07c9382e9aad
+Create Date: 2025-08-01 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'be9a1dc58c6f'
+down_revision = '07c9382e9aad'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('photo_rotation', sa.Integer(), nullable=True, server_default='0'))
+        batch_op.add_column(sa.Column('photo_zoom', sa.Float(), nullable=True, server_default='1'))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('photo_zoom')
+        batch_op.drop_column('photo_rotation')

--- a/models.py
+++ b/models.py
@@ -79,6 +79,8 @@ class User(UserMixin, db.Model):
 
 
     profile_photo = db.Column(db.String(200))
+    photo_rotation = db.Column(db.Integer, default=0)
+    photo_zoom = db.Column(db.Float, default=1.0)
 
     # 🆕 Novos campos adicionados:
     cpf = db.Column(db.String(14), unique=True, nullable=True)  # Ex: 123.456.789-00

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -12,8 +12,8 @@
         <!-- Foto -->
         <div class="col-md-4 text-center">
           {% if current_user.profile_photo %}
-            <img src="{{ current_user.profile_photo }}" class="img-thumbnail shadow-sm mb-2"
-                 style="width: 240px; height: 240px; object-fit: cover; border-radius: 1rem;"
+            <img id="profile-photo-img" src="{{ current_user.profile_photo }}" class="img-thumbnail shadow-sm mb-2"
+                 style="width: 240px; height: 240px; object-fit: cover; border-radius: 1rem; transform: rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});"
                  alt="Foto de {{ current_user.name }}">
           {% else %}
             <div class="bg-light border d-flex align-items-center justify-content-center mb-2"
@@ -24,6 +24,8 @@
 
           <div id="campo-upload-foto" class="mt-2 d-none">
             {{ form.profile_photo(class="form-control form-control-sm") }}
+            {{ form.photo_rotation(class="form-select form-select-sm mt-2") }}
+            {{ form.photo_zoom(class="form-select form-select-sm mt-2") }}
           </div>
         </div>
 
@@ -213,6 +215,19 @@ function toggleAll() {
     }
   }
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+  const rot = document.getElementById('photo_rotation');
+  const zoom = document.getElementById('photo_zoom');
+  const img = document.getElementById('profile-photo-img');
+  function update() {
+    if (img && rot && zoom) {
+      img.style.transform = `rotate(${rot.value}deg) scale(${zoom.value})`;
+    }
+  }
+  if (rot) rot.addEventListener('input', update);
+  if (zoom) zoom.addEventListener('input', update);
+});
 
 
   function mostrarTodasTransacoes() {


### PR DESCRIPTION
## Summary
- add `photo_rotation` and `photo_zoom` fields to `User`
- enable editing rotation and zoom in profile form
- save new fields in profile route
- show transformed photo and controls in profile page
- create migration for the new user columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882aff6538832eba993e05cce352e0