### PR TITLE
Add appointment model with health subscription validation

### DIFF
--- a/migrations/versions/d423b058d278_add_appointment_model.py
+++ b/migrations/versions/d423b058d278_add_appointment_model.py
@@ -1,0 +1,37 @@
+"""add appointment model
+
+Revision ID: d423b058d278
+Revises: b5c3f2d1e0ab, f9730e287995
+Create Date: 2025-08-11 13:00:31.631922
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd423b058d278'
+down_revision = ('b5c3f2d1e0ab', 'f9730e287995')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'appointment',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('animal_id', sa.Integer(), nullable=False),
+        sa.Column('tutor_id', sa.Integer(), nullable=False),
+        sa.Column('veterinario_id', sa.Integer(), nullable=False),
+        sa.Column('scheduled_at', sa.DateTime(), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('consulta_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['animal_id'], ['animal.id']),
+        sa.ForeignKeyConstraint(['tutor_id'], ['user.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['veterinario_id'], ['veterinario.id']),
+        sa.ForeignKeyConstraint(['consulta_id'], ['consulta.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('appointment')

--- a/models.py
+++ b/models.py
@@ -8,7 +8,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 import enum
-from sqlalchemy import Enum
+from sqlalchemy import Enum, event
 from enum import Enum
 from sqlalchemy import Enum as PgEnum
 
@@ -552,6 +552,63 @@ class VetSchedule(db.Model):
     veterinario = db.relationship('Veterinario', backref='horarios')
 
 
+
+
+class Appointment(db.Model):
+    __tablename__ = 'appointment'
+
+    id = db.Column(db.Integer, primary_key=True)
+    animal_id = db.Column(db.Integer, db.ForeignKey('animal.id'), nullable=False)
+    tutor_id = db.Column(
+        db.Integer,
+        db.ForeignKey('user.id', ondelete='CASCADE'),
+        nullable=False,
+    )
+    veterinario_id = db.Column(db.Integer, db.ForeignKey('veterinario.id'), nullable=False)
+    scheduled_at = db.Column(db.DateTime, nullable=False)
+    status = db.Column(db.String(20), nullable=False, default='scheduled')
+    consulta_id = db.Column(db.Integer, db.ForeignKey('consulta.id'), nullable=True)
+
+    animal = db.relationship(
+        'Animal',
+        backref=db.backref('appointments', cascade='all, delete-orphan'),
+    )
+    tutor = db.relationship(
+        'User',
+        foreign_keys=[tutor_id],
+        backref=db.backref('appointments', cascade='all, delete-orphan'),
+    )
+    veterinario = db.relationship(
+        'Veterinario',
+        backref=db.backref('appointments', cascade='all, delete-orphan'),
+    )
+    consulta = db.relationship(
+        'Consulta',
+        backref=db.backref('appointment', uselist=False),
+        uselist=False,
+    )
+
+    @classmethod
+    def has_active_subscription(cls, animal_id, tutor_id):
+        from models import HealthSubscription
+
+        return (
+            HealthSubscription.query
+            .filter_by(animal_id=animal_id, user_id=tutor_id, active=True)
+            .first()
+            is not None
+        )
+
+    @staticmethod
+    def _validate_subscription(mapper, connection, target):
+        if not type(target).has_active_subscription(target.animal_id, target.tutor_id):
+            raise ValueError(
+                'Animal does not have an active health subscription for this tutor.'
+            )
+
+
+event.listen(Appointment, 'before_insert', Appointment._validate_subscription)
+event.listen(Appointment, 'before_update', Appointment._validate_subscription)
 
 class Medicamento(db.Model):
     id = db.Column(db.Integer, primary_key=True)


### PR DESCRIPTION
## Summary
- add `Appointment` ORM model linking animals, tutors, vets and consultations
- validate active health plan before appointments are saved
- add Alembic migration for `appointment` table

## Testing
- `flask db upgrade heads` *(fails: no such table: order)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899e829516c832e8f03a263c90b9b31