### PR TITLE
Fix vaccine print view missing clinic

### DIFF
--- a/app.py
+++ b/app.py
@@ -2395,7 +2395,14 @@ def salvar_vacinas(animal_id):
 @app.route("/animal/<int:animal_id>/vacinas/imprimir")
 def imprimir_vacinas(animal_id):
     animal = Animal.query.get_or_404(animal_id)
-    return render_template("imprimir_vacinas.html", animal=animal)
+    clinica = None
+    if current_user.is_authenticated:
+        vet = getattr(current_user, "veterinario", None)
+        if vet and vet.clinica:
+            clinica = vet.clinica
+    if not clinica:
+        clinica = getattr(animal, "clinica", None) or Clinica.query.first()
+    return render_template("imprimir_vacinas.html", animal=animal, clinica=clinica)
 
 
 @app.route("/vacina/<int:vacina_id>/deletar", methods=["POST"])

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -45,9 +45,9 @@
 
     <div class="info-box">
       <strong>Clínica</strong><br>
-      {{ clinica.nome }}<br>
-      CRMV: {{ clinica.crmv or '—' }}<br>
-      Telefone: {{ clinica.telefone or '—' }}
+      {{ clinica.nome if clinica else '—' }}<br>
+      CRMV: {{ current_user.veterinario.crmv if current_user.veterinario else '—' }}<br>
+      Telefone: {{ clinica.telefone if clinica and clinica.telefone else '—' }}
     </div>
   </div>
 
@@ -90,7 +90,9 @@
 
   <footer>
     Documento válido apenas com carimbo e assinatura do médico veterinário responsável.<br>
-    {{ clinica.nome }} • {{ clinica.endereco }} • {{ clinica.telefone }} • {{ clinica.email }}
+    {% if clinica %}
+      {{ clinica.nome }} • {{ clinica.endereco or '—' }} • {{ clinica.telefone or '—' }} • {{ clinica.email or '—' }}
+    {% endif %}
   </footer>
 </div>
 
@@ -112,7 +114,7 @@
       alert('Número de telefone do responsável não informado.');
       return;
     }
-    const mensagem = encodeURIComponent(`Olá {{ animal.owner.name }}! Segue a carteira de vacinação de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
+    const mensagem = encodeURIComponent(`Olá {{ animal.owner.name }}! Segue a carteira de vacinação de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome if clinica else '' }}`);
     const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
     try {
       const wpp = window.open(url, '_blank');

--- a/tests/test_vacinas.py
+++ b/tests/test_vacinas.py
@@ -1,0 +1,28 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, Animal, Clinica
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_imprimir_vacinas_no_login(app):
+    with app.app_context():
+        db.create_all()
+        owner = User(name="Tutor", email="tutor@example.com", password_hash="x")
+        animal = Animal(name="Rex", owner=owner)
+        clinica = Clinica(nome="Pet Clinic")
+        db.session.add_all([owner, animal, clinica])
+        db.session.commit()
+        client = app.test_client()
+        resp = client.get(f"/animal/{animal.id}/vacinas/imprimir")
+        assert resp.status_code == 200
+        assert b"Rex" in resp.data
+        assert b"Pet Clinic" in resp.data


### PR DESCRIPTION
## Summary
- Load clinic information for vaccination print view with fallbacks
- Safeguard template when clinic data is absent and use vet CRMV
- Add regression test for vaccination print view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894cbce6fbc832eb723c37611e6ae68