### PR TITLE
Ensure delivery overview map displays without worker locations

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -147,12 +147,7 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const locations = {{ worker_locations|tojson }};
-      const mapEl = document.getElementById('workersMap');
-      if (!locations.length) {
-        if (mapEl) mapEl.style.display = 'none';
-        return;
-      }
-      const map = L.map('workersMap');
+      const map = L.map('workersMap').setView([0, 0], 2);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenStreetMap contributors'
       }).addTo(map);


### PR DESCRIPTION
## Summary
- Initialize Leaflet map with default view and always render map container
- Remove early return that hid map when there were no worker location points

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689328348f9c832ea404c1b28950ff3d