### PR TITLE
Add archiving for delivery requests

### DIFF
--- a/migrations/versions/8a0f9b6f2add_add_archived_to_delivery_request.py
+++ b/migrations/versions/8a0f9b6f2add_add_archived_to_delivery_request.py
@@ -1,0 +1,25 @@
+"""
+Add archived flag to delivery requests
+
+Revision ID: 8a0f9b6f2add
+Revises: 6ec5a8a3dea4
+Create Date: 2024-08-25 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '8a0f9b6f2add'
+down_revision = '6ec5a8a3dea4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('delivery_request', sa.Column('archived', sa.Boolean(), nullable=False, server_default='0'))
+    op.alter_column('delivery_request', 'archived', server_default=None)
+
+
+def downgrade():
+    op.drop_column('delivery_request', 'archived')

--- a/models.py
+++ b/models.py
@@ -783,6 +783,7 @@ class DeliveryRequest(db.Model):
         db.ForeignKey('user.id', ondelete='SET NULL'),
         nullable=True,
     )
+    archived = db.Column(db.Boolean, default=False, nullable=False)
 
     order = db.relationship('Order', backref='delivery_requests')
     requested_by = db.relationship(

--- a/templates/admin/delivery_archive.html
+++ b/templates/admin/delivery_archive.html
@@ -1,0 +1,28 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container my-4">
+  <h4 class="mb-3">📁 Entregas Arquivadas</h4>
+  <ul class="list-group shadow-sm mb-4">
+    {% for r in requests %}
+      {% set ord = r.order %}
+      <li class="list-group-item d-flex justify-content-between flex-column flex-md-row align-items-start align-items-md-center">
+        <div class="me-3">
+          <div class="fw-semibold">Pedido #{{ r.order_id }}</div>
+          <div class="small text-muted">
+            <div>Status: {{ r.status }}</div>
+            <div>Cliente: {{ ord.user.name if ord and ord.user else "—" }}</div>
+          </div>
+        </div>
+        <div class="d-flex flex-wrap gap-1 mt-2 mt-md-0">
+          <a href="{{ url_for('admin_delivery_detail', req_id=r.id) }}" class="btn btn-sm btn-outline-primary">Ver detalhes</a>
+          <form action="{{ url_for('admin_unarchive_delivery', req_id=r.id) }}" method="post" class="js-admin-delivery-form">
+            <button class="btn btn-sm btn-outline-secondary" title="Desarquivar">Desarquivar</button>
+          </form>
+        </div>
+      </li>
+    {% else %}
+      <li class="list-group-item text-muted">Não há registros.</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -80,6 +80,9 @@
           <form action="{{ url_for('admin_delete_delivery', req_id=r.id) }}" method="post" onsubmit="return confirm('Excluir pedido?');" class="js-admin-delivery-form">
             <button class="btn btn-sm btn-outline-danger" title="Excluir">Excluir</button>
           </form>
+          <form action="{{ url_for('admin_archive_delivery', req_id=r.id) }}" method="post" class="js-admin-delivery-form">
+            <button class="btn btn-sm btn-outline-secondary" title="Arquivar">Arquivar</button>
+          </form>
         </div>
       </li>
     {% else %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -348,6 +348,11 @@
                             <i class="fas fa-chart-line me-1 text-primary"></i> Entregas
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('delivery_archive') }}">
+                            <i class="fas fa-archive me-1 text-secondary"></i> Arquivadas
+                            </a>
+                        </li>
                     {% endif %}
                     
                     <li class="nav-item">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1457,3 +1457,33 @@ def test_update_tutor_profile_photo(monkeypatch, app):
         )
         assert resp.status_code == 200
         assert User.query.get(tutor.id).profile_photo == 'http://img'
+
+
+def test_archive_and_unarchive_delivery(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(id=1, name='Admin', email='a@a', password_hash='x', role='admin')
+        db.session.add(admin)
+        order = Order(id=1, user_id=1, created_at=datetime.utcnow())
+        db.session.add(order)
+        req = DeliveryRequest(id=1, order_id=1, requested_by_id=1)
+        db.session.add(req)
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: admin)
+        monkeypatch.setattr(app_module, '_is_admin', lambda: True)
+
+        client.post('/admin/delivery_requests/1/archive')
+        assert DeliveryRequest.query.get(1).archived is True
+
+        resp = client.get('/admin/delivery_overview')
+        assert b'Pedido #1' not in resp.data
+
+        resp = client.get('/admin/delivery_archive')
+        assert b'Pedido #1' in resp.data
+
+        client.post('/admin/delivery_requests/1/unarchive')
+        assert DeliveryRequest.query.get(1).archived is False


### PR DESCRIPTION
## Summary
- add `archived` flag to delivery requests with migration
- expose admin routes and UI to archive/unarchive deliveries
- show archived deliveries on a dedicated page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891f3f07670832e8611bf436ac1e0bf