### PR TITLE
Remover opção de abrir no Drive nas páginas de impressão

### DIFF
--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -112,7 +112,6 @@
 <div class="no-print" style="margin-bottom: 1em;">
   <button onclick="window.print()">🖨️ Imprimir</button>
   <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
-  <button onclick="abrirDrive()" style="margin-left: 5px;">📂 Abrir no Drive</button>
   <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
@@ -201,12 +200,6 @@
     if (confirm('Abrir página de assinatura agora?')) {
       window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
     }
-  }
-
-  function abrirDrive() {
-    const driveUrl = 'https://drive.google.com/viewerng/viewer?embedded=1&url=' +
-      encodeURIComponent(window.location.href);
-    window.open(driveUrl, '_blank');
   }
 
   function enviarWhatsApp() {

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -73,7 +73,6 @@
   <div class="no-print" style="margin-bottom: 1em;">
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
-    <button onclick="abrirDrive()" style="margin-left: 5px;">📂 Abrir no Drive</button>
     <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
@@ -139,12 +138,6 @@
     if (confirm('Abrir página de assinatura agora?')) {
       window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
     }
-  }
-
-  function abrirDrive() {
-    const driveUrl = 'https://drive.google.com/viewerng/viewer?embedded=1&url=' +
-      encodeURIComponent(window.location.href);
-    window.open(driveUrl, '_blank');
   }
 
   function enviarWhatsApp() {

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -111,7 +111,6 @@
   <div class="no-print" style="margin-bottom: 1em;">
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
-    <button onclick="abrirDrive()" style="margin-left: 5px;">📂 Abrir no Drive</button>
     <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
@@ -209,12 +208,6 @@
     if (confirm('Abrir página de assinatura agora?')) {
       window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
     }
-  }
-
-  function abrirDrive() {
-    const driveUrl = 'https://drive.google.com/viewerng/viewer?embedded=1&url=' +
-      encodeURIComponent(window.location.href);
-    window.open(driveUrl, '_blank');
   }
 
   function enviarWhatsApp() {

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -36,7 +36,6 @@
   <div class="no-print">
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left:5px;">🔏 Assinar</button>
-    <button onclick="abrirDrive()" style="margin-left:5px;">📂 Abrir no Drive</button>
     <button onclick="enviarWhatsApp()" style="margin-left:5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" style="margin-left:15px;">← Voltar</a>
   </div>
@@ -68,12 +67,6 @@
     if (confirm('Abrir página de assinatura agora?')) {
       window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
     }
-  }
-
-  function abrirDrive() {
-    const driveUrl = 'https://drive.google.com/viewerng/viewer?embedded=1&url=' +
-      encodeURIComponent(window.location.href);
-    window.open(driveUrl, '_blank');
   }
 
   function enviarWhatsApp() {


### PR DESCRIPTION
## Summary
- remover botão e função "Abrir no Drive" nas páginas de impressão de exames, receitas, vacinas e consultas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894bab7d1a4832ea8c6e6ad5c573754