### PR TITLE
Enable real-time delivery tracking on admin page

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -147,18 +147,44 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const locations = {{ worker_locations|tojson }};
+      const mapEl = document.getElementById('workersMap');
       if (!locations.length) {
-        const el = document.getElementById('workersMap');
-        if (el) el.style.display = 'none';
+        if (mapEl) mapEl.style.display = 'none';
         return;
       }
       const map = L.map('workersMap');
-      const coords = locations.map(l => [l.lat, l.lng]);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenStreetMap contributors'
       }).addTo(map);
-      coords.forEach(c => L.marker(c).addTo(map));
-      map.fitBounds(coords, { padding: [20, 20] });
+      const markers = {};
+      locations.forEach(l => {
+        markers[l.id] = L.marker([l.lat, l.lng]).addTo(map);
+      });
+      const fit = () => {
+        const pts = Object.values(markers).map(m => m.getLatLng());
+        if (pts.length) map.fitBounds(pts, { padding: [20, 20] });
+      };
+      fit();
+
+      async function refresh() {
+        try {
+          const resp = await fetch('{{ url_for('admin_delivery_locations') }}');
+          const data = await resp.json();
+          data.forEach(loc => {
+            const pos = [loc.lat, loc.lng];
+            if (markers[loc.id]) {
+              markers[loc.id].setLatLng(pos);
+            } else {
+              markers[loc.id] = L.marker(pos).addTo(map);
+            }
+          });
+          fit();
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      setInterval(refresh, 5000);
     });
   </script>
 

--- a/templates/delivery_detail.html
+++ b/templates/delivery_detail.html
@@ -156,4 +156,20 @@
   {% endif %}
 
 </div>
+{% if role == 'worker' %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  if (!('geolocation' in navigator)) return;
+  const send = pos => {
+    fetch('{{ url_for('update_delivery_location', req_id=req.id) }}', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json', 'Accept': 'application/json'},
+      body: JSON.stringify({lat: pos.coords.latitude, lng: pos.coords.longitude})
+    });
+  };
+  const err = err => console.error(err);
+  navigator.geolocation.watchPosition(send, err, {enableHighAccuracy: true});
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1580,3 +1580,53 @@ def test_delivery_overview_shows_worker_map(monkeypatch, app):
         assert b'id="workersMap"' in resp.data
         assert b'1.2' in resp.data
         assert b'3.4' in resp.data
+
+def test_update_delivery_location(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        worker = User(id=1, name='Worker', email='w@x.com', worker='delivery')
+        worker.set_password('x')
+        buyer = User(id=2, name='Buyer', email='b@x.com')
+        buyer.set_password('x')
+        order = Order(id=1, user_id=2)
+        req = DeliveryRequest(id=1, order_id=1, requested_by_id=2,
+                               status='em_andamento', worker_id=1)
+        db.session.add_all([worker, buyer, order, req])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: worker)
+
+        resp = client.post(f'/delivery_requests/{req.id}/location', json={'lat': 5.6, 'lng': 7.8})
+        assert resp.status_code == 200
+        db_req = DeliveryRequest.query.get(req.id)
+        assert db_req.worker_latitude == 5.6
+        assert db_req.worker_longitude == 7.8
+
+
+def test_admin_delivery_locations_endpoint(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(id=1, name='Admin', email='a@x.com', role='admin')
+        admin.set_password('x')
+        worker = User(id=2, name='Worker', email='w@x.com', worker='delivery')
+        worker.set_password('x')
+        order = Order(id=1, user_id=1)
+        req = DeliveryRequest(id=1, order_id=1, requested_by_id=1,
+                               status='em_andamento', worker_id=2,
+                               worker_latitude=1.1, worker_longitude=2.2)
+        db.session.add_all([admin, worker, order, req])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: admin)
+        monkeypatch.setattr(app_module, '_is_admin', lambda: True)
+
+        resp = client.get('/admin/delivery_locations')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data == [{'id': req.id, 'lat': 1.1, 'lng': 2.2}]


### PR DESCRIPTION
## Summary
- allow delivery workers to push location updates
- expose `/admin/delivery_locations` API and refresh map markers
- send worker geolocation automatically during active delivery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892285be374832e9f403f0f3d5694b2