### PR TITLE
Atualiza histórico de prescrições automaticamente

### DIFF
--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -273,7 +273,11 @@
         if (!response.ok || !data.success) throw new Error(data.message || 'Erro ao salvar prescrição');
         mostrarFeedback('Prescrição salva com sucesso!', 'success');
         if (data.html) {
-          document.getElementById('historico-prescricoes').innerHTML = data.html;
+          const container = document.getElementById('historico-prescricoes');
+          container.innerHTML = data.html;
+          if (typeof bindSyncForms === 'function') {
+            bindSyncForms(container);
+          }
         }
         prescricoes = [];
         renderPrescricoesTemp();


### PR DESCRIPTION
## Summary
- Recarrega o histórico de prescrições após salvar um novo bloco
- Reaplica os listeners dos formulários para ações de sincronização

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894cd187240832ea5c23eaf24c37527