### PR TITLE
Add Mercado Pago callback status page with delivery and address options

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -259,6 +259,12 @@ class CheckoutForm(FlaskForm):
     submit = SubmitField('Finalizar Compra')
 
 
+class EditAddressForm(FlaskForm):
+    """Formulário simples para atualizar o endereço de entrega de um pedido."""
+    shipping_address = TextAreaField('Endereço', validators=[DataRequired(), Length(max=200)])
+    submit = SubmitField('Salvar')
+
+
 class ProductUpdateForm(FlaskForm):
     name = StringField('Nome', validators=[DataRequired()])
     description = TextAreaField('Descrição')

--- a/templates/edit_address.html
+++ b/templates/edit_address.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container my-5 d-flex justify-content-center">
+  <div class="col-lg-6 bg-white shadow rounded-4 p-5 border">
+    <h2 class="fw-bold mb-3 text-center">Editar Endereço</h2>
+    <form method="post">
+      {{ form.hidden_tag() }}
+      <div class="mb-3">
+        {{ form.shipping_address.label(class="form-label") }}
+        {{ form.shipping_address(class="form-control", rows="3") }}
+      </div>
+      <div class="text-end">
+        <button type="submit" class="btn btn-primary">Salvar</button>
+        {% if payment_id %}
+        <a href="{{ url_for('payment_status', payment_id=payment_id) }}" class="btn btn-outline-secondary">Cancelar</a>
+        {% else %}
+        <a href="{{ url_for('loja') }}" class="btn btn-outline-secondary">Cancelar</a>
+        {% endif %}
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/payment_status.html
+++ b/templates/payment_status.html
@@ -44,6 +44,9 @@
       {% endfor %}
     </ul>
     <p class="text-end fw-bold">Total: R$ {{ '%.2f'|format((payment.__dict__.get('amount') or order.total_value())) }}</p>
+    {% if delivery_estimate %}
+    <p class="text-muted text-end">Previsão de entrega: {{ delivery_estimate|format_datetime_brazil('%d/%m/%Y') }}</p>
+    {% endif %}
     {% endif %}
 
     <div class="d-flex justify-content-center flex-wrap gap-3">
@@ -62,6 +65,21 @@
      class="btn btn-primary">
      <i class="bi bi-truck me-1"></i> Acompanhar pedido
   </a>
+{% endif %}
+
+{% if edit_address_url %}
+  <a href="{{ edit_address_url }}" class="btn btn-outline-primary">
+    <i class="bi bi-pencil me-1"></i> Editar endereço
+  </a>
+{% endif %}
+
+{% if cancel_url %}
+  <form action="{{ cancel_url }}" method="post" class="m-0">
+    {{ form.hidden_tag() }}
+    <button type="submit" class="btn btn-outline-danger">
+      <i class="bi bi-x-circle me-1"></i> Cancelar pedido
+    </button>
+  </form>
 {% endif %}
 
 


### PR DESCRIPTION
## Summary
- show Mercado Pago payment status page after callback, clearing session and exposing delivery estimate, cancel, and address edit actions
- add simple address edit form and page so users can update shipping after payment
- adjust tests to assert order summary and delivery forecast in payment status page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d8b2b3ec832e9eea029c7ea50238