### PR TITLE
Add appointment scheduling and management views

### DIFF
--- a/app.py
+++ b/app.py
@@ -170,7 +170,8 @@ from forms import (
     ResetPasswordRequestForm, ResetPasswordForm, OrderItemForm,
     DeliveryRequestForm, AddToCartForm, SubscribePlanForm,
     ProductUpdateForm, ProductPhotoForm, ChangePasswordForm,
-    DeleteAccountForm, ClinicHoursForm, VetScheduleForm
+    DeleteAccountForm, ClinicHoursForm, VetScheduleForm,
+    AppointmentForm, AppointmentDeleteForm
 )
 from helpers import calcular_idade, parse_data_nascimento
 
@@ -4951,6 +4952,61 @@ def pedido_detail(order_id):
 
 
 
+
+@app.route('/appointments/new', methods=['GET', 'POST'])
+@login_required
+def schedule_appointment():
+    form = AppointmentForm()
+    form.veterinario_id.choices = [
+        (v.id, v.user.name) for v in Veterinario.query.order_by(Veterinario.id).all()
+    ]
+    if form.validate_on_submit():
+        appt = Appointment(
+            tutor_id=current_user.id,
+            veterinario_id=form.veterinario_id.data,
+            scheduled_at=form.scheduled_at.data,
+            description=form.description.data,
+        )
+        db.session.add(appt)
+        db.session.commit()
+        flash('Agendamento criado com sucesso.', 'success')
+        return redirect(url_for('list_appointments'))
+    return render_template('schedule_appointment.html', form=form)
+
+
+@app.route('/appointments')
+@login_required
+def list_appointments():
+    appointments = (
+        Appointment.query
+        .filter_by(tutor_id=current_user.id)
+        .order_by(Appointment.scheduled_at)
+        .all()
+    )
+    return render_template('appointments.html', appointments=appointments)
+
+
+@app.route('/appointments/manage')
+@login_required
+def manage_appointments():
+    if current_user.role != 'admin' and current_user.worker != 'veterinario':
+        flash('Acesso restrito.', 'danger')
+        return redirect(url_for('index'))
+    appointments = Appointment.query.order_by(Appointment.scheduled_at).all()
+    delete_form = AppointmentDeleteForm()
+    return render_template('appointments_admin.html', appointments=appointments, delete_form=delete_form)
+
+
+@app.route('/appointments/<int:appointment_id>/delete', methods=['POST'])
+@login_required
+def delete_appointment(appointment_id):
+    appointment = Appointment.query.get_or_404(appointment_id)
+    if current_user.role != 'admin' and current_user.worker != 'veterinario':
+        abort(403)
+    db.session.delete(appointment)
+    db.session.commit()
+    flash('Agendamento removido.', 'success')
+    return redirect(request.referrer or url_for('manage_appointments'))
 
 
 if __name__ == "__main__":

--- a/forms.py
+++ b/forms.py
@@ -10,6 +10,7 @@ from wtforms import (
     DecimalField,
     IntegerField,
     DateField,
+    DateTimeField,
     TimeField,
 )
 from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional
@@ -212,6 +213,15 @@ class ChangePasswordForm(FlaskForm):
 class DeleteAccountForm(FlaskForm):
     submit = SubmitField('Excluir Conta')
 
+class AppointmentForm(FlaskForm):
+    veterinario_id = SelectField('Veterinário', coerce=int, validators=[DataRequired()])
+    scheduled_at = DateTimeField('Data e Hora', format='%Y-%m-%d %H:%M', validators=[DataRequired()])
+    description = TextAreaField('Descrição', validators=[Optional()])
+    submit = SubmitField('Agendar')
+
+
+class AppointmentDeleteForm(FlaskForm):
+    submit = SubmitField('Excluir')
 
 
 class MessageForm(FlaskForm):

--- a/models.py
+++ b/models.py
@@ -552,6 +552,18 @@ class VetSchedule(db.Model):
     veterinario = db.relationship('Veterinario', backref='horarios')
 
 
+class Appointment(db.Model):
+    __tablename__ = 'appointment'
+    id = db.Column(db.Integer, primary_key=True)
+    tutor_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    veterinario_id = db.Column(db.Integer, db.ForeignKey('veterinario.id'), nullable=False)
+    scheduled_at = db.Column(db.DateTime, nullable=False)
+    description = db.Column(db.Text)
+    status = db.Column(db.String(20), default='pendente')
+
+    tutor = db.relationship('User', backref='appointments', foreign_keys=[tutor_id])
+    veterinario = db.relationship('Veterinario', backref='appointments')
+
 
 class Medicamento(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/templates/appointments.html
+++ b/templates/appointments.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container mt-4">
+  <h2>Meus Agendamentos</h2>
+  <a href="{{ url_for('schedule_appointment') }}" class="btn btn-primary mb-3">
+    <i class="fas fa-plus me-1"></i> Novo Agendamento
+  </a>
+  <ul class="list-group">
+    {% for appt in appointments %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.veterinario.user.name }}</span>
+      </li>
+    {% else %}
+      <li class="list-group-item">Nenhum agendamento encontrado.</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/templates/appointments_admin.html
+++ b/templates/appointments_admin.html
@@ -1,0 +1,20 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container mt-4">
+  <h2>Agendamentos</h2>
+  <ul class="list-group">
+    {% for appt in appointments %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.tutor.name }} &rarr; {{ appt.veterinario.user.name }}</span>
+        <form method="POST" action="{{ url_for('delete_appointment', appointment_id=appt.id) }}" class="ms-2 js-confirm" data-message="Remover agendamento?">
+          {{ delete_form.hidden_tag() }}
+          <button type="submit" class="btn btn-sm btn-danger"><i class="fas fa-trash"></i></button>
+        </form>
+      </li>
+    {% else %}
+      <li class="list-group-item">Nenhum agendamento encontrado.</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -348,6 +348,11 @@
                             <i class="fas fa-chart-line me-1 text-primary"></i> Entregas
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('manage_appointments') }}">
+                            <i class="fas fa-calendar-check me-1 text-primary"></i> Consultas
+                            </a>
+                        </li>
                     {% endif %}
                     
                     <li class="nav-item">
@@ -365,6 +370,11 @@
                             <i class="fas fa-shopping-bag me-1 text-warning"></i> Loja
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('list_appointments') }}">
+                            <i class="fas fa-calendar-alt me-1 text-primary"></i> Agendamentos
+                        </a>
+                    </li>
 
                     {% if current_user.is_authenticated %}
                         {% if current_user.worker == 'veterinario' %}
@@ -376,6 +386,11 @@
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ url_for('add_animal') }}">
                                     <i class="fas fa-plus-circle me-1 text-success"></i> Meu novo Animal
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ url_for('manage_appointments') }}">
+                                    <i class="fas fa-calendar-check me-1 text-primary"></i> Consultas
                                 </a>
                             </li>
                         {% elif current_user.worker == 'delivery' %}

--- a/templates/schedule_appointment.html
+++ b/templates/schedule_appointment.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container mt-4">
+  <h2>Agendar Consulta</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+      {{ form.veterinario_id.label(class="form-label") }}
+      {{ form.veterinario_id(class="form-select") }}
+    </div>
+    <div class="mb-3">
+      {{ form.scheduled_at.label(class="form-label") }}
+      {{ form.scheduled_at(class="form-control", placeholder="YYYY-MM-DD HH:MM") }}
+    </div>
+    <div class="mb-3">
+      {{ form.description.label(class="form-label") }}
+      {{ form.description(class="form-control", rows=3) }}
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create Appointment model and forms for scheduling and deletion
- add routes and templates for users to book and review appointments
- provide admin/vet interface and navigation links for managing appointments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e82d2864832ebcb8b84b74157b7b