### PR TITLE
Fix loading spinner persistence on consulta form errors

### DIFF
--- a/static/offline.js
+++ b/static/offline.js
@@ -59,7 +59,8 @@
     if(navigator.onLine){
       try {
         const resp = await fetchWithTimeout(url, opts);
-        if(resp.ok) return resp;
+        // Retorna a resposta mesmo que contenha erro de validação
+        if (resp) return resp;
       } catch(e){ /* fallthrough */ }
     }
     const q = loadQueue();
@@ -86,7 +87,7 @@
     if (resp) {
       let json = null;
       try { json = await resp.json(); } catch(e) {}
-      const evt = new CustomEvent('form-sync-success', {detail: {form, data: json}, cancelable: true});
+      const evt = new CustomEvent('form-sync-success', {detail: {form, data: json, response: resp}, cancelable: true});
       document.dispatchEvent(evt);
       if (!evt.defaultPrevented) {
         location.reload();

--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -246,17 +246,17 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 document.addEventListener('form-sync-success', function(ev) {
-  const {form, data} = ev.detail || {};
+  const {form, data, response} = ev.detail || {};
   if (!form) return;
 
-  // Remove spinner e reativa botão
   const btn = form.querySelector('button[type="submit"]');
   btn?.querySelector('.spinner-border')?.remove();
   if (btn) btn.disabled = false;
 
-  // Destaca a aba relacionada
+  const success = !(data && data.success === false) && (!response || response.ok);
+
   const pane = form.closest('.tab-pane');
-  if (pane && pane.id) {
+  if (success && pane && pane.id) {
     const link = document.querySelector(`[data-bs-target="#${pane.id}"]`);
     if (link) {
       link.classList.add('tab-saved-highlight');
@@ -272,9 +272,10 @@ document.addEventListener('form-sync-success', function(ev) {
     }
     const toastEl = document.getElementById('actionToast');
     if (toastEl) {
-      toastEl.querySelector('.toast-body').textContent = (data && data.message) || 'Consulta salva com sucesso!';
+      const msg = (data && (data.message || data.error)) || 'Consulta salva com sucesso!';
+      toastEl.querySelector('.toast-body').textContent = msg;
       toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
-      toastEl.classList.add('bg-success');
+      toastEl.classList.add(success ? 'bg-success' : 'bg-danger');
       bootstrap.Toast.getOrCreateInstance(toastEl).show();
     }
   }


### PR DESCRIPTION
## Summary
- return server responses from fetchOrQueue even when not `ok`
- include the Response in `form-sync-success` event details
- show an error toast and re-enable the submit button when the consulta form returns a failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b7cc01a8832eb1ed8f7c69ddc08f