### PR TITLE
feat: push delivery updates via sse

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -161,25 +161,21 @@
       };
       fit();
 
-      async function refresh() {
+      const evt = new EventSource('{{ url_for('admin_delivery_locations_stream') }}');
+      evt.onmessage = (e) => {
         try {
-          const resp = await fetch('{{ url_for('admin_delivery_locations') }}');
-          const data = await resp.json();
-          data.forEach(loc => {
-            const pos = [loc.lat, loc.lng];
-            if (markers[loc.id]) {
-              markers[loc.id].setLatLng(pos);
-            } else {
-              markers[loc.id] = L.marker(pos).addTo(map);
-            }
-          });
+          const loc = JSON.parse(e.data);
+          const pos = [loc.lat, loc.lng];
+          if (markers[loc.id]) {
+            markers[loc.id].setLatLng(pos);
+          } else {
+            markers[loc.id] = L.marker(pos).addTo(map);
+          }
           fit();
         } catch (err) {
           console.error(err);
         }
-      }
-
-      setInterval(refresh, 5000);
+      };
     });
   </script>
 


### PR DESCRIPTION
## Summary
- stream delivery location changes to admins using server-sent events
- update delivery overview to listen to SSE instead of polling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689330ba17e4832ebe64e1d18fb360ba