### PR TITLE
Improve consulta save feedback

### DIFF
--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -5,9 +5,9 @@
   <!-- Cabeçalho melhorado -->
   <div class="d-flex justify-content-between align-items-center mb-4">
     {% if animal %}
-      <h2 class="mb-0">🩺 <span class="text-primary">{{ animal.name }}</span> - Prontuário</h2>
+      <h2 class="mb-0">🩺 <span class="text-primary" id="animal-name">{{ animal.name }}</span> - Prontuário</h2>
     {% elif tutor %}
-      <h2 class="mb-0">🩺 Novo Atendimento para <span class="text-primary">{{ tutor.name }}</span></h2>
+      <h2 class="mb-0">🩺 Novo Atendimento para <span class="text-primary" id="tutor-name">{{ tutor.name }}</span></h2>
     {% else %}
       <h2 class="mb-0">🩺 Novo Atendimento Veterinário</h2>
     {% endif %}
@@ -213,13 +213,25 @@ document.addEventListener('DOMContentLoaded', function() {
     localStorage.removeItem('tabSavedHighlight');
   }
 
-  // Adiciona spinners e guarda aba corrente ao enviar formulário
   document.querySelectorAll('.tab-pane form[data-sync]').forEach(form => {
-    form.addEventListener('submit', () => {
+    form.addEventListener('submit', async ev => {
+      ev.preventDefault();
+
+      if (!form.checkValidity()) {
+        form.classList.add('was-validated');
+        return;
+      }
+
+      const validateFn = form.dataset.validate && window[form.dataset.validate];
+      if (validateFn && typeof validateFn === 'function' && !validateFn(form)) {
+        return;
+      }
+
       const pane = form.closest('.tab-pane');
       if (pane && pane.id) {
         localStorage.setItem('tabSavedHighlight', pane.id);
       }
+
       const btn = form.querySelector('button[type="submit"]');
       if (btn && !btn.querySelector('.spinner-border')) {
         btn.disabled = true;
@@ -227,11 +239,55 @@ document.addEventListener('DOMContentLoaded', function() {
         sp.className = 'spinner-border spinner-border-sm ms-2';
         sp.setAttribute('role', 'status');
         btn.appendChild(sp);
-        // Fallback: remove spinner after 3 seconds if no response
-        btn.spinnerTimer = setTimeout(() => {
-          btn.querySelector('.spinner-border')?.remove();
-          btn.disabled = false;
-        }, 3000);
+      }
+
+      let data = null;
+      let ok = false;
+      try {
+        const resp = await fetch(form.action, {
+          method: 'POST',
+          headers: {'Accept': 'application/json'},
+          body: new FormData(form)
+        });
+        ok = resp.ok;
+        try { data = await resp.json(); } catch(e) {}
+      } catch(err) {}
+
+      if (btn) {
+        btn.querySelector('.spinner-border')?.remove();
+        btn.disabled = false;
+      }
+
+      if (ok && data) {
+        if (form.dataset.target && data.html) {
+          const container = document.querySelector(form.dataset.target);
+          if (container) container.innerHTML = data.html;
+        }
+        if (data.tutor_name) {
+          const el = document.getElementById('tutor-name');
+          if (el) el.textContent = data.tutor_name;
+        }
+        if (data.animal_name) {
+          const el = document.getElementById('animal-name');
+          if (el) el.textContent = data.animal_name;
+        }
+      }
+
+      const toastEl = document.getElementById('actionToast');
+      if (toastEl) {
+        const msg = (data && (data.message || data.error)) || (ok ? 'Salvo com sucesso!' : 'Falha ao salvar');
+        toastEl.querySelector('.toast-body').textContent = msg;
+        toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+        toastEl.classList.add(ok ? 'bg-success' : 'bg-danger');
+        bootstrap.Toast.getOrCreateInstance(toastEl).show();
+      }
+
+      if (ok && pane && pane.id) {
+        const link = document.querySelector(`[data-bs-target="#${pane.id}"]`);
+        if (link) {
+          link.classList.add('tab-saved-highlight');
+          setTimeout(() => link.classList.remove('tab-saved-highlight'), 2000);
+        }
       }
     });
   });
@@ -240,7 +296,7 @@ document.addEventListener('DOMContentLoaded', function() {
   document.getElementById('consultaTabs').addEventListener('shown.bs.tab', function(event) {
     const target = event.target.getAttribute('data-bs-target').replace('#', '');
     localStorage.setItem('abaAtivaConsulta', target);
-    
+
     // Lógica específica para medicamentos
     if (target === 'medicamentos') {
       setTimeout(() => ativarAutocomplete(), 100);
@@ -248,46 +304,6 @@ document.addEventListener('DOMContentLoaded', function() {
       if (medInput) medInput.dispatchEvent(new Event('input'));
     }
   });
-});
-
-document.addEventListener('form-sync-success', function(ev) {
-  const {form, data, response} = ev.detail || {};
-  if (!form) return;
-
-  const btn = form.querySelector('button[type="submit"]');
-  if (btn) {
-    clearTimeout(btn.spinnerTimer);
-    btn.spinnerTimer = null;
-    btn.querySelector('.spinner-border')?.remove();
-    btn.disabled = false;
-  }
-
-  const success = !(data && data.success === false) && (!response || response.ok);
-
-  const pane = form.closest('.tab-pane');
-  if (success && pane && pane.id) {
-    const link = document.querySelector(`[data-bs-target="#${pane.id}"]`);
-    if (link) {
-      link.classList.add('tab-saved-highlight');
-      setTimeout(() => link.classList.remove('tab-saved-highlight'), 2000);
-    }
-  }
-
-  if (form.id === 'consulta-form') {
-    ev.preventDefault();
-    if (data && data.html) {
-      const container = document.getElementById('historico-consultas');
-      if (container) container.innerHTML = data.html;
-    }
-    const toastEl = document.getElementById('actionToast');
-    if (toastEl) {
-      const msg = (data && (data.message || data.error)) || 'Consulta salva com sucesso!';
-      toastEl.querySelector('.toast-body').textContent = msg;
-      toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
-      toastEl.classList.add(success ? 'bg-success' : 'bg-danger');
-      bootstrap.Toast.getOrCreateInstance(toastEl).show();
-    }
-  }
 });
 
 </script>

--- a/templates/partials/animal_form.html
+++ b/templates/partials/animal_form.html
@@ -1,7 +1,7 @@
 {% from 'components/photo_cropper.html' import photo_cropper %}
 <form method="POST" action="{{ url_for('update_animal', animal_id=animal.id) }}"
-      enctype="multipart/form-data" onsubmit="return validarCadastroAnimal();"
-      class="needs-validation" novalidate data-sync="true">
+      enctype="multipart/form-data"
+      class="needs-validation" novalidate data-sync data-validate="validarCadastroAnimal">
 
   <h5 class="mb-3">🐾 Cadastro do Animal</h5>
 

--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -8,7 +8,7 @@
 
 <form id="consulta-form" method="POST"
       action="{{ url_for('update_consulta', consulta_id=consulta.id) }}{% if edit_mode %}?edit=1{% endif %}"
-      class="needs-validation" novalidate data-sync="true">
+      class="needs-validation" novalidate data-sync data-target="#historico-consultas">
 
   <!-- Seção de Queixa Principal -->
   <div class="mb-3">

--- a/templates/partials/tutor_form.html
+++ b/templates/partials/tutor_form.html
@@ -23,8 +23,7 @@
 <!-- 👤 Formulário de Tutor - Aprimorado com validação e organização -->
 <form id="tutor-form" method="POST" enctype="multipart/form-data"
       {% if has_tutor %}action="{{ url_for('update_tutor', user_id=tutor.id) }}"{% endif %}
-      class="needs-validation" novalidate
-      onsubmit="this.querySelector('button[type=submit]').disabled = true;">
+      class="needs-validation" novalidate data-sync>
   
   <h5 class="mb-4 d-flex align-items-center gap-2">
     <i class="bi bi-person-fill"></i> Cadastro do Tutor


### PR DESCRIPTION
## Summary
- enable async fetch handling for all consulta page forms with optional history refresh and toast feedback
- mark tutor, animal, and consulta partials for async save and dynamic header/history updates
- return JSON responses from tutor and animal update routes for seamless front-end syncing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c13bffd4832eb1fecd22092931c3