### PR TITLE
Add admin animal status controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from PIL import Image
 
 
 from dotenv import load_dotenv
-from flask import Flask, session, send_from_directory, abort
+from flask import Flask, session, send_from_directory, abort, request, jsonify
 from itsdangerous import URLSafeTimedSerializer
 
 # ----------------------------------------------------------------
@@ -1054,6 +1054,30 @@ def deletar_animal(animal_id):
     animal.removido_em = datetime.utcnow()
     db.session.commit()
     flash('Animal marcado como removido. Histórico preservado.', 'success')
+    return redirect(url_for('list_animals'))
+
+
+@app.route('/animal/<int:animal_id>/set_modo', methods=['POST'])
+@login_required
+def set_animal_modo(animal_id):
+    """Allows admins to update the animal availability mode."""
+    if not _is_admin():
+        abort(403)
+
+    animal = Animal.query.get_or_404(animal_id)
+    new_modo = (request.json.get('modo') if request.is_json
+                else request.form.get('modo'))
+
+    allowed = {'doação', 'venda', 'vendido', 'adotado', 'perdido'}
+    if new_modo not in allowed:
+        abort(400)
+
+    animal.modo = new_modo
+    db.session.commit()
+
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(message='Modo atualizado', modo=animal.modo)
+
     return redirect(url_for('list_animals'))
 
 

--- a/templates/animals.html
+++ b/templates/animals.html
@@ -70,6 +70,18 @@
         {# renderiza normalmente #}
       <div class="col">
         <div class="card h-100 shadow-sm border-0 rounded-4 position-relative {% if animal.modo == 'perdido' %}border border-danger{% endif %}">
+          {% if is_admin %}
+          <div class="position-absolute top-0 end-0 m-2 dropdown">
+            <button class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">⚙</button>
+            <ul class="dropdown-menu">
+              <li><a class="dropdown-item change-modo" href="#" data-animal-id="{{ animal.id }}" data-modo="doação">Doação</a></li>
+              <li><a class="dropdown-item change-modo" href="#" data-animal-id="{{ animal.id }}" data-modo="venda">Venda</a></li>
+              <li><a class="dropdown-item change-modo" href="#" data-animal-id="{{ animal.id }}" data-modo="vendido">Vendido</a></li>
+              <li><a class="dropdown-item change-modo" href="#" data-animal-id="{{ animal.id }}" data-modo="adotado">Adotado</a></li>
+              <li><a class="dropdown-item change-modo" href="#" data-animal-id="{{ animal.id }}" data-modo="perdido">Perdido</a></li>
+            </ul>
+          </div>
+          {% endif %}
 
           {% if animal.image %}
           <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 200px; object-fit: cover;" loading="lazy" alt="Imagem de {{ animal.name }}">
@@ -246,6 +258,22 @@
     if (!form) return;
     form.querySelectorAll('select,input').forEach(el => {
       el.addEventListener('change', () => form.submit());
+    });
+
+    document.querySelectorAll('.change-modo').forEach(el => {
+      el.addEventListener('click', evt => {
+        evt.preventDefault();
+        fetch(`/animal/${el.dataset.animalId}/set_modo`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: JSON.stringify({modo: el.dataset.modo})
+        }).then(res => {
+          if (res.ok) window.location.reload();
+        });
+      });
     });
   });
 </script>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1284,3 +1284,33 @@ def test_update_tutor_profile_photo(monkeypatch, app):
         )
         assert resp.status_code == 200
         assert User.query.get(tutor.id).profile_photo == 'http://img'
+
+
+def test_admin_can_update_animal_modo(monkeypatch, app):
+    client = app.test_client()
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        admin = User(id=1, name='Admin', email='admin@test', role='admin')
+        admin.set_password('x')
+        animal = Animal(id=1, name='Dog', modo='doação', user_id=1)
+        db.session.add_all([admin, animal])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: admin)
+        monkeypatch.setattr(app_module, '_is_admin', lambda: True)
+
+        for idx, fn in enumerate(flask_app.template_context_processors[None]):
+            if fn.__name__ == 'inject_unread_count':
+                flask_app.template_context_processors[None][idx] = lambda: {'unread_messages': 0}
+
+        resp = client.post(
+            '/animal/1/set_modo',
+            json={'modo': 'perdido'},
+            headers={'Accept': 'application/json'}
+        )
+        assert resp.status_code == 200
+        assert Animal.query.get(1).modo == 'perdido'


### PR DESCRIPTION
## Summary
- let admins update an animal's `modo`
- expose dropdown in animal cards
- test admin update logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a3a1620dc832eb9f3c637fd7f0d75