### PR TITLE
Hide inactive feature modules on animal profile

### DIFF
--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -134,17 +134,6 @@
 
 
 
-
-
-  <!-- FUNCIONALIDADES FUTURAS -->
-  <div class="card shadow-sm p-4 mb-4">
-    <h5 class="text-muted mb-3"><i class="bi bi-tools"></i> Funcionalidades Futuras</h5>
-    <ul class="list-unstyled">
-      <li><strong>🛍️ Histórico de Compras:</strong> <span class="text-muted">Função em breve 🛠️</span></li>
-      <li><strong>🧼 Banhos e Tosa:</strong> <span class="text-muted">Função em breve 🛠️</span></li>
-    </ul>
-  </div>
-
   <!-- VOLTAR -->
   <h3>Ficha de {{ animal.name }}</h3>
   <p><strong>Tutor:</strong>


### PR DESCRIPTION
## Summary
- remove "Funcionalidades Futuras" block from animal profile page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d413ed98832eaa29c69dd714dd59