### PR TITLE
Fix caching of detached ORM objects

### DIFF
--- a/app.py
+++ b/app.py
@@ -3499,12 +3499,20 @@ def mp_sdk():
 # Caches for frequently requested lists
 @cache
 def list_species():
-    return Species.query.order_by(Species.name).all()
+    """Return a lightweight list of species as dictionaries."""
+    return [
+        {"id": sp.id, "name": sp.name}
+        for sp in Species.query.order_by(Species.name).all()
+    ]
 
 
 @cache
 def list_breeds():
-    return Breed.query.order_by(Breed.name).all()
+    """Return a lightweight list of breeds as dictionaries."""
+    return [
+        {"id": br.id, "name": br.name, "species_id": br.species_id}
+        for br in Breed.query.order_by(Breed.name).all()
+    ]
 
 
 @cache


### PR DESCRIPTION
## Summary
- avoid returning detached SQLAlchemy objects from cached lookups

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ac0d7bc4832e86e65a8529073533