### PR TITLE
Add buyer actions to order detail

### DIFF
--- a/app.py
+++ b/app.py
@@ -4644,6 +4644,10 @@ def pedido_detail(order_id):
     else:
         abort(403)
 
+    form = CheckoutForm()
+    edit_address_url = url_for("edit_order_address", order_id=order.id)
+    cancel_url = url_for("buyer_cancel_delivery", req_id=req.id) if req else None
+
     return render_template(
         "delivery_detail.html",
         req=req,
@@ -4652,7 +4656,10 @@ def pedido_detail(order_id):
         buyer=buyer,
         delivery_worker=delivery_worker,
         total=total,
-        role=role
+        role=role,
+        form=form,
+        edit_address_url=edit_address_url,
+        cancel_url=cancel_url,
     )
 
 

--- a/templates/delivery_detail.html
+++ b/templates/delivery_detail.html
@@ -142,5 +142,21 @@
   </div>
   {% endif %}
 
+  {% if role == 'buyer' %}
+  <div class="d-flex justify-content-center gap-3 mt-4">
+    <a href="{{ edit_address_url }}" class="btn btn-outline-primary">
+      <i class="bi bi-pencil me-1"></i> Editar endereço
+    </a>
+    {% if cancel_url %}
+    <form action="{{ cancel_url }}" method="post" class="m-0">
+      {{ form.hidden_tag() }}
+      <button type="submit" class="btn btn-outline-danger">
+        <i class="bi bi-x-circle me-1"></i> Cancelar pedido
+      </button>
+    </form>
+    {% endif %}
+  </div>
+  {% endif %}
+
 </div>
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -302,6 +302,74 @@ def test_pedido_detail_forbidden(monkeypatch, app):
         assert response.status_code == 403
 
 
+def test_pedido_detail_buttons_for_buyer(monkeypatch, app):
+    client = app.test_client()
+
+    class FakeProduct:
+        price = 10.0
+        name = 'P'
+        image_url = None
+
+    class FakeItem:
+        product = FakeProduct()
+        quantity = 1
+
+    class FakeReq:
+        id = 5
+        status = 'pendente'
+        requested_at = datetime.utcnow()
+        accepted_at = None
+        completed_at = None
+        canceled_at = None
+        worker = None
+
+    class FakeBuyer:
+        id = 1
+        name = 'Buyer'
+        email = 'b@example.com'
+
+    class FakeOrderObj:
+        id = 1
+        user_id = 1
+        created_at = datetime.utcnow()
+        items = [FakeItem()]
+        payment = None
+        delivery_requests = [FakeReq()]
+        user = FakeBuyer()
+        shipping_address = 'Rua'
+        def total_value(self):
+            return 10.0
+
+    class FakeQuery:
+        def options(self, *a, **k):
+            return self
+        def get_or_404(self, _):
+            return FakeOrderObj()
+
+    with app.app_context():
+        monkeypatch.setattr(Order, 'query', FakeQuery())
+        class FakeMsgQuery:
+            def filter_by(self, **kwargs):
+                return self
+            def count(self):
+                return 0
+        monkeypatch.setattr(Message, 'query', FakeMsgQuery())
+        import flask_login.utils as login_utils
+        class FakeUser:
+            is_authenticated = True
+            id = 1
+            worker = None
+            name = 'Buyer'
+            role = 'buyer'
+        monkeypatch.setattr(login_utils, '_get_user', lambda: FakeUser())
+        monkeypatch.setattr(app_module, '_is_admin', lambda: False)
+
+        response = client.get('/pedido/1')
+        html = response.get_data(as_text=True)
+        assert 'Editar endereço' in html
+        assert 'Cancelar pedido' in html
+
+
 def test_cart_quantity_updates(monkeypatch, app):
     client = app.test_client()
 


### PR DESCRIPTION
## Summary
- Allow buyers to edit order address or cancel from order detail page
- Display corresponding buttons on `/pedido/<order_id>`
- Test coverage for buyer options in order detail

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e4379404832e8d0271b721726115