### PR TITLE
Add confirmation modal and feedback for actions

### DIFF
--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -165,13 +165,13 @@
       <div id="opcoes-falecimento" class="mt-3 d-none">
 
         <!-- Falecido agora -->
-        <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}" class="mb-2 js-animal-status">
+        <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}" class="mb-2 js-animal-status js-confirm" data-message="Deseja marcar {{ animal.name }} como falecido agora?">
           <input type="hidden" name="falecimento_em" value="">
           <button class="btn btn-dark btn-sm" type="submit">✅ Falecido agora</button>
         </form>
 
         <!-- Escolher data -->
-        <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}" class="js-animal-status">
+        <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}" class="js-animal-status js-confirm" data-message="Deseja marcar {{ animal.name }} como falecido?">
           <div class="mb-2">
             <label for="falecimento_em" class="form-label mb-1">Data e hora do falecimento:</label>
             <input type="datetime-local" name="falecimento_em" id="falecimento_em" class="form-control form-control-sm">
@@ -181,9 +181,7 @@
       </div>
 
       <!-- Botão: Arquivar definitivamente -->
-      <form method="POST" action="{{ url_for('arquivar_animal', animal_id=animal.id) }}"
-            onsubmit="return confirm('Tem certeza que deseja excluir este animal permanentemente?');"
-            class="mt-3 js-animal-status">
+      <form method="POST" action="{{ url_for('arquivar_animal', animal_id=animal.id) }}" class="mt-3 js-animal-status js-confirm" data-message="Tem certeza que deseja excluir este animal permanentemente?">
         <button class="btn btn-outline-danger btn-sm" type="submit">
           🗑️ Deletar definitivamente
         </button>
@@ -201,14 +199,12 @@
     </div>
 
     {% if current_user.worker == 'veterinario' %}
-      <form method="POST" action="{{ url_for('reverter_falecimento', animal_id=animal.id) }}" class="js-animal-status">
+      <form method="POST" action="{{ url_for('reverter_falecimento', animal_id=animal.id) }}" class="js-animal-status js-confirm" data-message="Deseja reverter o falecimento de {{ animal.name }}?">
         <button class="btn btn-sm btn-outline-success">↩️ Reverter Falecimento</button>
       </form>
 
       <!-- Botão: Arquivar definitivamente -->
-      <form method="POST" action="{{ url_for('arquivar_animal', animal_id=animal.id) }}"
-            onsubmit="return confirm('Tem certeza que deseja excluir este animal permanentemente?');"
-            class="ms-2 js-animal-status">
+      <form method="POST" action="{{ url_for('arquivar_animal', animal_id=animal.id) }}" class="ms-2 js-animal-status js-confirm" data-message="Tem certeza que deseja excluir este animal permanentemente?">
         <button class="btn btn-outline-danger btn-sm" type="submit">
           🗑️ Deletar definitivamente
         </button>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -448,6 +448,21 @@
     <footer>
         &copy; Lucas Marcelino • PetOrlândia 2025 <i class="fas fa-paw text-primary"></i>
     </footer>
+    <div class="modal fade" id="confirmModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Confirmação</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                </div>
+                <div class="modal-body"></div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" class="btn btn-primary" id="confirmModalOk">Confirmar</button>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
         <div id="actionToast" class="toast text-white border-0" role="alert" aria-live="assertive" aria-atomic="true">
@@ -471,6 +486,45 @@
                     }, 600); // tempo igual ao CSS
                 });
             }, 3000); // aparece por 3 segundos
+        });
+    </script>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const flashMessages = {{ flash_messages|tojson }};
+            flashMessages.forEach(([category, message], idx) => {
+                setTimeout(() => {
+                    const toastEl = document.getElementById('actionToast');
+                    toastEl.querySelector('.toast-body').textContent = message;
+                    toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+                    toastEl.classList.add('bg-' + (category || 'success'));
+                    new bootstrap.Toast(toastEl).show();
+                }, idx * 1000);
+            });
+
+            const confirmModalEl = document.getElementById('confirmModal');
+            const confirmModal = new bootstrap.Modal(confirmModalEl);
+            const confirmBtn = document.getElementById('confirmModalOk');
+            let confirmTarget = null;
+
+            document.querySelectorAll('form.js-confirm').forEach(form => {
+                form.addEventListener('submit', ev => {
+                    if (form.dataset.confirmed) { return; }
+                    ev.preventDefault();
+                    confirmTarget = form;
+                    const msg = form.dataset.message || 'Tem certeza?';
+                    confirmModalEl.querySelector('.modal-body').textContent = msg;
+                    confirmModal.show();
+                });
+            });
+
+            confirmBtn.addEventListener('click', () => {
+                if (confirmTarget) {
+                    confirmTarget.dataset.confirmed = 'true';
+                    confirmTarget.submit();
+                }
+                confirmModal.hide();
+            });
         });
     </script>
 


### PR DESCRIPTION
## Summary
- Show flash messages as Bootstrap toasts and add reusable confirmation modal
- Require confirmation before changing animal status, with success toast

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d2b410c8832eadf711900182e785