### PR TITLE
Avoid displaying 'None' in form fields

### DIFF
--- a/templates/animals.html
+++ b/templates/animals.html
@@ -52,7 +52,7 @@
         </select>
       </div>
       <div class="col-md-2">
-        <input type="number" name="age" value="{{ age }}" class="form-control rounded-pill" placeholder="Idade">
+        <input type="number" name="age" value="{{ '' if age is none else age }}" class="form-control rounded-pill" placeholder="Idade">
       </div>
       <div class="col-md-1">
         <button type="submit" class="btn btn-outline-primary w-100 rounded-pill">Filtrar</button>

--- a/templates/checkout_confirm.html
+++ b/templates/checkout_confirm.html
@@ -31,7 +31,7 @@
   </div>
   <form action="{{ url_for('checkout') }}" method="post" class="text-end">
     {{ form.csrf_token }}
-    <input type="hidden" name="address_id" value="{{ form.address_id.data }}">
+    <input type="hidden" name="address_id" value="{{ '' if form.address_id.data is none else form.address_id.data }}">
     <button type="submit" class="btn btn-success">
       Continuar para Pagamento
     </button>

--- a/templates/editar_bloco_exames.html
+++ b/templates/editar_bloco_exames.html
@@ -10,12 +10,12 @@
       <div class="card-body">
         <div class="mb-2 position-relative">
           <label class="form-label">Nome do Exame</label>
-          <input type="text" class="form-control exame-nome" value="{{ exame.nome }}" oninput="sugerirExames(this)">
+          <input type="text" class="form-control exame-nome" value="{{ exame.nome or '' }}" oninput="sugerirExames(this)">
           <ul class="autocomplete-sugestoes list-group position-absolute w-100" style="z-index: 10;"></ul>
         </div>
         <div class="mb-2">
           <label class="form-label">Justificativa</label>
-          <textarea class="form-control exame-justificativa" rows="2">{{ exame.justificativa }}</textarea>
+          <textarea class="form-control exame-justificativa" rows="2">{{ exame.justificativa or '' }}</textarea>
         </div>
         <button type="button" class="btn btn-danger btn-sm btn-remover">🗑️ Remover</button>
       </div>

--- a/templates/partials/animal_form.html
+++ b/templates/partials/animal_form.html
@@ -73,7 +73,7 @@
     <div class="col-md-6">
       <label for="animal-peso" class="form-label">Peso (kg)</label>
       <input id="animal-peso" type="number" name="peso" class="form-control" 
-             step="0.01" min="0.1" max="200" value="{{ animal.peso or '' }}">
+             step="0.01" min="0.1" max="200" value="{{ '' if animal.peso is none else animal.peso }}">
       <div class="invalid-feedback">Por favor, insira um peso válido (0.1-200 kg).</div>
     </div>
 

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -49,12 +49,12 @@
           <div class="card-body">
             <div class="mb-2 position-relative">
               <label class="form-label">Nome do Exame</label>
-              <input type="text" class="form-control exame-nome" value="{{ exame.nome }}" oninput="sugerirExames(this)">
+              <input type="text" class="form-control exame-nome" value="{{ exame.nome or '' }}" oninput="sugerirExames(this)">
               <ul class="autocomplete-sugestoes list-group position-absolute w-100" style="z-index: 10;"></ul>
             </div>
             <div class="mb-2">
               <label class="form-label">Justificativa</label>
-              <textarea class="form-control exame-justificativa" rows="2">{{ exame.justificativa }}</textarea>
+              <textarea class="form-control exame-justificativa" rows="2">{{ exame.justificativa or '' }}</textarea>
             </div>
             <button type="button" class="btn btn-danger btn-sm btn-remover" onclick="removerExame(this)">🗑️ Remover</button>
           </div>

--- a/templates/pedido_detail.html
+++ b/templates/pedido_detail.html
@@ -38,7 +38,7 @@
   <div class="mb-4">
     <label class="form-label fw-bold">Código de Rastreio</label>
     <div class="input-group">
-      <input type="text" class="form-control" value="{{ delivery.tracking_code }}" readonly id="trackInput">
+      <input type="text" class="form-control" value="{{ delivery.tracking_code or '' }}" readonly id="trackInput">
       <button class="btn btn-outline-secondary" type="button" onclick="navigator.clipboard.writeText(document.getElementById('trackInput').value)">
         <i class="bi bi-clipboard"></i>
       </button>

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -35,11 +35,11 @@
         {{ tutor_form.hidden_tag() }}
         <div class="col-md-6">
           <label class="form-label">Nome</label>
-          <input name="name" class="form-control" value="{{ tutor.name }}" required>
+          <input name="name" class="form-control" value="{{ tutor.name or '' }}" required>
         </div>
         <div class="col-md-6">
           <label class="form-label">E‑mail</label>
-          <input name="email" type="email" class="form-control" value="{{ tutor.email }}" required>
+          <input name="email" type="email" class="form-control" value="{{ tutor.email or '' }}" required>
         </div>
         <div class="col-md-6">
           <label class="form-label">Telefone</label>
@@ -194,7 +194,7 @@
 
             <div class="col-md-6">
               <label class="form-label">Nome</label>
-              <input name="name" class="form-control" value="{{ a.name }}" required>
+              <input name="name" class="form-control" value="{{ a.name or '' }}" required>
             </div>
 
 
@@ -236,19 +236,19 @@
             </div>
             <div class="col-md-3">
               <label class="form-label">Microchip</label>
-              <input name="microchip_number" class="form-control" value="{{ a.microchip_number }}">
+              <input name="microchip_number" class="form-control" value="{{ a.microchip_number or '' }}">
             </div>
             <div class="col-md-3">
               <label class="form-label">Peso (kg)</label>
-              <input name="peso" type="number" step="0.01" class="form-control" value="{{ a.peso }}">
+              <input name="peso" type="number" step="0.01" class="form-control" value="{{ '' if a.peso is none else a.peso }}">
             </div>
             <div class="col-md-6">
               <label class="form-label">Plano de Saúde</label>
-              <input name="health_plan" class="form-control" value="{{ a.health_plan }}">
+              <input name="health_plan" class="form-control" value="{{ a.health_plan or '' }}">
             </div>
             <div class="col-12">
               <label class="form-label">Descrição</label>
-              <textarea name="description" class="form-control">{{ a.description }}</textarea>
+              <textarea name="description" class="form-control">{{ a.description or '' }}</textarea>
             </div>
             <div class="col-12">
               <label class="form-label">Castrado?</label>


### PR DESCRIPTION
## Summary
- Ensure checkout address hidden field renders empty string when unset
- Normalize exam editing forms to blank out missing values
- Prevent tutor and animal edit forms from showing `None`
- Keep filters and weights from defaulting to `None` in animal forms

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_6894fc76a1c8832e89e0fe4dcf9b54c6