### PR TITLE
Hide cancel button after order cancellation

### DIFF
--- a/app.py
+++ b/app.py
@@ -4536,7 +4536,11 @@ def payment_status(payment_id):
     if order and order.created_at:
         delivery_estimate = order.created_at + timedelta(days=5)
 
-    cancel_url = url_for('buyer_cancel_delivery', req_id=delivery_req.id) if delivery_req else None
+    cancel_url = (
+        url_for('buyer_cancel_delivery', req_id=delivery_req.id)
+        if delivery_req and delivery_req.status not in ['cancelada', 'concluida']
+        else None
+    )
     edit_address_url = url_for('edit_order_address', order_id=payment.order_id) if order else None
 
     return render_template(
@@ -4646,7 +4650,11 @@ def pedido_detail(order_id):
 
     form = CheckoutForm()
     edit_address_url = url_for("edit_order_address", order_id=order.id)
-    cancel_url = url_for("buyer_cancel_delivery", req_id=req.id) if req else None
+    cancel_url = (
+        url_for("buyer_cancel_delivery", req_id=req.id)
+        if req and req.status not in ['cancelada', 'concluida']
+        else None
+    )
 
     return render_template(
         "delivery_detail.html",


### PR DESCRIPTION
## Summary
- hide cancel button when delivery request is already cancelled or completed
- show cancelled status in purchase list
- test cancel button visibility and cancelled status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891f080ef98832e8480cb0abc58554d