### PR TITLE
Add vet appointment scheduling with availability checks

### DIFF
--- a/templates/appointment_confirmation.html
+++ b/templates/appointment_confirmation.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container mt-4">
+  <h2>Consulta agendada!</h2>
+  <p>Sua consulta foi marcada para {{ appointment.scheduled_at|datetime_brazil }} com o veterinário {{ appointment.veterinario.user.name if appointment.veterinario and appointment.veterinario.user else appointment.veterinario_id }}.</p>
+  <a href="{{ url_for('list_appointments') }}" class="btn btn-primary">Ver agendamentos</a>
+</div>
+{% endblock %}

--- a/templates/schedule_appointment.html
+++ b/templates/schedule_appointment.html
@@ -6,16 +6,24 @@
   <form method="POST">
     {{ form.hidden_tag() }}
     <div class="mb-3">
+      {{ form.animal_id.label(class="form-label") }}
+      {{ form.animal_id(class="form-select") }}
+    </div>
+    <div class="mb-3">
       {{ form.veterinario_id.label(class="form-label") }}
       {{ form.veterinario_id(class="form-select") }}
     </div>
     <div class="mb-3">
-      {{ form.scheduled_at.label(class="form-label") }}
-      {{ form.scheduled_at(class="form-control", placeholder="YYYY-MM-DD HH:MM") }}
+      {{ form.date.label(class="form-label") }}
+      {{ form.date(class="form-control", type="date") }}
     </div>
     <div class="mb-3">
-      {{ form.description.label(class="form-label") }}
-      {{ form.description(class="form-control", rows=3) }}
+      {{ form.time.label(class="form-label") }}
+      {{ form.time(class="form-control", type="time") }}
+    </div>
+    <div class="mb-3">
+      {{ form.reason.label(class="form-label") }}
+      {{ form.reason(class="form-control", rows=3) }}
     </div>
     {{ form.submit(class="btn btn-primary") }}
   </form>


### PR DESCRIPTION
## Summary
- add helper to verify veterinarian availability against schedules and existing appointments
- allow logged-in users to schedule appointments if slot is available
- add appointment confirmation page and update scheduling form

## Testing
- `pytest` *(fails: Table 'endereco' is already defined for this MetaData instance)*

------
https://chatgpt.com/codex/tasks/task_e_6899ec849e14832e822d0fb019ac6c70