### PR TITLE
Padroniza textos para português

### DIFF
--- a/templates/add_animal.html
+++ b/templates/add_animal.html
@@ -59,7 +59,7 @@
 
             <div class="mb-3">
                 {{ form.date_of_birth.label(class="form-label") }}
-                {{ form.date_of_birth(class="form-control rounded-pill" + (" is-invalid" if form.date_of_birth.errors else ""), id="date_of_birth") }}
+                {{ form.date_of_birth(class="form-control rounded-pill" + (" is-invalid" if form.date_of_birth.errors else ""), id="date_of_birth", lang="pt-BR", placeholder="dd/mm/aaaa") }}
                 {% for error in form.date_of_birth.errors %}
                     <div class="invalid-feedback d-block">{{ error }}</div>
                 {% endfor %}

--- a/templates/editar_animal.html
+++ b/templates/editar_animal.html
@@ -28,7 +28,7 @@
     </select>
 
     {{ form.age.label(class="mt-2") }} {{ form.age(class="form-control", id="age") }}
-    {{ form.date_of_birth.label(class="mt-2") }} {{ form.date_of_birth(class="form-control", id="date_of_birth") }}
+    {{ form.date_of_birth.label(class="mt-2") }} {{ form.date_of_birth(class="form-control", id="date_of_birth", lang="pt-BR", placeholder="dd/mm/aaaa") }}
     {{ form.sex.label(class="mt-2") }} {{ form.sex(class="form-select") }}
     {{ form.description.label(class="mt-2") }} {{ form.description(class="form-control") }}
     {{ form.image.label(class="mt-2") }}

--- a/templates/loja.html
+++ b/templates/loja.html
@@ -4,7 +4,7 @@
   <!-- Header Section -->
   <div class="text-center mb-4 mb-lg-5">
     <h1 class="display-5 fw-bold mb-3 text-primary">
-      <i class="bi bi-shop-window me-2"></i>PetOrlândia Store
+      <i class="bi bi-shop-window me-2"></i>Loja PetOrlândia
     </h1>
     <p class="lead text-muted max-w-800 mx-auto">
       Os melhores produtos para o seu pet com entrega rápida e atendimento especializado!

--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -54,7 +54,7 @@
       </div>
       <div class="col-md-6">
         <label class="form-label">Data de Nascimento</label>
-        <input type="date" name="date_of_birth" id="date_of_birth" class="form-control">
+        <input type="date" name="date_of_birth" id="date_of_birth" class="form-control" lang="pt-BR" placeholder="dd/mm/aaaa">
       </div>
       <div class="col-md-6">
         <label class="form-label">Idade (anos)</label>

--- a/test.py
+++ b/test.py
@@ -43,8 +43,8 @@ if response["status"] == 201:
     pref = response["response"]
     print("✅ Preference criada!")
     print("pref_id:", pref["id"])
-    print("Checkout PROD:", pref["init_point"])
-    print("Checkout SANDBOX:", pref["sandbox_init_point"])
+    print("Pagamento PROD:", pref["init_point"])
+    print("Pagamento SANDBOX:", pref["sandbox_init_point"])
 else:
     print("❌ Erro HTTP", response["status"])
     pprint(response)


### PR DESCRIPTION
## Resumo
- Ajusta campo de data do cadastro de animais para formato `dd/mm/aaaa`
- Troca termos em inglês por português na loja e script de teste

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d299b9e4832eb8e3cc8ef2b49ded