### PR TITLE
Atualiza histórico de exames após salvar

### DIFF
--- a/app.py
+++ b/app.py
@@ -2826,7 +2826,12 @@ def atualizar_bloco_exames(bloco_id):
             db.session.delete(ex)
 
     db.session.commit()
-    return jsonify(success=True)
+
+    historico_html = render_template(
+        'partials/historico_exames.html',
+        animal=bloco.animal
+    )
+    return jsonify(success=True, html=historico_html)
 
 
 

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -209,21 +209,19 @@ function salvarBlocoExames(blocoId, consultaId) {
 
   fetch(`/bloco_exames/${blocoId}/atualizar`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
     body: JSON.stringify({ exames, observacoes_gerais })
   })
   .then(async res => {
-    if (res.ok) {
-      const data = await res.json();
-      if (data.success) {
-        alert('Bloco de exames salvo!');
-        location.reload();
-      } else {
-        alert('Erro ao salvar.');
+    const data = await res.json();
+    if (res.ok && data.success) {
+      alert('Bloco de exames salvo!');
+      if (data.html) {
+        document.getElementById('historico-exames').innerHTML = data.html;
       }
     } else {
-      const errorMessage = await res.text();
-      alert(errorMessage || 'Erro desconhecido ao salvar.');
+      const msg = data && data.message ? data.message : 'Erro ao salvar.';
+      alert(msg);
     }
   })
   .catch(err => {


### PR DESCRIPTION
## Summary
- Atualiza rota de atualização de bloco de exames para retornar HTML atualizado do histórico
- Atualiza JavaScript do histórico de exames para substituir o histórico na página após salvar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894be95583c832ea359846bc212b2bc