### PR TITLE
Remove intrusive offline save messages

### DIFF
--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -189,7 +189,9 @@
         mostrarFeedback('Erro ao salvar exames.', 'danger');
       }
     } else {
-      mostrarFeedback('Solicitação salva offline e será enviada quando possível.', 'info');
+      // Offline: mantém exames na fila sem mostrar notificação
+      exames = [];
+      renderExamesTemp();
     }
 
     btn.disabled = false;

--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -282,7 +282,9 @@
         prescricoes = [];
         renderPrescricoesTemp();
       } else {
-        mostrarFeedback('Prescrição salva offline. Sincronizaremos em breve.', 'info');
+        // Offline: ação armazenada para sincronização futura sem exibir pop-up
+        prescricoes = [];
+        renderPrescricoesTemp();
       }
 
     } catch (err) {

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -178,7 +178,9 @@
           mostrarFeedback('Erro ao salvar vacinas.', 'danger');
         }
       } else {
-        mostrarFeedback('Vacinas salvas offline e serão enviadas quando possível.', 'info');
+        // Offline: registra localmente sem exibir aviso
+        vacinas = [];
+        renderVacinasTemp();
       }
 
       btn.disabled = false;


### PR DESCRIPTION
## Summary
- Avoid pop-up messages when saving prescriptions, vaccines, or exams while offline
- Queue offline actions silently so the UI updates without interruptions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ec872f38832ea117877acea70f57