### PR TITLE
Implement pagination for admin delivery overview

### DIFF
--- a/app.py
+++ b/app.py
@@ -3454,10 +3454,33 @@ def delivery_overview():
         .order_by(DeliveryRequest.id.desc())
     )
 
-    open_requests = base_q.filter_by(status="pendente").all()
-    in_progress   = base_q.filter_by(status="em_andamento").all()
-    completed     = base_q.filter_by(status="concluida").all()
-    canceled      = base_q.filter_by(status="cancelada").all()
+    per_page = 10
+    open_page = request.args.get('open_page', 1, type=int)
+    progress_page = request.args.get('progress_page', 1, type=int)
+    completed_page = request.args.get('completed_page', 1, type=int)
+    canceled_page = request.args.get('canceled_page', 1, type=int)
+
+    open_pagination = (
+        base_q.filter_by(status="pendente")
+              .paginate(page=open_page, per_page=per_page, error_out=False)
+    )
+    progress_pagination = (
+        base_q.filter_by(status="em_andamento")
+              .paginate(page=progress_page, per_page=per_page, error_out=False)
+    )
+    completed_pagination = (
+        base_q.filter_by(status="concluida")
+              .paginate(page=completed_page, per_page=per_page, error_out=False)
+    )
+    canceled_pagination = (
+        base_q.filter_by(status="cancelada")
+              .paginate(page=canceled_page, per_page=per_page, error_out=False)
+    )
+
+    open_requests = open_pagination.items
+    in_progress   = progress_pagination.items
+    completed     = completed_pagination.items
+    canceled      = canceled_pagination.items
 
     # produtos para o bloco de estoque
     products = Product.query.order_by(Product.name).all()
@@ -3469,6 +3492,14 @@ def delivery_overview():
         in_progress   = in_progress,
         completed     = completed,
         canceled      = canceled,
+        open_pagination = open_pagination,
+        progress_pagination = progress_pagination,
+        completed_pagination = completed_pagination,
+        canceled_pagination = canceled_pagination,
+        open_page = open_page,
+        progress_page = progress_page,
+        completed_page = completed_page,
+        canceled_page = canceled_page,
     )
 
 

--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -15,7 +15,7 @@
     {% endfor %}
   </ul>
 
-  {% macro lista(reqs, titulo, cls_badge, lbl_badge) %}
+{% macro lista(reqs, pagination, page_var, titulo, cls_badge, lbl_badge, open_page, progress_page, completed_page, canceled_page) %}
   <h4 class="mt-4 {{ cls_badge }}">{{ titulo }}</h4>
   <ul class="list-group shadow-sm mb-4">
     {% for r in reqs %}
@@ -86,21 +86,31 @@
       <li class="list-group-item text-muted">Não há registros.</li>
     {% endfor %}
   </ul>
-  {% endmacro %}
-
-  <!-- ▸ Listas ----------------------------------------------------------- -->
+  {% if pagination and pagination.has_next %}
+  <div class="text-center mb-4">
+    <a class="btn btn-sm btn-outline-secondary"
+       href="{{ url_for('delivery_overview',
+                        open_page=(pagination.next_num if page_var=='open_page' else open_page),
+                        progress_page=(pagination.next_num if page_var=='progress_page' else progress_page),
+                        completed_page=(pagination.next_num if page_var=='completed_page' else completed_page),
+                        canceled_page=(pagination.next_num if page_var=='canceled_page' else canceled_page) ) }}">
+      Mostrar mais
+    </a>
+  </div>
+  {% endif %}
+{% endmacro %}  <!-- ▸ Listas ----------------------------------------------------------- -->
   <div class="row row-cols-1 row-cols-md-4 g-4">
     <div class="col">
-      {{ lista(open_requests, "🟡 Solicitações Abertas",   "bg-warning text-dark", "Pendente") }}
+      {{ lista(open_requests, open_pagination, 'open_page', "🟡 Solicitações Abertas",   "bg-warning text-dark", "Pendente", open_page, progress_page, completed_page, canceled_page) }}
     </div>
     <div class="col">
-      {{ lista(in_progress,   "🔵 Em Andamento",          "bg-info text-dark",   "Em andamento") }}
+      {{ lista(in_progress, progress_pagination, 'progress_page', "🔵 Em Andamento",          "bg-info text-dark", "Em andamento", open_page, progress_page, completed_page, canceled_page) }}
     </div>
     <div class="col">
-      {{ lista(completed,     "✅ Concluídas",            "bg-success",          "Concluída") }}
+      {{ lista(completed, completed_pagination, 'completed_page', "✅ Concluídas",            "bg-success", "Concluída", open_page, progress_page, completed_page, canceled_page) }}
     </div>
     <div class="col">
-      {{ lista(canceled,      "❌ Canceladas",            "bg-danger",           "Cancelada") }}
+      {{ lista(canceled, canceled_pagination, 'canceled_page', "❌ Canceladas",            "bg-danger", "Cancelada", open_page, progress_page, completed_page, canceled_page) }}
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- paginate delivery request columns in admin dashboard
- add pagination controls to the delivery overview template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f0789c18832e8e3f5f6ee6b76120