### PR TITLE
Hide archived deliveries on user page

### DIFF
--- a/templates/delivery_archive.html
+++ b/templates/delivery_archive.html
@@ -1,0 +1,26 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container my-4">
+  <h4 class="mb-3">📁 Entregas Arquivadas</h4>
+  <ul class="list-group shadow-sm mb-4">
+    {% for r in requests %}
+      {% set ord = r.order %}
+      <li class="list-group-item d-flex justify-content-between flex-column flex-md-row align-items-start align-items-md-center">
+        <div class="me-3">
+          <div class="fw-semibold">Pedido #{{ r.order_id }}</div>
+          <div class="small text-muted">
+            <div>Status: {{ r.status }}</div>
+            {% if ord and ord.user %}<div>Cliente: {{ ord.user.name }}</div>{% endif %}
+          </div>
+        </div>
+        <a href="{{ url_for('delivery_detail', req_id=r.id) }}" class="btn btn-sm btn-outline-primary mt-2 mt-md-0">Ver detalhes</a>
+      </li>
+    {% else %}
+      <li class="list-group-item text-muted">Não há registros.</li>
+    {% endfor %}
+  </ul>
+  <div class="text-center">
+    <a class="btn btn-outline-secondary" href="{{ url_for('list_delivery_requests') }}">Voltar</a>
+  </div>
+</div>
+{% endblock %}

--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -150,6 +150,12 @@
     </div>
 
   </div><!-- /accordion -->
+
+  <div class="text-center mt-4">
+    <a class="btn btn-outline-secondary" href="{{ url_for('delivery_archive_user') }}">
+      <i class="fas fa-archive me-1"></i> Arquivadas: pedidos arquivados
+    </a>
+  </div>
 </div>
 <script>
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- hide admin-archived deliveries from /delivery_requests and counts API
- add archive page and navigation button for users
- cover behaviour with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689212857100832e9e6f066c4ca75f42