### PR TITLE
Remove delivery worker map and location tracking

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -2,12 +2,6 @@
 
 {% block head %}
   {{ super() }}
-  <link
-    rel="stylesheet"
-    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-    integrity="sha256-sA+e2yz1G+u/ehabSGvtQvE4H14R/2uOeGjn5ERm2y8="
-    crossorigin=""
-  />
 {% endblock %}
 
 {% block main %}
@@ -133,51 +127,6 @@
       <i class="fas fa-archive me-1"></i> Arquivadas: pedidos arquivados
     </a>
   </div>
-
-  <div class="mt-4">
-    <h4>Mapa dos entregadores</h4>
-    <div id="workersMap" style="height: 400px;"></div>
-  </div>
-
-  <script
-    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-    integrity="sha256-o9N1jG8CjNd8Pr+X/4A9Hd4RJpcJnSMr3vzYW3LFyf0="
-    crossorigin=""
-  ></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const locations = {{ worker_locations|tojson }};
-      const map = L.map('workersMap').setView([0, 0], 2);
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; OpenStreetMap contributors'
-      }).addTo(map);
-      const markers = {};
-      locations.forEach(l => {
-        markers[l.id] = L.marker([l.lat, l.lng]).addTo(map);
-      });
-      const fit = () => {
-        const pts = Object.values(markers).map(m => m.getLatLng());
-        if (pts.length) map.fitBounds(pts, { padding: [20, 20] });
-      };
-      fit();
-
-      const evt = new EventSource('{{ url_for('admin_delivery_locations_stream') }}');
-      evt.onmessage = (e) => {
-        try {
-          const loc = JSON.parse(e.data);
-          const pos = [loc.lat, loc.lng];
-          if (markers[loc.id]) {
-            markers[loc.id].setLatLng(pos);
-          } else {
-            markers[loc.id] = L.marker(pos).addTo(map);
-          }
-          fit();
-        } catch (err) {
-          console.error(err);
-        }
-      };
-    });
-  </script>
 
 </div>
 {% endblock %}

--- a/templates/delivery_detail.html
+++ b/templates/delivery_detail.html
@@ -156,20 +156,4 @@
   {% endif %}
 
 </div>
-{% if role == 'worker' %}
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  if (!('geolocation' in navigator)) return;
-  const send = pos => {
-    fetch('{{ url_for('update_delivery_location', req_id=req.id) }}', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json', 'Accept': 'application/json'},
-      body: JSON.stringify({lat: pos.coords.latitude, lng: pos.coords.longitude})
-    });
-  };
-  const err = err => console.error(err);
-  navigator.geolocation.watchPosition(send, err, {enableHighAccuracy: true});
-});
-</script>
-{% endif %}
 {% endblock %}

--- a/templates/delivery_requests.html
+++ b/templates/delivery_requests.html
@@ -40,7 +40,7 @@
         {# -------- Botões só para entregador -------- #}
         {% if current_user.worker == 'delivery' %}
           {% if req.status == 'pendente' %}
-            <form action="{{ url_for('accept_delivery', req_id=req.id) }}" method="post" class="js-delivery-form" data-requires-location="true">
+            <form action="{{ url_for('accept_delivery', req_id=req.id) }}" method="post" class="js-delivery-form">
               <button class="btn btn-sm btn-primary">Aceitar</button>
             </form>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -547,17 +547,7 @@
       document.querySelectorAll('.js-delivery-form').forEach(form => {
         form.addEventListener('submit', async ev => {
           ev.preventDefault();
-          let url = form.action;
-          if (form.dataset.requiresLocation === 'true') {
-            try {
-              const pos = await new Promise((resolve, reject) => navigator.geolocation.getCurrentPosition(resolve, reject));
-              const { latitude, longitude } = pos.coords;
-              url += (url.includes('?') ? '&' : '?') + `lat=${latitude}&lng=${longitude}`;
-            } catch (err) {
-              alert('É necessário permitir acesso à localização para aceitar a entrega.');
-              return;
-            }
-          }
+          const url = form.action;
           const resp = await fetchOrQueue(url, {method: 'POST', headers: {'Accept': 'application/json'}});
           if (resp && resp.ok) {
             const data = await resp.json();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1382,16 +1382,15 @@ def test_accept_delivery_redirects(monkeypatch, app):
         monkeypatch.setattr(app_module, '_is_admin', lambda: False)
 
         resp = client.post(
-            f'/delivery_requests/{req.id}/accept?lat=1.2&lng=3.4',
+            f'/delivery_requests/{req.id}/accept',
             headers={'Accept': 'application/json'}
         )
         assert resp.status_code == 200
         db_req = DeliveryRequest.query.get(req.id)
-        assert db_req.worker_latitude == 1.2
-        assert db_req.worker_longitude == 3.4
+        assert db_req.worker_id == worker.id
 
 
-def test_accept_delivery_requires_location(monkeypatch, app):
+def test_accept_delivery_without_location(monkeypatch, app):
     client = app.test_client()
 
     with app.app_context():
@@ -1415,9 +1414,9 @@ def test_accept_delivery_requires_location(monkeypatch, app):
             f'/delivery_requests/{req.id}/accept',
             headers={'Accept': 'application/json'}
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 200
         data = resp.get_json()
-        assert data['category'] == 'danger'
+        assert data['category'] == 'success'
 
 
 def test_update_tutor_duplicate_cpf(monkeypatch, app):
@@ -1552,110 +1551,3 @@ def test_delivery_requests_hide_archived(monkeypatch, app):
         assert 'Pedido #1' not in html
 
 
-def test_delivery_overview_shows_worker_map(monkeypatch, app):
-    client = app.test_client()
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-        admin = User(id=1, name='Admin', email='a@a', password_hash='x', role='admin')
-        addr = Endereco(id=1, cep='11111-000', latitude=1.2, longitude=3.4)
-        worker = User(id=2, name='Worker', email='w@x.com', worker='delivery', endereco=addr)
-        worker.set_password('x')
-        db.session.add_all([admin, addr, worker])
-        db.session.commit()
-
-        import flask_login.utils as login_utils
-        monkeypatch.setattr(login_utils, '_get_user', lambda: admin)
-        monkeypatch.setattr(app_module, '_is_admin', lambda: True)
-
-        resp = client.get('/admin/delivery_overview')
-        assert b'id="workersMap"' in resp.data
-        assert b'1.2' in resp.data
-        assert b'3.4' in resp.data
-
-def test_update_delivery_location(monkeypatch, app):
-    client = app.test_client()
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-        addr = Endereco(id=1, cep='11111-000')
-        worker = User(id=1, name='Worker', email='w@x.com', worker='delivery', endereco=addr)
-        worker.set_password('x')
-        buyer = User(id=2, name='Buyer', email='b@x.com')
-        buyer.set_password('x')
-        order = Order(id=1, user_id=2)
-        req = DeliveryRequest(id=1, order_id=1, requested_by_id=2,
-                               status='em_andamento', worker_id=1)
-        db.session.add_all([addr, worker, buyer, order, req])
-        db.session.commit()
-
-        import flask_login.utils as login_utils
-        monkeypatch.setattr(login_utils, '_get_user', lambda: worker)
-
-        resp = client.post(f'/delivery_requests/{req.id}/location', json={'lat': 5.6, 'lng': 7.8})
-        assert resp.status_code == 200
-        db_req = DeliveryRequest.query.get(req.id)
-        assert db_req.worker_latitude == 5.6
-        assert db_req.worker_longitude == 7.8
-        db_worker = User.query.get(worker.id)
-        assert db_worker.endereco.latitude == 5.6
-        assert db_worker.endereco.longitude == 7.8
-
-
-def test_worker_without_address_gets_location_on_overview(monkeypatch, app):
-    client = app.test_client()
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-        admin = User(id=1, name='Admin', email='a@a', role='admin')
-        admin.set_password('x')
-        worker = User(id=2, name='Worker', email='w@x.com', worker='delivery')
-        worker.set_password('x')
-        order = Order(id=1, user_id=1)
-        req = DeliveryRequest(
-            id=1,
-            order_id=1,
-            requested_by_id=1,
-            status='em_andamento',
-            worker_id=2,
-        )
-        db.session.add_all([admin, worker, order, req])
-        db.session.commit()
-
-        import flask_login.utils as login_utils
-        monkeypatch.setattr(login_utils, '_get_user', lambda: worker)
-        resp = client.post('/delivery_requests/1/location', json={'lat': 10.0, 'lng': 20.0})
-        assert resp.status_code == 200
-        db_worker = User.query.get(worker.id)
-        assert db_worker.endereco is not None
-        assert db_worker.endereco.latitude == 10.0
-        assert db_worker.endereco.longitude == 20.0
-
-        monkeypatch.setattr(login_utils, '_get_user', lambda: admin)
-        monkeypatch.setattr(app_module, '_is_admin', lambda: True)
-        resp = client.get('/admin/delivery_overview')
-        assert resp.status_code == 200
-        assert b'10.0' in resp.data and b'20.0' in resp.data
-
-
-def test_admin_delivery_locations_endpoint(monkeypatch, app):
-    client = app.test_client()
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-        admin = User(id=1, name='Admin', email='a@x.com', role='admin')
-        admin.set_password('x')
-        addr = Endereco(id=1, cep='11111-000', latitude=1.1, longitude=2.2)
-        worker = User(id=2, name='Worker', email='w@x.com', worker='delivery', endereco=addr)
-        worker.set_password('x')
-        db.session.add_all([admin, addr, worker])
-        db.session.commit()
-
-        import flask_login.utils as login_utils
-        monkeypatch.setattr(login_utils, '_get_user', lambda: admin)
-        monkeypatch.setattr(app_module, '_is_admin', lambda: True)
-
-        resp = client.get('/admin/delivery_locations')
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data == [{'id': worker.id, 'lat': 1.1, 'lng': 2.2}]


### PR DESCRIPTION
## Summary
- Drop delivery worker map and related location streaming endpoints
- Simplify accept delivery flow to stop requesting or storing worker coordinates
- Remove geolocation requirements and scripts from templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689355edbd9c832eb975de9a7c627c4e