### PR TITLE
Use Jinja filter for phone digits in print templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,6 +157,11 @@ def format_datetime_brazil(value, fmt="%d/%m/%Y %H:%M"):
 
     return value
 
+@app.template_filter("digits_only")
+def digits_only(value):
+    """Return only the digits from a string."""
+    return "".join(filter(str.isdigit, value)) if value else ""
+
 # ----------------------------------------------------------------
 # 6)  Forms e helpers
 # ----------------------------------------------------------------

--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -210,7 +210,7 @@
   }
 
   function enviarWhatsApp() {
-    const numero = "{{ ''.join(ch for ch in bloco.animal.owner.phone if ch.isdigit()) if bloco.animal.owner.phone else '' }}";
+    const numero = "{{ bloco.animal.owner.phone | digits_only }}";
     if (!numero) {
       alert('Número de telefone do tutor não informado.');
       return;

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -148,7 +148,7 @@
   }
 
   function enviarWhatsApp() {
-    const numero = "{{ ''.join(ch for ch in tutor.phone if ch.isdigit()) if tutor.phone else '' }}";
+    const numero = "{{ tutor.phone | digits_only }}";
     if (!numero) {
       alert('Número de telefone do tutor não informado.');
       return;

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -218,7 +218,7 @@
   }
 
   function enviarWhatsApp() {
-    const numero = "{{ ''.join(ch for ch in tutor.phone if ch.isdigit()) if tutor.phone else '' }}";
+    const numero = "{{ tutor.phone | digits_only }}";
     if (!numero) {
       alert('Número de telefone do tutor não informado.');
       return;

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -77,7 +77,7 @@
   }
 
   function enviarWhatsApp() {
-    const numero = "{{ ''.join(ch for ch in animal.owner.phone if ch.isdigit()) if animal.owner.phone else '' }}";
+    const numero = "{{ animal.owner.phone | digits_only }}";
     if (!numero) {
       alert('Número de telefone do tutor não informado.');
       return;


### PR DESCRIPTION
## Summary
- add `digits_only` Jinja filter to strip non-numeric characters
- update print templates to use `digits_only` for WhatsApp number generation

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_6894ba110914832eaf9d241f66b9ab30