### PR TITLE
Restore Flask-Admin assets on admin pages

### DIFF
--- a/templates/admin/master.html
+++ b/templates/admin/master.html
@@ -16,6 +16,9 @@
   <!-- Font Awesome 6 -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
+  <!-- Flask-Admin select2 styles -->
+  <link rel="stylesheet" href="{{ url_for('painel_admin.static', filename='vendor/select2/select2.min.css') }}">
+
   <style>
     :root {
       --primary-color: #4e73df;
@@ -461,11 +464,20 @@
     {% endblock %}
   </div>
 
-  <!-- Bootstrap JS -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- jQuery and Flask-Admin dependencies -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('painel_admin.static', filename='vendor/moment.min.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='vendor/select2/select2.min.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='admin/js/helpers.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='admin/js/actions.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='admin/js/bs4_modal.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='admin/js/bs4_filters.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='admin/js/filters.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='admin/js/form.js') }}"></script>
 
-  <!-- Custom JS -->
-  <script>
+    <!-- Custom JS -->
+    <script>
     document.addEventListener('DOMContentLoaded', () => {
       // Toggle sidebar collapse
       const toggleSidebar = document.querySelector('.toggle-sidebar');


### PR DESCRIPTION
## Summary
- load Flask-Admin vendor CSS and scripts via `painel_admin` static blueprint

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890a9838084832eac3d64c35fa1d2a1