### PR TITLE
Add continue shopping button on cart page

### DIFF
--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -59,6 +59,9 @@
     </div>
 
 
+    <a href="{{ url_for('loja') }}" class="btn btn-outline-primary me-2">
+      <i class="bi bi-shop-window"></i> Continuar comprando
+    </a>
     <button type="submit" class="btn btn-lg btn-success shadow-sm">
       <i class="bi bi-cash-stack"></i> {{ form.submit.label.text }}
     </button>


### PR DESCRIPTION
## Summary
- add a "Continuar comprando" button to the cart page so users can go back to the store

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689095e9b1a0832eb2ab36aff120192b