### PR TITLE
Fix account dropdown on consulta_qr page

### DIFF
--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -396,16 +396,10 @@ document.addEventListener('form-sync-success', function(ev) {
 </style>
 
 <script>
+// Initialize dropdowns normally without interfering with Bootstrap's events
 document.addEventListener("DOMContentLoaded", function () {
-  // Rebind dropdown after all tab JS is attached
-  const dropdownTriggers = document.querySelectorAll('.dropdown-toggle[data-bs-toggle="dropdown"]');
-  dropdownTriggers.forEach(trigger => {
-    bootstrap.Dropdown.getOrCreateInstance(trigger); // Ensures instance exists
-    trigger.addEventListener('click', function (e) {
-      e.preventDefault(); // Let Bootstrap handle toggle
-      e.stopImmediatePropagation(); // Prevent tab handlers from swallowing event
-      bootstrap.Dropdown.getOrCreateInstance(trigger).toggle();
-    });
+  document.querySelectorAll('.dropdown-toggle[data-bs-toggle="dropdown"]').forEach(trigger => {
+    bootstrap.Dropdown.getOrCreateInstance(trigger);
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- ensure profile dropdown initializes without conflicting event handlers on consulta QR page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689508195060832e8ec3f788fedf79eb