### PR TITLE
Add navigation buttons to product detail page

### DIFF
--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -19,6 +19,10 @@
         {{ form.quantity(class="form-control w-auto", min="1") }}
         <button type="submit" class="btn btn-primary">Adicionar ao Carrinho</button>
       </form>
+      <div class="mt-3">
+        <a href="{{ url_for('loja') }}" class="btn btn-outline-secondary me-2">Continuar comprando</a>
+        <a href="{{ url_for('ver_carrinho') }}" class="btn btn-outline-primary">Ir ao carrinho</a>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- add buttons on product page to continue shopping or view cart

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890955cb6b8832e96382a234818c6d4