### PR TITLE
Add veterinarian specialties management

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -24,14 +24,14 @@ def _is_admin():
 # --------------------------------------------------------------------------
 try:
     from models import (
-        Breed, Species, TipoRacao, ApresentacaoMedicamento, VacinaModelo, Consulta, Veterinario,
+        Breed, Species, TipoRacao, ApresentacaoMedicamento, VacinaModelo, Consulta, Veterinario, Specialty,
         Clinica, ClinicHours, VetSchedule, Prescricao, Medicamento, db, User, Animal, Message,
         Transaction, Review, Favorite, AnimalPhoto, UserRole, ExameModelo,
         Product, Order, OrderItem, DeliveryRequest, HealthPlan, HealthSubscription, PickupLocation, Endereco, Payment, PaymentMethod, PaymentStatus
     )
 except ImportError:
     from .models import (
-        Breed, Species, TipoRacao, ApresentacaoMedicamento, VacinaModelo, Consulta, Veterinario,
+        Breed, Species, TipoRacao, ApresentacaoMedicamento, VacinaModelo, Consulta, Veterinario, Specialty,
         Clinica, ClinicHours, VetSchedule, Prescricao, Medicamento, db, User, Animal, Message,
         Transaction, Review, Favorite, AnimalPhoto, UserRole, ExameModelo,
         Product, Order, OrderItem, DeliveryRequest, HealthPlan, HealthSubscription, PickupLocation, Endereco, Payment, PaymentMethod, PaymentStatus
@@ -229,8 +229,9 @@ class EnderecoAdmin(MyModelView):
 
 
 class VeterinarioAdmin(MyModelView):
-    form_columns = ['user', 'crmv', 'clinica']
-    column_list = ['id', 'user', 'crmv', 'clinica']
+    form_columns = ['user', 'crmv', 'clinica', 'specialties']
+    column_list = ['id', 'user', 'crmv', 'clinica', 'specialty_list']
+    column_labels = {'specialty_list': 'Especialidades'}
 
 class ClinicaAdmin(MyModelView):
     form_extra_fields = {
@@ -441,6 +442,7 @@ def init_admin(app):
     admin.add_view(ClinicHoursAdmin(ClinicHours, db.session, name='Horários da Clínica'))
     admin.add_view(VetScheduleAdmin(VetSchedule, db.session, name='Agenda do Veterinário'))
     admin.add_view(VeterinarioAdmin(Veterinario, db.session))
+    admin.add_view(MyModelView(Specialty, db.session, name='Especialidades'))
     admin.add_view(MyModelView(ExameModelo, db.session))
     admin.add_view(MyModelView(Consulta, db.session))
     admin.add_view(MyModelView(VacinaModelo, db.session))

--- a/forms.py
+++ b/forms.py
@@ -3,6 +3,7 @@ from wtforms import (
     StringField,
     TextAreaField,
     SelectField,
+    SelectMultipleField,
     PasswordField,
     SubmitField,
     BooleanField,
@@ -297,6 +298,11 @@ class VetScheduleForm(FlaskForm):
     )
     hora_inicio = TimeField('Hora de Início', validators=[DataRequired()])
     hora_fim = TimeField('Hora de Fim', validators=[DataRequired()])
+    submit = SubmitField('Salvar')
+
+
+class VetSpecialtyForm(FlaskForm):
+    specialties = SelectMultipleField('Especialidades', coerce=int)
     submit = SubmitField('Salvar')
 
 

--- a/migrations/versions/b5c3f2d1e0ab_add_specialty_model.py
+++ b/migrations/versions/b5c3f2d1e0ab_add_specialty_model.py
@@ -1,0 +1,36 @@
+"""add specialty model
+
+Revision ID: b5c3f2d1e0ab
+Revises: 01fb1a503d86
+Create Date: 2024-11-19 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b5c3f2d1e0ab'
+down_revision = '01fb1a503d86'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'specialty',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('nome', sa.String(length=120), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('nome')
+    )
+    op.create_table(
+        'veterinario_especialidade',
+        sa.Column('veterinario_id', sa.Integer(), nullable=False),
+        sa.Column('specialty_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['veterinario_id'], ['veterinario.id']),
+        sa.ForeignKeyConstraint(['specialty_id'], ['specialty.id']),
+        sa.PrimaryKeyConstraint('veterinario_id', 'specialty_id')
+    )
+
+def downgrade():
+    op.drop_table('veterinario_especialidade')
+    op.drop_table('specialty')

--- a/models.py
+++ b/models.py
@@ -504,6 +504,22 @@ class ClinicHours(db.Model):
 
     clinica = db.relationship('Clinica', backref='horarios')
 
+# Associação many-to-many entre veterinário e especialidade
+veterinario_especialidade = db.Table(
+    'veterinario_especialidade',
+    db.Column('veterinario_id', db.Integer, db.ForeignKey('veterinario.id'), primary_key=True),
+    db.Column('specialty_id', db.Integer, db.ForeignKey('specialty.id'), primary_key=True)
+)
+
+
+class Specialty(db.Model):
+    __tablename__ = 'specialty'
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(120), unique=True, nullable=False)
+
+    def __str__(self):
+        return self.nome
+
 class Veterinario(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(
@@ -515,6 +531,11 @@ class Veterinario(db.Model):
     clinica_id = db.Column(db.Integer, db.ForeignKey('clinica.id'))
 
     user = db.relationship('User', back_populates='veterinario', uselist=False)
+    specialties = db.relationship('Specialty', secondary='veterinario_especialidade', backref='veterinarios')
+
+    @property
+    def specialty_list(self):
+        return ", ".join(s.nome for s in self.specialties)
 
     def __str__(self):
         return f"{self.user.name} (CRMV: {self.crmv})"

--- a/templates/edit_vet_specialties.html
+++ b/templates/edit_vet_specialties.html
@@ -1,0 +1,14 @@
+{% extends 'layout.html' %}
+{% block main %}
+<div class="container py-4">
+  <h2 class="mb-4">Especialidades – {{ veterinario.user.name }}</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+      {{ form.specialties.label }}
+      {{ form.specialties(class="form-select", multiple=true) }}
+    </div>
+    <button type="submit" class="btn btn-primary">Salvar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -16,11 +16,19 @@
                 {% if tutor.cpf %}
                   <p class="mb-1"><strong>CPF:</strong> {{ tutor.cpf }}</p>
                 {% endif %}
+                {% if tutor.worker|lower == 'veterinario' and tutor.veterinario.specialties %}
+                  <p class="mb-1"><strong>Especialidades:</strong> {{ tutor.veterinario.specialty_list }}</p>
+                {% endif %}
               </div>
               <div class="d-flex flex-wrap gap-2 mt-3">
                 <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-dark w-100">
                   📋 Ver Ficha
                 </a>
+                {% if tutor.worker|lower == 'veterinario' %}
+                <a href="{{ url_for('edit_vet_specialties', veterinario_id=tutor.veterinario.id) }}" class="btn btn-sm btn-outline-primary w-100">
+                  🩺 Especialidades
+                </a>
+                {% endif %}
               </div>
             </div>
           </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -54,6 +54,19 @@
           {{ field_row('Email', form.email, 'email', current_user.email) }}
           {{ field_row('Telefone', form.phone, 'phone', current_user.phone) }}
 
+          {% if current_user.veterinario %}
+          <div class="mb-3">
+            <label class="form-label">Especialidades</label>
+            <div class="d-flex flex-wrap gap-2">
+              {% for esp in current_user.veterinario.specialties %}
+                <span class="badge bg-secondary">{{ esp.nome }}</span>
+              {% else %}
+                <span class="text-muted">---</span>
+              {% endfor %}
+            </div>
+          </div>
+          {% endif %}
+
           <!-- Endereço -->
           {% set tutor = current_user %}
           {% set endereco = tutor.endereco if tutor and tutor.endereco else None %}

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -66,6 +66,19 @@
           <label class="form-label">Foto do Tutor</label>
           {{ photo_cropper(tutor_form.profile_photo, tutor_form.photo_rotation, tutor_form.photo_zoom, tutor_form.photo_offset_x, tutor_form.photo_offset_y, tutor.profile_photo, 150, 'profile_photo', 'user') }}
         </div>
+        {% if tutor.worker|lower == 'veterinario' and tutor.veterinario %}
+        <div class="col-12">
+          <label class="form-label">Especialidades</label>
+          <div class="d-flex flex-wrap gap-2">
+            {% for esp in tutor.veterinario.specialties %}
+              <span class="badge bg-secondary">{{ esp.nome }}</span>
+            {% else %}
+              <span class="text-muted">Nenhuma</span>
+            {% endfor %}
+          </div>
+          <a href="{{ url_for('edit_vet_specialties', veterinario_id=tutor.veterinario.id) }}" class="btn btn-sm btn-outline-primary mt-2">Editar Especialidades</a>
+        </div>
+        {% endif %}
 
 
         <!-- ======================== Endereço ======================== -->

--- a/templates/tutores.html
+++ b/templates/tutores.html
@@ -99,7 +99,11 @@
       data.forEach(t => {
         const li = document.createElement('li');
         li.className = 'list-group-item list-group-item-action';
-        li.textContent = `${t.name} (${t.email})`;
+        let texto = `${t.name} (${t.email})`;
+        if (t.specialties) {
+          texto += ` – ${t.specialties}`;
+        }
+        li.textContent = texto;
         li.onclick = () => window.location = `/ficha_tutor/${t.id}`;
         listaTutor.appendChild(li);
       });

--- a/templates/vet_schedule.html
+++ b/templates/vet_schedule.html
@@ -3,6 +3,9 @@
 {% block main %}
 <div class="container mt-4">
   <h2>Agenda – {{ veterinario.user.name }}</h2>
+  {% if veterinario.specialties %}
+  <p><strong>Especialidades:</strong> {{ veterinario.specialty_list }}</p>
+  {% endif %}
   <ul class="list-unstyled">
     {% for h in horarios %}
       <li>{{ h.dia_semana }}: {{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}</li>


### PR DESCRIPTION
## Summary
- add Specialty model and many-to-many link with Veterinario
- allow clinics to assign specialties to vets and manage via admin
- display veterinarian specialties in profiles, listings, and search

## Testing
- `pytest`
- `flask db migrate -m "add specialty model"` *(fails: Target database is not up to date)*

------
https://chatgpt.com/codex/tasks/task_e_6899da0293cc832e817ccd84babf5af1