### PR TITLE
Add back button to delivery archive

### DIFF
--- a/templates/admin/delivery_archive.html
+++ b/templates/admin/delivery_archive.html
@@ -24,5 +24,8 @@
       <li class="list-group-item text-muted">Não há registros.</li>
     {% endfor %}
   </ul>
+  <div class="text-center">
+    <a class="btn btn-outline-secondary" href="{{ url_for('delivery_overview') }}">Voltar</a>
+  </div>
 </div>
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1484,6 +1484,8 @@ def test_archive_and_unarchive_delivery(monkeypatch, app):
 
         resp = client.get('/admin/delivery_archive')
         assert b'Pedido #1' in resp.data
+        assert b'Voltar' in resp.data
+        assert b'href="/admin/delivery_overview"' in resp.data
 
         client.post('/admin/delivery_requests/1/unarchive')
         assert DeliveryRequest.query.get(1).archived is False


### PR DESCRIPTION
## Summary
- add "Voltar" button to admin delivery archive page
- test delivery archive renders a back link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689216ff8660832e98e8d83e94301571