### PR TITLE
Add photo cropper to tutor page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1775,6 +1775,24 @@ def update_tutor(user_id):
         filename = f"{uuid.uuid4().hex}_{secure_filename(photo.filename)}"
         upload_profile_photo_async(user.id, photo.read(), photo.content_type, filename)
 
+    # Controles de corte da foto
+    try:
+        user.photo_rotation = int(request.form.get('photo_rotation', user.photo_rotation or 0))
+    except ValueError:
+        pass
+    try:
+        user.photo_zoom = float(request.form.get('photo_zoom', user.photo_zoom or 1.0))
+    except ValueError:
+        pass
+    try:
+        user.photo_offset_x = float(request.form.get('photo_offset_x', user.photo_offset_x or 0))
+    except ValueError:
+        pass
+    try:
+        user.photo_offset_y = float(request.form.get('photo_offset_y', user.photo_offset_y or 0))
+    except ValueError:
+        pass
+
     # 📍 Endereço
     addr_fields = {
         k: request.form.get(k) or None
@@ -1830,6 +1848,11 @@ def ficha_tutor(tutor_id):
     # Ano atual
     current_year = datetime.now(BR_TZ).year
 
+    # Formulários para usar o photo_cropper no template
+    tutor_form = EditProfileForm(obj=tutor)
+    animal_forms = {a.id: AnimalForm(obj=a) for a in animais}
+    new_animal_form = AnimalForm()
+
     # Busca todas as espécies e raças
     species_list = list_species()
     breeds = Breed.query.options(joinedload(Breed.species)).all()
@@ -1850,7 +1873,10 @@ def ficha_tutor(tutor_id):
         animais=animais,
         current_year=current_year,
         species_list=species_list,
-        breed_map=breed_map
+        breed_map=breed_map,
+        tutor_form=tutor_form,
+        animal_forms=animal_forms,
+        new_animal_form=new_animal_form
     )
 
 
@@ -1924,10 +1950,22 @@ def update_animal(animal_id):
         image_url = upload_to_s3(image_file, filename, folder="animals")
         animal.image = image_url
 
-    animal.photo_rotation = form.photo_rotation.data
-    animal.photo_zoom = form.photo_zoom.data
-    animal.photo_offset_x = form.photo_offset_x.data
-    animal.photo_offset_y = form.photo_offset_y.data
+    try:
+        animal.photo_rotation = int(request.form.get('photo_rotation', animal.photo_rotation or 0))
+    except ValueError:
+        pass
+    try:
+        animal.photo_zoom = float(request.form.get('photo_zoom', animal.photo_zoom or 1.0))
+    except ValueError:
+        pass
+    try:
+        animal.photo_offset_x = float(request.form.get('photo_offset_x', animal.photo_offset_x or 0))
+    except ValueError:
+        pass
+    try:
+        animal.photo_offset_y = float(request.form.get('photo_offset_y', animal.photo_offset_y or 0))
+    except ValueError:
+        pass
 
     db.session.commit()
     flash('Dados do animal atualizados com sucesso!', 'success')

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -1,4 +1,5 @@
 {% extends 'layout.html' %}
+{% from 'components/photo_cropper.html' import photo_cropper %}
 {% block main %}
 <div class="container py-4">
 
@@ -31,6 +32,7 @@
 
 
       <form action="{{ url_for('update_tutor', user_id=tutor.id) }}" method="POST" enctype="multipart/form-data" class="row g-3">
+        {{ tutor_form.hidden_tag() }}
         <div class="col-md-6">
           <label class="form-label">Nome</label>
           <input name="name" class="form-control" value="{{ tutor.name }}" required>
@@ -62,7 +64,7 @@
         </div>
         <div class="col-md-8">
           <label class="form-label">Foto do Tutor</label>
-          <input type="file" name="profile_photo" id="profile_photo" accept="image/*" class="form-control">
+          {{ photo_cropper(tutor_form.profile_photo, tutor_form.photo_rotation, tutor_form.photo_zoom, tutor_form.photo_offset_x, tutor_form.photo_offset_y, tutor.profile_photo, 150, 'profile_photo') }}
         </div>
 
 
@@ -178,6 +180,7 @@
 <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">
     <div class="modal-content">
       <form action="{{ url_for('update_animal', animal_id=a.id) }}" method="POST" enctype="multipart/form-data">
+        {{ animal_forms[a.id].hidden_tag() }}
         <div class="modal-header">
           <h5 class="modal-title">✏️ Editar {{ a.name }}</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
@@ -186,18 +189,7 @@
           <div class="row g-3">
 
             <div class="col-12 text-center">
-              <img id="preview-animal-{{ a.id }}"
-                   src="{{ a.image or '' }}"
-                   alt="Foto do Animal"
-                   class="img-thumbnail {% if not a.image %}d-none{% endif %}"
-                   style="max-height: 150px;">
-            </div>
-
-            <div class="col-12">
-              <label class="form-label">Alterar Foto</label>
-              <input name="image" type="file" accept="image/*"
-                     class="form-control"
-                     onchange="previewAnimalImage(event, '{{ a.id }}')">
+              {{ photo_cropper(animal_forms[a.id].image, animal_forms[a.id].photo_rotation, animal_forms[a.id].photo_zoom, animal_forms[a.id].photo_offset_x, animal_forms[a.id].photo_offset_y, a.image, 150, 'animal-image-' ~ a.id) }}
             </div>
 
             <div class="col-md-6">
@@ -297,6 +289,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <form action="{{ url_for('novo_animal') }}" method="POST" enctype="multipart/form-data">
+        {{ new_animal_form.hidden_tag() }}
         <div class="modal-body">
           <input type="hidden" name="tutor_id" value="{{ tutor.id }}">
 
@@ -355,7 +348,7 @@
             </div>
             <div class="col-md-6">
               <label class="form-label">Foto do Animal</label>
-              <input name="image" type="file" accept="image/*" class="form-control">
+              {{ photo_cropper(new_animal_form.image, new_animal_form.photo_rotation, new_animal_form.photo_zoom, new_animal_form.photo_offset_x, new_animal_form.photo_offset_y, '', 150, 'new-animal-image') }}
             </div>
             <div class="col-12">
               <label class="form-label">Descrição</label>
@@ -421,19 +414,7 @@
     });
   }
 
-  function previewAnimalImage(event, id) {
-    const input = event.target;
-    const file = input.files[0];
-    const preview = document.getElementById('preview-animal-' + id);
-    if (file && preview) {
-      const reader = new FileReader();
-      reader.onload = function (e) {
-        preview.src = e.target.result;
-        preview.classList.remove('d-none');
-      };
-      reader.readAsDataURL(file);
-    }
-  }
+
 
   // ========== ANIMAL: Date <-> Age ==========
   const animalDob = document.getElementById("animal_dob");
@@ -523,22 +504,6 @@
     return new Date(today.getFullYear() - age, today.getMonth(), today.getDate());
   }
 
-  // ========== Foto do Tutor ==========
-  const profileInput = document.getElementById('profile_photo');
-  if (profileInput) {
-    profileInput.addEventListener('change', function (event) {
-      const preview = document.getElementById('preview-tutor');
-      const file = event.target.files[0];
-      if (file && preview) {
-        const reader = new FileReader();
-        reader.onload = function (e) {
-          preview.src = e.target.result;
-          preview.classList.remove('d-none');
-        };
-        reader.readAsDataURL(file);
-      }
-    });
-  }
 </script>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- load forms in `ficha_tutor` for using image cropper
- persist tutor and animal photo options when updating
- replace image inputs on tutor detail page with `photo_cropper`
- remove old preview JS

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ae1c2490832eb6b2099b830390fd