### PR TITLE
Implement profile photo cropping

### DIFF
--- a/app.py
+++ b/app.py
@@ -503,6 +503,8 @@ def profile():
         current_user.phone = form.phone.data
         current_user.photo_rotation = form.photo_rotation.data
         current_user.photo_zoom = form.photo_zoom.data
+        current_user.photo_offset_x = form.photo_offset_x.data
+        current_user.photo_offset_y = form.photo_offset_y.data
 
         # Atualiza ou cria endereço
         endereco = current_user.endereco

--- a/forms.py
+++ b/forms.py
@@ -177,6 +177,8 @@ class EditProfileForm(FlaskForm):
 ])
     photo_rotation = IntegerField('Rotação', default=0, validators=[Optional()])
     photo_zoom = DecimalField('Zoom', places=2, default=1.0, validators=[Optional()])
+    photo_offset_x = DecimalField('Offset X', places=0, default=0, validators=[Optional()])
+    photo_offset_y = DecimalField('Offset Y', places=0, default=0, validators=[Optional()])
     submit = SubmitField('Salvar Alterações')
 
 

--- a/migrations/versions/abc12345_photo_crop_offsets.py
+++ b/migrations/versions/abc12345_photo_crop_offsets.py
@@ -1,0 +1,27 @@
+"""add photo crop offsets to user
+
+Revision ID: abc12345
+Revises: be9a1dc58c6f
+Create Date: 2025-08-02 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'abc12345'
+down_revision = 'be9a1dc58c6f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('photo_offset_x', sa.Float(), nullable=True, server_default='0'))
+        batch_op.add_column(sa.Column('photo_offset_y', sa.Float(), nullable=True, server_default='0'))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('photo_offset_y')
+        batch_op.drop_column('photo_offset_x')

--- a/models.py
+++ b/models.py
@@ -81,6 +81,8 @@ class User(UserMixin, db.Model):
     profile_photo = db.Column(db.String(200))
     photo_rotation = db.Column(db.Integer, default=0)
     photo_zoom = db.Column(db.Float, default=1.0)
+    photo_offset_x = db.Column(db.Float, default=0.0)
+    photo_offset_y = db.Column(db.Float, default=0.0)
 
     # 🆕 Novos campos adicionados:
     cpf = db.Column(db.String(14), unique=True, nullable=True)  # Ex: 123.456.789-00

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -12,12 +12,11 @@
         <!-- Foto -->
         <div class="col-md-4 text-center">
           {% if current_user.profile_photo %}
-            <img id="profile-photo-img" src="{{ current_user.profile_photo }}" class="img-thumbnail shadow-sm mb-2"
-                 style="width: 240px; height: 240px; object-fit: cover; border-radius: 1rem; transform: rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});"
-                 alt="Foto de {{ current_user.name }}">
+            <div id="photo-container" class="img-thumbnail shadow-sm mb-2 position-relative overflow-hidden" style="width: 240px; height: 240px; border-radius: 1rem;">
+              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" style="width:100%; height:100%; object-fit: cover; cursor: move; transform: translate({{ current_user.photo_offset_x or 0 }}px, {{ current_user.photo_offset_y or 0 }}px) rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});" alt="Foto de {{ current_user.name }}">
+            </div>
           {% else %}
-            <div class="bg-light border d-flex align-items-center justify-content-center mb-2"
-                 style="width: 240px; height: 240px; border-radius: 1rem; font-size: 1.2rem; color: #555;">
+            <div class="bg-light border d-flex align-items-center justify-content-center mb-2" style="width: 240px; height: 240px; border-radius: 1rem; font-size: 1.2rem; color: #555;">
               Sem Foto
             </div>
           {% endif %}
@@ -36,6 +35,8 @@
             </div>
             {{ form.photo_rotation(class="d-none", id="photo_rotation") }}
             {{ form.photo_zoom(class="d-none", id="photo_zoom") }}
+            {{ form.photo_offset_x(class="d-none", id="photo_offset_x") }}
+            {{ form.photo_offset_y(class="d-none", id="photo_offset_y") }}
           </div>
         </div>
 
@@ -231,6 +232,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const fileInput = document.getElementById('profile_photo');
   const rotField = document.getElementById('photo_rotation');
   const zoomField = document.getElementById('photo_zoom');
+  const offsetXField = document.getElementById('photo_offset_x');
+  const offsetYField = document.getElementById('photo_offset_y');
   const rotateLeft = document.getElementById('rotate-left');
   const rotateRight = document.getElementById('rotate-right');
   const zoomIn = document.getElementById('zoom-in');
@@ -238,13 +241,17 @@ document.addEventListener('DOMContentLoaded', function () {
 
   let rotation = parseInt(rotField.value || 0, 10);
   let zoom = parseFloat(zoomField.value || 1);
+  let offsetX = parseFloat(offsetXField.value || 0);
+  let offsetY = parseFloat(offsetYField.value || 0);
 
   function update() {
     if (img) {
-      img.style.transform = `rotate(${rotation}deg) scale(${zoom})`;
+      img.style.transform = `translate(${offsetX}px, ${offsetY}px) rotate(${rotation}deg) scale(${zoom})`;
     }
     rotField.value = rotation;
     zoomField.value = zoom.toFixed(2);
+    offsetXField.value = Math.round(offsetX);
+    offsetYField.value = Math.round(offsetY);
   }
 
   if (fileInput) {
@@ -264,6 +271,42 @@ document.addEventListener('DOMContentLoaded', function () {
   if (rotateRight) rotateRight.addEventListener('click', () => { rotation = (rotation + 90) % 360; update(); });
   if (zoomIn) zoomIn.addEventListener('click', () => { zoom = Math.min(zoom + 0.25, 3); update(); });
   if (zoomOut) zoomOut.addEventListener('click', () => { zoom = Math.max(zoom - 0.25, 0.5); update(); });
+
+  // arrastar para ajustar o corte da foto
+  let dragging = false;
+  let startX, startY;
+
+  if (img) {
+    img.addEventListener('mousedown', (e) => {
+      dragging = true;
+      startX = e.clientX - offsetX;
+      startY = e.clientY - offsetY;
+    });
+    document.addEventListener('mousemove', (e) => {
+      if (dragging) {
+        offsetX = e.clientX - startX;
+        offsetY = e.clientY - startY;
+        update();
+      }
+    });
+    document.addEventListener('mouseup', () => { dragging = false; });
+
+    img.addEventListener('touchstart', (e) => {
+      dragging = true;
+      const t = e.touches[0];
+      startX = t.clientX - offsetX;
+      startY = t.clientY - offsetY;
+    });
+    document.addEventListener('touchmove', (e) => {
+      if (dragging) {
+        const t = e.touches[0];
+        offsetX = t.clientX - startX;
+        offsetY = t.clientY - startY;
+        update();
+      }
+    });
+    document.addEventListener('touchend', () => { dragging = false; });
+  }
 
   update();
 });


### PR DESCRIPTION
## Summary
- add draggable offsets for profile photo cropping
- store offset values in database and forms
- wrap profile image in cropped container
- record offsets in migrations and update profile route

## Testing
- `source venv/Scripts/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a36f9728832e925314f9e8018da5