### PR TITLE
Enable async deletion for consultation history

### DIFF
--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -248,6 +248,21 @@ document.addEventListener('DOMContentLoaded', function() {
       if (medInput) medInput.dispatchEvent(new Event('input'));
     }
   });
+
+  ['historico-consultas','historico-prescricoes','historico-exames','historico-vacinas'].forEach(id => {
+    const container = document.getElementById(id);
+    if (container) {
+      container.addEventListener('submit', function(e) {
+        const form = e.target;
+        if (form.classList.contains('delete-history-form')) {
+          const msg = form.dataset.confirm || 'Excluir este registro?';
+          if (!confirm(msg)) {
+            e.preventDefault();
+          }
+        }
+      });
+    }
+  });
 });
 
 document.addEventListener('form-sync-success', function(ev) {
@@ -271,6 +286,23 @@ document.addEventListener('form-sync-success', function(ev) {
       link.classList.add('tab-saved-highlight');
       setTimeout(() => link.classList.remove('tab-saved-highlight'), 2000);
     }
+  }
+
+  if (form.classList.contains('delete-history-form')) {
+    ev.preventDefault();
+    if (data && data.html && form.dataset.target) {
+      const container = document.getElementById(form.dataset.target);
+      if (container) container.innerHTML = data.html;
+    }
+    const toastEl = document.getElementById('actionToast');
+    if (toastEl) {
+      const msg = (data && (data.message || data.error)) || (success ? 'Item removido!' : 'Erro ao remover item');
+      toastEl.querySelector('.toast-body').textContent = msg;
+      toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+      toastEl.classList.add(success ? 'bg-info' : 'bg-danger');
+      bootstrap.Toast.getOrCreateInstance(toastEl).show();
+    }
+    return;
   }
 
   if (form.id === 'consulta-form') {

--- a/templates/partials/historico_consultas.html
+++ b/templates/partials/historico_consultas.html
@@ -21,8 +21,8 @@
       </tr>
     </thead>
     <tbody>
-      {% for c in historico_consultas %}
-      <tr>
+        {% for c in historico_consultas %}
+        <tr id="consulta-{{ c.id }}">
         <td class="text-nowrap">{{ c.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</td>
         <td class="break-word-cell">{{ c.queixa_principal or '—' }}</td>
         <td class="break-word-cell">{{ c.historico_clinico or '—' }}</td>
@@ -34,8 +34,8 @@
           <a href="{{ url_for('imprimir_consulta', consulta_id=c.id) }}"
              class="btn btn-outline-dark btn-sm">🖨️ Imprimir</a>
           <form action="{{ url_for('deletar_consulta', consulta_id=c.id) }}"
-                method="POST" class="d-inline"
-                onsubmit="return confirm('Excluir esta consulta?');">
+                method="POST" class="d-inline delete-history-form" data-sync
+                data-target="historico-consultas" data-confirm="Excluir esta consulta?">
             <button class="btn btn-outline-danger btn-sm">🗑️</button>
           </form>
         </td>

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -11,7 +11,9 @@
         <strong>Exames solicitados em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</strong>
       </div>
       <div class="d-flex gap-2">
-        <form method="POST" action="{{ url_for('deletar_bloco_exames', bloco_id=bloco.id) }}" onsubmit="return confirm('Deseja realmente excluir este bloco de exames?');">
+        <form method="POST" action="{{ url_for('deletar_bloco_exames', bloco_id=bloco.id) }}"
+              class="delete-history-form" data-sync data-target="historico-exames"
+              data-confirm="Deseja realmente excluir este bloco de exames?">
           <button type="submit" class="btn btn-danger btn-sm">
             <i class="bi bi-trash"></i> Excluir
           </button>

--- a/templates/partials/historico_prescricoes.html
+++ b/templates/partials/historico_prescricoes.html
@@ -27,8 +27,9 @@
       <div class="d-flex flex-wrap gap-2">
         <form method="POST"
               action="{{ url_for('deletar_bloco_prescricao', bloco_id=bloco.id) }}"
-              class="d-inline"
-              onsubmit="return confirm('Deseja mesmo excluir este bloco de prescrições?');">
+              class="d-inline delete-history-form" data-sync
+              data-target="historico-prescricoes"
+              data-confirm="Deseja mesmo excluir este bloco de prescrições?">
           <button class="btn btn-danger btn-sm">🗑 Excluir</button>
         </form>
 

--- a/templates/partials/historico_vacinas.html
+++ b/templates/partials/historico_vacinas.html
@@ -21,7 +21,8 @@
 
       <div class="mt-2 d-flex gap-2">
         <form method="POST" action="{{ url_for('deletar_vacina', vacina_id=vacina.id) }}"
-              onsubmit="return confirm('Deseja mesmo remover esta vacina?')">
+              class="delete-history-form" data-sync data-target="historico-vacinas"
+              data-confirm="Deseja mesmo remover esta vacina?">
           <button class="btn btn-sm btn-danger">🗑️ Remover</button>
         </form>
 


### PR DESCRIPTION
## Summary
- Return updated partial HTML from delete routes for consultations, prescriptions, exams, and vaccines
- Mark history delete forms for unified async handling and container refresh
- Generalize consultation QR JS to confirm deletions and show toast feedback without full reload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c1832004832eb1ff46882246d105