### PR TITLE
Enable admin animal deletion

### DIFF
--- a/app.py
+++ b/app.py
@@ -651,7 +651,8 @@ def list_animals():
         species_id=species_id,
         breed_id=breed_id,
         sex=sex,
-        age=age
+        age=age,
+        is_admin=_is_admin()
     )
 
 

--- a/templates/animals.html
+++ b/templates/animals.html
@@ -69,7 +69,16 @@
       {% else %}
         {# renderiza normalmente #}
       <div class="col">
-        <div class="card h-100 shadow-sm border-0 rounded-4 {% if animal.modo == 'perdido' %}border border-danger{% endif %}">
+        <div class="card h-100 shadow-sm border-0 rounded-4 position-relative {% if animal.modo == 'perdido' %}border border-danger{% endif %}">
+          {% if is_admin %}
+          <form method="POST" action="{{ url_for('deletar_animal', animal_id=animal.id) }}"
+                onsubmit="return confirm('Excluir permanentemente este animal?');"
+                class="position-absolute top-0 end-0 m-2">
+            <button type="submit" class="btn btn-sm btn-danger" title="Excluir">
+              ❌
+            </button>
+          </form>
+          {% endif %}
           {% if animal.image %}
           <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 200px; object-fit: cover;" loading="lazy" alt="Imagem de {{ animal.name }}">
           {% endif %}


### PR DESCRIPTION
## Summary
- allow injection of `is_admin` on the animals listing route
- display a red delete button on each animal card for admins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cd66141c832eb42bbe0f34dac557