### PR TITLE
Align product detail cart form with site standard

### DIFF
--- a/app.py
+++ b/app.py
@@ -3747,7 +3747,7 @@ def produto_detail(product_id):
 
     update_form = ProductUpdateForm(obj=product, prefix='upd')
     photo_form = ProductPhotoForm(prefix='photo')
-    cart_form = AddToCartForm(prefix='cart')
+    form = AddToCartForm()
 
     if _is_admin():
         if update_form.validate_on_submit() and update_form.submit.data:
@@ -3781,7 +3781,7 @@ def produto_detail(product_id):
         product=product,
         update_form=update_form,
         photo_form=photo_form,
-        cart_form=cart_form,
+        form=form,
         is_admin=_is_admin(),
     )
 

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -15,8 +15,8 @@
       <p>{{ product.description }}</p>
       <p class="h4 text-success">R$ {{ '%.2f'|format(product.price)|replace('.', ',') }}</p>
       <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}" method="post" class="d-flex align-items-center gap-2 js-cart-form">
-        {{ cart_form.hidden_tag() }}
-        {{ cart_form.quantity(class="form-control w-auto", min="1") }}
+        {{ form.hidden_tag() }}
+        {{ form.quantity(class="form-control w-auto", min="1") }}
         <button type="submit" class="btn btn-primary">Adicionar ao Carrinho</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- Use default `AddToCartForm` on product detail page
- Update product detail template to match sitewide cart form naming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68908d04a494832e993aa68a7183d37b