### PR TITLE
Remove duplicate Appointment model

### DIFF
--- a/models.py
+++ b/models.py
@@ -554,20 +554,6 @@ class VetSchedule(db.Model):
 
 class Appointment(db.Model):
     __tablename__ = 'appointment'
-    id = db.Column(db.Integer, primary_key=True)
-    tutor_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    veterinario_id = db.Column(db.Integer, db.ForeignKey('veterinario.id'), nullable=False)
-    scheduled_at = db.Column(db.DateTime, nullable=False)
-    description = db.Column(db.Text)
-    status = db.Column(db.String(20), default='pendente')
-
-    tutor = db.relationship('User', backref='appointments', foreign_keys=[tutor_id])
-    veterinario = db.relationship('Veterinario', backref='appointments')
-
-
-
-class Appointment(db.Model):
-    __tablename__ = 'appointment'
 
     id = db.Column(db.Integer, primary_key=True)
     animal_id = db.Column(db.Integer, db.ForeignKey('animal.id'), nullable=False)


### PR DESCRIPTION
## Summary
- remove extra `Appointment` model definition causing SQLAlchemy table conflicts

## Testing
- `pytest`
- `python - <<'PY'
import importlib
import app
print('imported app')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6899ecc84784832eaa9f35d009155438