### PR TITLE
Make photo cropper reusable

### DIFF
--- a/static/photo_cropper.js
+++ b/static/photo_cropper.js
@@ -1,0 +1,81 @@
+function initPhotoCropper(prefix) {
+  const img = document.getElementById(prefix + '-img');
+  const fileInput = document.getElementById(prefix);
+  const rotField = document.getElementById(prefix + '-rotation');
+  const zoomField = document.getElementById(prefix + '-zoom');
+  const offsetXField = document.getElementById(prefix + '-offset-x');
+  const offsetYField = document.getElementById(prefix + '-offset-y');
+  const rotateLeft = document.getElementById(prefix + '-rotate-left');
+  const rotateRight = document.getElementById(prefix + '-rotate-right');
+  const zoomIn = document.getElementById(prefix + '-zoom-in');
+  const zoomOut = document.getElementById(prefix + '-zoom-out');
+
+  let rotation = rotField ? parseInt(rotField.value || 0, 10) : 0;
+  let zoom = zoomField ? parseFloat(zoomField.value || 1) : 1;
+  let offsetX = offsetXField ? parseFloat(offsetXField.value || 0) : 0;
+  let offsetY = offsetYField ? parseFloat(offsetYField.value || 0) : 0;
+
+  function update() {
+    if (img) {
+      img.style.transform = `translate(${offsetX}px, ${offsetY}px) rotate(${rotation}deg) scale(${zoom})`;
+    }
+    if (rotField) rotField.value = rotation;
+    if (zoomField) zoomField.value = zoom.toFixed(2);
+    if (offsetXField) offsetXField.value = Math.round(offsetX);
+    if (offsetYField) offsetYField.value = Math.round(offsetY);
+  }
+
+  if (fileInput) {
+    fileInput.addEventListener('change', (e) => {
+      const file = e.target.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = ev => { if (img) img.src = ev.target.result; };
+        reader.readAsDataURL(file);
+      }
+    });
+  }
+
+  if (rotateLeft) rotateLeft.addEventListener('click', () => { rotation = (rotation - 90 + 360) % 360; update(); });
+  if (rotateRight) rotateRight.addEventListener('click', () => { rotation = (rotation + 90) % 360; update(); });
+  if (zoomIn) zoomIn.addEventListener('click', () => { zoom = Math.min(zoom + 0.25, 3); update(); });
+  if (zoomOut) zoomOut.addEventListener('click', () => { zoom = Math.max(zoom - 0.25, 0.5); update(); });
+
+  let dragging = false;
+  let startX, startY;
+
+  if (img) {
+    img.addEventListener('mousedown', (e) => {
+      dragging = true;
+      startX = e.clientX - offsetX;
+      startY = e.clientY - offsetY;
+    });
+    document.addEventListener('mousemove', (e) => {
+      if (dragging) {
+        offsetX = e.clientX - startX;
+        offsetY = e.clientY - startY;
+        update();
+      }
+    });
+    document.addEventListener('mouseup', () => { dragging = false; });
+
+    img.addEventListener('touchstart', (e) => {
+      dragging = true;
+      const t = e.touches[0];
+      startX = t.clientX - offsetX;
+      startY = t.clientY - offsetY;
+    });
+    document.addEventListener('touchmove', (e) => {
+      if (dragging) {
+        const t = e.touches[0];
+        offsetX = t.clientX - startX;
+        offsetY = t.clientY - startY;
+        update();
+      }
+    });
+    document.addEventListener('touchend', () => { dragging = false; });
+  }
+
+  update();
+}
+

--- a/templates/components/photo_cropper.html
+++ b/templates/components/photo_cropper.html
@@ -1,0 +1,22 @@
+{% macro photo_cropper(file_field, rotation_field=None, zoom_field=None, offset_x_field=None, offset_y_field=None, image_url='', id_prefix='photo', size=240) %}
+<div class="text-center">
+  <div id="{{ id_prefix }}-container" class="img-thumbnail shadow-sm mb-2 position-relative overflow-hidden" style="width: {{ size }}px; height: {{ size }}px; border-radius: 1rem;">
+    <img id="{{ id_prefix }}-img" src="{{ image_url }}" style="width:100%; height:100%; object-fit: cover; cursor: move;" alt="Foto">
+  </div>
+  <div class="mt-2" id="{{ id_prefix }}-controls">
+    {{ file_field(class="form-control form-control-sm", id=id_prefix) }}
+    <div class="d-flex justify-content-center gap-2 my-2">
+      <button type="button" id="{{ id_prefix }}-rotate-left" class="btn btn-outline-secondary btn-sm" title="Girar 90° à esquerda"><i class="fas fa-undo"></i></button>
+      <button type="button" id="{{ id_prefix }}-rotate-right" class="btn btn-outline-secondary btn-sm" title="Girar 90° à direita"><i class="fas fa-redo"></i></button>
+      <button type="button" id="{{ id_prefix }}-zoom-out" class="btn btn-outline-secondary btn-sm" title="Diminuir zoom">-</button>
+      <button type="button" id="{{ id_prefix }}-zoom-in" class="btn btn-outline-secondary btn-sm" title="Aumentar zoom">+</button>
+    </div>
+    {% if rotation_field %}{{ rotation_field(class='d-none', id=id_prefix + '-rotation') }}{% endif %}
+    {% if zoom_field %}{{ zoom_field(class='d-none', id=id_prefix + '-zoom') }}{% endif %}
+    {% if offset_x_field %}{{ offset_x_field(class='d-none', id=id_prefix + '-offset-x') }}{% endif %}
+    {% if offset_y_field %}{{ offset_y_field(class='d-none', id=id_prefix + '-offset-y') }}{% endif %}
+  </div>
+</div>
+<script>initPhotoCropper('{{ id_prefix }}');</script>
+{% endmacro %}
+

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -486,6 +486,7 @@
       }
   </script>
   <script src="{{ url_for('static', filename='offline.js') }}"></script>
+  <script src="{{ url_for('static', filename='photo_cropper.js') }}"></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -11,33 +11,8 @@
 
         <!-- Foto -->
         <div class="col-md-4 text-center">
-          {% if current_user.profile_photo %}
-            <div id="photo-container" class="img-thumbnail shadow-sm mb-2 position-relative overflow-hidden" style="width: 240px; height: 240px; border-radius: 1rem;">
-              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" style="width:100%; height:100%; object-fit: cover; cursor: move; transform: translate({{ current_user.photo_offset_x or 0 }}px, {{ current_user.photo_offset_y or 0 }}px) rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});" alt="Foto de {{ current_user.name }}">
-            </div>
-          {% else %}
-            <div class="bg-light border d-flex align-items-center justify-content-center mb-2" style="width: 240px; height: 240px; border-radius: 1rem; font-size: 1.2rem; color: #555;">
-              Sem Foto
-            </div>
-          {% endif %}
-
-          <div id="campo-upload-foto" class="mt-2 d-none">
-            {{ form.profile_photo(class="form-control form-control-sm", id="profile_photo") }}
-            <div class="d-flex justify-content-center gap-2 my-2">
-              <button type="button" id="rotate-left" class="btn btn-outline-secondary btn-sm" title="Girar 90° à esquerda">
-                <i class="fas fa-undo"></i>
-              </button>
-              <button type="button" id="rotate-right" class="btn btn-outline-secondary btn-sm" title="Girar 90° à direita">
-                <i class="fas fa-redo"></i>
-              </button>
-              <button type="button" id="zoom-out" class="btn btn-outline-secondary btn-sm" title="Diminuir zoom">-</button>
-              <button type="button" id="zoom-in" class="btn btn-outline-secondary btn-sm" title="Aumentar zoom">+</button>
-            </div>
-            {{ form.photo_rotation(class="d-none", id="photo_rotation") }}
-            {{ form.photo_zoom(class="d-none", id="photo_zoom") }}
-            {{ form.photo_offset_x(class="d-none", id="photo_offset_x") }}
-            {{ form.photo_offset_y(class="d-none", id="photo_offset_y") }}
-          </div>
+          {% from "components/photo_cropper.html" import photo_cropper %}
+          {{ photo_cropper(form.profile_photo, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, current_user.profile_photo, "profile_photo", 240) }}
         </div>
 
         <!-- Informações -->
@@ -226,90 +201,6 @@ function toggleAll() {
     }
   }
 }
-
-document.addEventListener('DOMContentLoaded', function () {
-  const img = document.getElementById('profile-photo-img');
-  const fileInput = document.getElementById('profile_photo');
-  const rotField = document.getElementById('photo_rotation');
-  const zoomField = document.getElementById('photo_zoom');
-  const offsetXField = document.getElementById('photo_offset_x');
-  const offsetYField = document.getElementById('photo_offset_y');
-  const rotateLeft = document.getElementById('rotate-left');
-  const rotateRight = document.getElementById('rotate-right');
-  const zoomIn = document.getElementById('zoom-in');
-  const zoomOut = document.getElementById('zoom-out');
-
-  let rotation = parseInt(rotField.value || 0, 10);
-  let zoom = parseFloat(zoomField.value || 1);
-  let offsetX = parseFloat(offsetXField.value || 0);
-  let offsetY = parseFloat(offsetYField.value || 0);
-
-  function update() {
-    if (img) {
-      img.style.transform = `translate(${offsetX}px, ${offsetY}px) rotate(${rotation}deg) scale(${zoom})`;
-    }
-    rotField.value = rotation;
-    zoomField.value = zoom.toFixed(2);
-    offsetXField.value = Math.round(offsetX);
-    offsetYField.value = Math.round(offsetY);
-  }
-
-  if (fileInput) {
-    fileInput.addEventListener('change', (e) => {
-      const file = e.target.files[0];
-      if (file) {
-        const reader = new FileReader();
-        reader.onload = ev => {
-          if (img) img.src = ev.target.result;
-        };
-        reader.readAsDataURL(file);
-      }
-    });
-  }
-
-  if (rotateLeft) rotateLeft.addEventListener('click', () => { rotation = (rotation - 90 + 360) % 360; update(); });
-  if (rotateRight) rotateRight.addEventListener('click', () => { rotation = (rotation + 90) % 360; update(); });
-  if (zoomIn) zoomIn.addEventListener('click', () => { zoom = Math.min(zoom + 0.25, 3); update(); });
-  if (zoomOut) zoomOut.addEventListener('click', () => { zoom = Math.max(zoom - 0.25, 0.5); update(); });
-
-  // arrastar para ajustar o corte da foto
-  let dragging = false;
-  let startX, startY;
-
-  if (img) {
-    img.addEventListener('mousedown', (e) => {
-      dragging = true;
-      startX = e.clientX - offsetX;
-      startY = e.clientY - offsetY;
-    });
-    document.addEventListener('mousemove', (e) => {
-      if (dragging) {
-        offsetX = e.clientX - startX;
-        offsetY = e.clientY - startY;
-        update();
-      }
-    });
-    document.addEventListener('mouseup', () => { dragging = false; });
-
-    img.addEventListener('touchstart', (e) => {
-      dragging = true;
-      const t = e.touches[0];
-      startX = t.clientX - offsetX;
-      startY = t.clientY - offsetY;
-    });
-    document.addEventListener('touchmove', (e) => {
-      if (dragging) {
-        const t = e.touches[0];
-        offsetX = t.clientX - startX;
-        offsetY = t.clientY - startY;
-        update();
-      }
-    });
-    document.addEventListener('touchend', () => { dragging = false; });
-  }
-
-  update();
-});
 
 
   function mostrarTodasTransacoes() {


### PR DESCRIPTION
## Summary
- make photo cropper component reusable
- include new JS helper in layout
- replace profile page markup with the new macro

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a650b758832ebe07c7f27ff768ef