### PR TITLE
Move archived deliveries link into delivery overview

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -117,5 +117,11 @@
     </div>
   </div>
 
+  <div class="text-center mt-4">
+    <a class="btn btn-outline-secondary" href="{{ url_for('delivery_archive') }}">
+      <i class="fas fa-archive me-1"></i> Arquivadas: pedidos arquivados
+    </a>
+  </div>
+
 </div>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -348,11 +348,6 @@
                             <i class="fas fa-chart-line me-1 text-primary"></i> Entregas
                             </a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('delivery_archive') }}">
-                            <i class="fas fa-archive me-1 text-secondary"></i> Arquivadas
-                            </a>
-                        </li>
                     {% endif %}
                     
                     <li class="nav-item">


### PR DESCRIPTION
## Summary
- remove "Arquivadas" admin nav link from layout
- add archived deliveries button at bottom of admin delivery overview

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891f87105a4832eb6206ce4fc15ad19