### PR TITLE
Atualiza histórico de exames sem recarregar

### DIFF
--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -177,7 +177,11 @@
       if (data.success) {
         mostrarFeedback('Solicitação de exames salva com sucesso!');
         if (data.html) {
-          document.getElementById('historico-exames').innerHTML = data.html;
+          const container = document.getElementById('historico-exames');
+          container.innerHTML = data.html;
+          if (typeof bindSyncForms === 'function') {
+            bindSyncForms(container);
+          }
         }
         exames = [];
         renderExamesTemp();

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -1,6 +1,3 @@
-{% extends 'base_consulta.html' %}
-
-{% block main %}
 <div class="container py-4">
   <h2 class="mb-4">📋 Histórico e Edição de Exames</h2>
 
@@ -77,9 +74,7 @@
   </div>
   {% endfor %}
 </div>
-{% endblock %}
 
-{% block scripts %}
 <style>
 @keyframes fadeIn {
   from { opacity: 0; transform: scale(0.95); }
@@ -219,7 +214,11 @@ function salvarBlocoExames(blocoId, consultaId) {
     if (res.ok && data.success) {
       alert('Bloco de exames salvo!');
       if (data.html) {
-        document.getElementById('historico-exames').innerHTML = data.html;
+        const container = document.getElementById('historico-exames');
+        container.innerHTML = data.html;
+        if (typeof bindSyncForms === 'function') {
+          bindSyncForms(container);
+        }
       }
     } else {
       const msg = data && data.message ? data.message : 'Erro ao salvar.';
@@ -232,4 +231,3 @@ function salvarBlocoExames(blocoId, consultaId) {
   });
 }
 </script>
-{% endblock %}


### PR DESCRIPTION
## Resumo
- Torna `historico_exames.html` um parcial puro para inserir novos blocos de exames dinamicamente
- Atualiza `exames_form.html` e o salvamento de blocos para recarregar o histórico e reativar formulários sem recarregar a página

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ccd48910832e86c05d8c6b0e090e