### PR TITLE
Add WhatsApp share buttons to printable pages

### DIFF
--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -113,6 +113,7 @@
   <button onclick="window.print()">🖨️ Imprimir</button>
   <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
   <button onclick="abrirDrive()" style="margin-left: 5px;">📂 Abrir no Drive</button>
+  <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
 </div>
@@ -206,6 +207,16 @@
     const driveUrl = 'https://drive.google.com/viewerng/viewer?embedded=1&url=' +
       encodeURIComponent(window.location.href);
     window.open(driveUrl, '_blank');
+  }
+
+  function enviarWhatsApp() {
+    const numero = "{{ ''.join(ch for ch in bloco.animal.owner.phone if ch.isdigit()) if bloco.animal.owner.phone else '' }}";
+    if (!numero) {
+      alert('Número de telefone do tutor não informado.');
+      return;
+    }
+    const mensagem = encodeURIComponent('Segue a prescrição do(a) ' + '{{ bloco.animal.name }}' + ': ' + window.location.href);
+    window.open(`https://api.whatsapp.com/send?phone=${numero}&text=${mensagem}`, '_blank');
   }
 </script>
 

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -74,6 +74,7 @@
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
     <button onclick="abrirDrive()" style="margin-left: 5px;">📂 Abrir no Drive</button>
+    <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
   </div>
@@ -144,6 +145,16 @@
     const driveUrl = 'https://drive.google.com/viewerng/viewer?embedded=1&url=' +
       encodeURIComponent(window.location.href);
     window.open(driveUrl, '_blank');
+  }
+
+  function enviarWhatsApp() {
+    const numero = "{{ ''.join(ch for ch in tutor.phone if ch.isdigit()) if tutor.phone else '' }}";
+    if (!numero) {
+      alert('Número de telefone do tutor não informado.');
+      return;
+    }
+    const mensagem = encodeURIComponent('Segue o resumo da consulta: ' + window.location.href);
+    window.open(`https://api.whatsapp.com/send?phone=${numero}&text=${mensagem}`, '_blank');
   }
 </script>
 </body>

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -112,6 +112,7 @@
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
     <button onclick="abrirDrive()" style="margin-left: 5px;">📂 Abrir no Drive</button>
+    <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
   </div>
@@ -214,6 +215,16 @@
     const driveUrl = 'https://drive.google.com/viewerng/viewer?embedded=1&url=' +
       encodeURIComponent(window.location.href);
     window.open(driveUrl, '_blank');
+  }
+
+  function enviarWhatsApp() {
+    const numero = "{{ ''.join(ch for ch in tutor.phone if ch.isdigit()) if tutor.phone else '' }}";
+    if (!numero) {
+      alert('Número de telefone do tutor não informado.');
+      return;
+    }
+    const mensagem = encodeURIComponent('Segue a solicitação de exames: ' + window.location.href);
+    window.open(`https://api.whatsapp.com/send?phone=${numero}&text=${mensagem}`, '_blank');
   }
 </script>
 

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -37,6 +37,7 @@
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left:5px;">🔏 Assinar</button>
     <button onclick="abrirDrive()" style="margin-left:5px;">📂 Abrir no Drive</button>
+    <button onclick="enviarWhatsApp()" style="margin-left:5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" style="margin-left:15px;">← Voltar</a>
   </div>
 
@@ -73,6 +74,16 @@
     const driveUrl = 'https://drive.google.com/viewerng/viewer?embedded=1&url=' +
       encodeURIComponent(window.location.href);
     window.open(driveUrl, '_blank');
+  }
+
+  function enviarWhatsApp() {
+    const numero = "{{ ''.join(ch for ch in animal.owner.phone if ch.isdigit()) if animal.owner.phone else '' }}";
+    if (!numero) {
+      alert('Número de telefone do tutor não informado.');
+      return;
+    }
+    const mensagem = encodeURIComponent('Segue a carteirinha de vacinação: ' + window.location.href);
+    window.open(`https://api.whatsapp.com/send?phone=${numero}&text=${mensagem}`, '_blank');
   }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- allow sending consultation, prescription, exam, and vaccine printouts via WhatsApp

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894b2672148832e9278dae1d251a366