### PR TITLE
Improve WhatsApp sharing in print templates

### DIFF
--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -112,7 +112,7 @@
 <div class="no-print" style="margin-bottom: 1em;">
   <button onclick="window.print()">🖨️ Imprimir</button>
   <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
-  <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
+  <button onclick="enviarWhatsApp()" id="btn-whatsapp" style="margin-left: 5px;">📱 WhatsApp</button>
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
 </div>
@@ -196,6 +196,12 @@
 </footer>
 
 <script>
+  const numeroWhatsApp = "{{ bloco.animal.owner.phone | digits_only if bloco.animal.owner and bloco.animal.owner.phone else '' }}";
+  const btnWhats = document.getElementById('btn-whatsapp');
+  if (!numeroWhatsApp && btnWhats) {
+    btnWhats.style.display = 'none';
+  }
+
   function abrirAssinatura() {
     if (confirm('Abrir página de assinatura agora?')) {
       window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
@@ -203,13 +209,21 @@
   }
 
   function enviarWhatsApp() {
-    const numero = "{{ bloco.animal.owner.phone | digits_only }}";
-    if (!numero) {
+    if (!numeroWhatsApp) {
       alert('Número de telefone do tutor não informado.');
       return;
     }
-    const mensagem = encodeURIComponent('Segue a prescrição do(a) ' + '{{ bloco.animal.name }}' + ': ' + window.location.href);
-    window.open(`https://api.whatsapp.com/send?phone=${numero}&text=${mensagem}`, '_blank');
+    const mensagem = encodeURIComponent('Olá {{ bloco.animal.owner.name }}! Segue o link da prescrição de {{ bloco.animal.name }}: ' + window.location.href + ' Qualquer dúvida, estamos à disposição. Equipe PetOrlândia.');
+    const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
+    try {
+      const wpp = window.open(url, '_blank');
+      if (!wpp) {
+        alert('Não foi possível abrir o WhatsApp. Verifique o bloqueador de pop-ups.');
+      }
+    } catch (err) {
+      console.error('Erro ao abrir WhatsApp:', err);
+      alert('Ocorreu um erro ao abrir o WhatsApp. Tente novamente.');
+    }
   }
 </script>
 

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -73,7 +73,7 @@
   <div class="no-print" style="margin-bottom: 1em;">
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
-    <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
+    <button onclick="enviarWhatsApp()" id="btn-whatsapp" style="margin-left: 5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
   </div>
@@ -134,6 +134,12 @@
   </footer>
   {% endif %}
 <script>
+  const numeroWhatsApp = "{{ tutor.phone | digits_only if tutor and tutor.phone else '' }}";
+  const btnWhats = document.getElementById('btn-whatsapp');
+  if (!numeroWhatsApp && btnWhats) {
+    btnWhats.style.display = 'none';
+  }
+
   function abrirAssinatura() {
     if (confirm('Abrir página de assinatura agora?')) {
       window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
@@ -141,13 +147,21 @@
   }
 
   function enviarWhatsApp() {
-    const numero = "{{ tutor.phone | digits_only }}";
-    if (!numero) {
+    if (!numeroWhatsApp) {
       alert('Número de telefone do tutor não informado.');
       return;
     }
-    const mensagem = encodeURIComponent('Segue o resumo da consulta: ' + window.location.href);
-    window.open(`https://api.whatsapp.com/send?phone=${numero}&text=${mensagem}`, '_blank');
+    const mensagem = encodeURIComponent('Olá {{ tutor.name }}! Segue o resumo da consulta de {{ animal.name }}: ' + window.location.href + ' Qualquer dúvida, estamos à disposição. Equipe PetOrlândia.');
+    const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
+    try {
+      const wpp = window.open(url, '_blank');
+      if (!wpp) {
+        alert('Não foi possível abrir o WhatsApp. Verifique o bloqueador de pop-ups.');
+      }
+    } catch (err) {
+      console.error('Erro ao abrir WhatsApp:', err);
+      alert('Ocorreu um erro ao abrir o WhatsApp. Tente novamente.');
+    }
   }
 </script>
 </body>

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -111,7 +111,7 @@
   <div class="no-print" style="margin-bottom: 1em;">
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left: 5px;">🔏 Assinar</button>
-    <button onclick="enviarWhatsApp()" style="margin-left: 5px;">📱 WhatsApp</button>
+    <button onclick="enviarWhatsApp()" id="btn-whatsapp" style="margin-left: 5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}"
        style="margin-left: 15px;">← Voltar</a>
   </div>
@@ -204,6 +204,12 @@
   </footer>
 
 <script>
+  const numeroWhatsApp = "{{ tutor.phone | digits_only if tutor and tutor.phone else '' }}";
+  const btnWhats = document.getElementById('btn-whatsapp');
+  if (!numeroWhatsApp && btnWhats) {
+    btnWhats.style.display = 'none';
+  }
+
   function abrirAssinatura() {
     if (confirm('Abrir página de assinatura agora?')) {
       window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
@@ -211,13 +217,21 @@
   }
 
   function enviarWhatsApp() {
-    const numero = "{{ tutor.phone | digits_only }}";
-    if (!numero) {
+    if (!numeroWhatsApp) {
       alert('Número de telefone do tutor não informado.');
       return;
     }
-    const mensagem = encodeURIComponent('Segue a solicitação de exames: ' + window.location.href);
-    window.open(`https://api.whatsapp.com/send?phone=${numero}&text=${mensagem}`, '_blank');
+    const mensagem = encodeURIComponent('Olá {{ tutor.name }}! Segue a solicitação de exames de {{ animal.name }}: ' + window.location.href + ' Qualquer dúvida, estamos à disposição. Equipe PetOrlândia.');
+    const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
+    try {
+      const wpp = window.open(url, '_blank');
+      if (!wpp) {
+        alert('Não foi possível abrir o WhatsApp. Verifique o bloqueador de pop-ups.');
+      }
+    } catch (err) {
+      console.error('Erro ao abrir WhatsApp:', err);
+      alert('Ocorreu um erro ao abrir o WhatsApp. Tente novamente.');
+    }
   }
 </script>
 

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -36,7 +36,7 @@
   <div class="no-print">
     <button onclick="window.print()">🖨️ Imprimir</button>
     <button onclick="abrirAssinatura()" style="margin-left:5px;">🔏 Assinar</button>
-    <button onclick="enviarWhatsApp()" style="margin-left:5px;">📱 WhatsApp</button>
+    <button onclick="enviarWhatsApp()" id="btn-whatsapp" style="margin-left:5px;">📱 WhatsApp</button>
     <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" style="margin-left:15px;">← Voltar</a>
   </div>
 
@@ -63,6 +63,12 @@
   </table>
 
 <script>
+  const numeroWhatsApp = "{{ animal.owner.phone | digits_only if animal.owner and animal.owner.phone else '' }}";
+  const btnWhats = document.getElementById('btn-whatsapp');
+  if (!numeroWhatsApp && btnWhats) {
+    btnWhats.style.display = 'none';
+  }
+
   function abrirAssinatura() {
     if (confirm('Abrir página de assinatura agora?')) {
       window.open('https://assinador.iti.br/assinatura/index.xhtml', '_blank');
@@ -70,13 +76,21 @@
   }
 
   function enviarWhatsApp() {
-    const numero = "{{ animal.owner.phone | digits_only }}";
-    if (!numero) {
+    if (!numeroWhatsApp) {
       alert('Número de telefone do tutor não informado.');
       return;
     }
-    const mensagem = encodeURIComponent('Segue a carteirinha de vacinação: ' + window.location.href);
-    window.open(`https://api.whatsapp.com/send?phone=${numero}&text=${mensagem}`, '_blank');
+    const mensagem = encodeURIComponent('Olá {{ animal.owner.name }}! Segue o link da carteirinha de vacinação de {{ animal.name }}: ' + window.location.href + ' Qualquer dúvida, estamos à disposição. Equipe PetOrlândia.');
+    const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
+    try {
+      const wpp = window.open(url, '_blank');
+      if (!wpp) {
+        alert('Não foi possível abrir o WhatsApp. Verifique o bloqueador de pop-ups.');
+      }
+    } catch (err) {
+      console.error('Erro ao abrir WhatsApp:', err);
+      alert('Ocorreu um erro ao abrir o WhatsApp. Tente novamente.');
+    }
   }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- send professional WhatsApp messages from print pages
- hide share button when tutor lacks a phone and add error handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894bc735064832e96e0d2ea7306053b