### PR TITLE
Refresh history partials after async deletion

### DIFF
--- a/static/offline.js
+++ b/static/offline.js
@@ -76,12 +76,24 @@
     if (ev.defaultPrevented) return;
     const form = ev.target;
     if (!form.matches('form[data-sync]')) return;
+
+    // Mensagem de confirmação para formulários de histórico
+    if (form.classList.contains('delete-history-form')) {
+      const msg = form.dataset.confirm || 'Excluir este registro?';
+      if (!window.confirm(msg)) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        return;
+      }
+    }
+
     if (!form.checkValidity()) {
       ev.preventDefault();
       ev.stopPropagation();
       form.classList.add('was-validated');
       return;
     }
+
     ev.preventDefault();
     const data = new FormData(form);
     const resp = await window.fetchOrQueue(form.action, {method: form.method || 'POST', headers: {'Accept': 'application/json'}, body: data});
@@ -92,6 +104,22 @@
       document.dispatchEvent(evt);
       if (!evt.defaultPrevented) {
         location.reload();
+      }
+    }
+  });
+
+  // Atualiza automaticamente o contêiner do histórico após exclusões
+  document.addEventListener('form-sync-success', ev => {
+    const detail = ev.detail || {};
+    const form = detail.form;
+    const data = detail.data;
+    if (!form || !form.classList.contains('delete-history-form')) return;
+
+    ev.preventDefault();
+    if (data && data.html && form.dataset.target) {
+      const container = document.getElementById(form.dataset.target);
+      if (container) {
+        container.innerHTML = data.html;
       }
     }
   });

--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -315,20 +315,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 
-  ['historico-consultas','historico-prescricoes','historico-exames','historico-vacinas'].forEach(id => {
-    const container = document.getElementById(id);
-    if (container) {
-      container.addEventListener('submit', function(e) {
-        const form = e.target;
-        if (form.classList.contains('delete-history-form')) {
-          const msg = form.dataset.confirm || 'Excluir este registro?';
-          if (!confirm(msg)) {
-            e.preventDefault();
-          }
-        }
-      });
-    }
-  });
 });
 
 


### PR DESCRIPTION
## Summary
- handle history deletions centrally to avoid full-page reloads
- drop per-page deletion handler in `consulta_qr.html`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ed12a3fc832ebaf633a767683064