### PR TITLE
Enable vets to manage clinic and schedule from index

### DIFF
--- a/app.py
+++ b/app.py
@@ -1597,7 +1597,14 @@ def clinic_hours(clinica_id):
 @app.route('/admin/clinica/<int:clinica_id>/horarios', methods=['GET', 'POST'])
 @login_required
 def edit_clinic_hours(clinica_id):
-    if not _is_admin():
+    if not (
+        _is_admin()
+        or (
+            current_user.worker == 'veterinario'
+            and getattr(current_user, 'veterinario', None)
+            and current_user.veterinario.clinica_id == clinica_id
+        )
+    ):
         abort(403)
     clinica = Clinica.query.get_or_404(clinica_id)
     form = ClinicHoursForm()
@@ -1635,7 +1642,14 @@ def vet_schedule(veterinario_id):
 @app.route('/admin/veterinario/<int:veterinario_id>/agenda', methods=['GET', 'POST'])
 @login_required
 def edit_vet_schedule(veterinario_id):
-    if not _is_admin():
+    if not (
+        _is_admin()
+        or (
+            current_user.worker == 'veterinario'
+            and getattr(current_user, 'veterinario', None)
+            and current_user.veterinario.id == veterinario_id
+        )
+    ):
         abort(403)
     veterinario = Veterinario.query.get_or_404(veterinario_id)
     form = VetScheduleForm()

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,6 +91,20 @@
                    data-bs-toggle="tooltip" title="Veja os tutores cadastrados.">
                     👥 Tutores
                 </a>
+
+                {% if current_user.worker == 'veterinario' and current_user.veterinario %}
+                <a href="{{ url_for('edit_clinic_hours', clinica_id=current_user.veterinario.clinica_id) }}"
+                   class="btn btn-outline-info rounded-pill shadow-sm px-4 py-2"
+                   data-bs-toggle="tooltip" title="Gerencie as informações da sua clínica.">
+                    🏥 Clínica
+                </a>
+
+                <a href="{{ url_for('edit_vet_schedule', veterinario_id=current_user.veterinario.id) }}"
+                   class="btn btn-outline-warning rounded-pill shadow-sm px-4 py-2"
+                   data-bs-toggle="tooltip" title="Administre sua agenda de atendimentos.">
+                    🗓️ Agenda
+                </a>
+                {% endif %}
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- Allow veterinarians to edit their clinic hours and own schedule
- Add professional area buttons linking to clinic and schedule management

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899e8f0e4b0832eae2fe59c33e42ac6