### PR TITLE
Fix worker locations JSON injection for admin delivery map

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -146,7 +146,10 @@
   ></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      const locations = {{ worker_locations|tojson }};
+      // Ensure the JSON is inserted without escaping so Leaflet receives
+      // valid coordinates. If the data is escaped the script breaks and the
+      // map never renders.
+      const locations = {{ worker_locations|tojson|safe }};
       const map = L.map('workersMap').setView([0, 0], 2);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenStreetMap contributors'


### PR DESCRIPTION
## Summary
- ensure worker locations JSON is injected without escaping so Leaflet map renders correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893584212a4832ebb911ac6741c1192