### PR TITLE
Improve photo upload UI with placeholders

### DIFF
--- a/templates/add_animal.html
+++ b/templates/add_animal.html
@@ -99,7 +99,7 @@
 
             <div class="mb-3">
                 {{ form.image.label(class="form-label") }}
-                {{ photo_cropper(form.image, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, '', 150, 'animal_image') }}
+                {{ photo_cropper(form.image, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, '', 150, 'animal_image', 'animal') }}
                 {% for error in form.image.errors %}
                     <div class="invalid-feedback d-block">{{ error }}</div>
                 {% endfor %}

--- a/templates/components/photo_cropper.html
+++ b/templates/components/photo_cropper.html
@@ -1,9 +1,14 @@
 
-{% macro photo_cropper(file_field, rot_field, zoom_field, offset_x_field, offset_y_field, image_url='', size=240, id=None) %}
+{% macro photo_cropper(file_field, rot_field, zoom_field, offset_x_field, offset_y_field, image_url='', size=240, id=None, placeholder_type='user') %}
 {% set id = id or file_field.id %}
+{% if placeholder_type == 'animal' %}
+  {% set placeholder_url = url_for('static', filename='default_animal.png') %}
+{% else %}
+  {% set placeholder_url = url_for('static', filename='default_user.png') %}
+{% endif %}
 <div class="photo-cropper text-center">
   <div id="{{ id }}-container" class="img-thumbnail shadow-sm mb-2 position-relative overflow-hidden" style="width: {{ size }}px; height: {{ size }}px; border-radius: 1rem;">
-    <img id="{{ id }}-img" src="{{ image_url }}" style="width:100%; height:100%; object-fit: cover; cursor: move; {% if not image_url %}display:none;{% endif %} transform: translate({{ offset_x_field.data or 0 }}px, {{ offset_y_field.data or 0 }}px) rotate({{ rot_field.data or 0 }}deg) scale({{ zoom_field.data or 1 }});" alt="Imagem">
+    <img id="{{ id }}-img" src="{{ image_url if image_url else placeholder_url }}" style="width:100%; height:100%; object-fit: cover; cursor: move; {% if not image_url %}opacity:0.6;{% endif %} transform: translate({{ offset_x_field.data or 0 }}px, {{ offset_y_field.data or 0 }}px) rotate({{ rot_field.data or 0 }}deg) scale({{ zoom_field.data or 1 }});" alt="Imagem">
   </div>
   {{ file_field(class='form-control form-control-sm', id=id, accept='image/*') }}
   <div class="d-flex justify-content-center gap-2 my-2">

--- a/templates/partials/animal_form.html
+++ b/templates/partials/animal_form.html
@@ -10,7 +10,7 @@
     <div class="col-md-6">
       <label for="animal-name" class="form-label">Foto e Nome do Animal</label>
         <div class="d-flex align-items-center gap-3">
-          {{ photo_cropper(form.image, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, animal.image, 60, 'animal-image') }}
+          {{ photo_cropper(form.image, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, animal.image, 60, 'animal-image', 'animal') }}
           <input id="animal-name" type="text" name="name" class="form-control"
                  placeholder="Nome do animal" value="{{ animal.name or '' }}" required
                  minlength="2" maxlength="50">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -24,7 +24,7 @@
           {% endif %}
 
           <div id="campo-upload-foto" class="mt-2 d-none">
-            {{ photo_cropper(form.profile_photo, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, current_user.profile_photo, 240, 'profile_photo') }}
+            {{ photo_cropper(form.profile_photo, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, current_user.profile_photo, 240, 'profile_photo', 'user') }}
           </div>
 
         </div>

--- a/templates/register.html
+++ b/templates/register.html
@@ -38,7 +38,7 @@
             <!-- Foto de Perfil -->
             <div class="mb-3">
                 {{ form.profile_photo.label(class="form-label") }}
-                {{ photo_cropper(form.profile_photo, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, '', 120, 'profile_photo') }}
+                {{ photo_cropper(form.profile_photo, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, '', 120, 'profile_photo', 'user') }}
                 {% for error in form.profile_photo.errors %}
                     <div class="text-danger">{{ error }}</div>
                 {% endfor %}

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -64,7 +64,7 @@
         </div>
         <div class="col-md-8">
           <label class="form-label">Foto do Tutor</label>
-          {{ photo_cropper(tutor_form.profile_photo, tutor_form.photo_rotation, tutor_form.photo_zoom, tutor_form.photo_offset_x, tutor_form.photo_offset_y, tutor.profile_photo, 150, 'profile_photo') }}
+          {{ photo_cropper(tutor_form.profile_photo, tutor_form.photo_rotation, tutor_form.photo_zoom, tutor_form.photo_offset_x, tutor_form.photo_offset_y, tutor.profile_photo, 150, 'profile_photo', 'user') }}
         </div>
 
 
@@ -189,7 +189,7 @@
           <div class="row g-3">
 
             <div class="col-12 text-center">
-              {{ photo_cropper(animal_forms[a.id].image, animal_forms[a.id].photo_rotation, animal_forms[a.id].photo_zoom, animal_forms[a.id].photo_offset_x, animal_forms[a.id].photo_offset_y, a.image, 150, 'animal-image-' ~ a.id) }}
+              {{ photo_cropper(animal_forms[a.id].image, animal_forms[a.id].photo_rotation, animal_forms[a.id].photo_zoom, animal_forms[a.id].photo_offset_x, animal_forms[a.id].photo_offset_y, a.image, 150, 'animal-image-' ~ a.id, 'animal') }}
             </div>
 
             <div class="col-md-6">
@@ -348,7 +348,7 @@
             </div>
             <div class="col-md-6">
               <label class="form-label">Foto do Animal</label>
-              {{ photo_cropper(new_animal_form.image, new_animal_form.photo_rotation, new_animal_form.photo_zoom, new_animal_form.photo_offset_x, new_animal_form.photo_offset_y, '', 150, 'new-animal-image') }}
+              {{ photo_cropper(new_animal_form.image, new_animal_form.photo_rotation, new_animal_form.photo_zoom, new_animal_form.photo_offset_x, new_animal_form.photo_offset_y, '', 150, 'new-animal-image', 'animal') }}
             </div>
             <div class="col-12">
               <label class="form-label">Descrição</label>


### PR DESCRIPTION
## Summary
- add default placeholders for users and animals
- update photo cropper macro to use placeholders
- update templates to pass placeholder type
- remove placeholder images from repository to avoid PR failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888b280372c832e80a05e294133ccfd