### PR TITLE
Enable multi-day scheduling for clinics and vets

### DIFF
--- a/app.py
+++ b/app.py
@@ -1613,13 +1613,14 @@ def edit_clinic_hours(clinica_id):
     if request.method == 'GET':
         form.clinica_id.data = clinica.id
     if form.validate_on_submit():
-        horario = ClinicHours(
-            clinica_id=form.clinica_id.data,
-            dia_semana=form.dia_semana.data,
-            hora_abertura=form.hora_abertura.data,
-            hora_fechamento=form.hora_fechamento.data,
-        )
-        db.session.add(horario)
+        for dia in form.dias_semana.data:
+            horario = ClinicHours(
+                clinica_id=form.clinica_id.data,
+                dia_semana=dia,
+                hora_abertura=form.hora_abertura.data,
+                hora_fechamento=form.hora_fechamento.data,
+            )
+            db.session.add(horario)
         db.session.commit()
         flash('Horário salvo com sucesso.', 'success')
         return redirect(url_for('clinic_detail', clinica_id=clinica.id))
@@ -1658,13 +1659,14 @@ def edit_vet_schedule(veterinario_id):
     if request.method == 'GET':
         form.veterinario_id.data = veterinario.id
     if form.validate_on_submit():
-        horario = VetSchedule(
-            veterinario_id=form.veterinario_id.data,
-            dia_semana=form.dia_semana.data,
-            hora_inicio=form.hora_inicio.data,
-            hora_fim=form.hora_fim.data,
-        )
-        db.session.add(horario)
+        for dia in form.dias_semana.data:
+            horario = VetSchedule(
+                veterinario_id=form.veterinario_id.data,
+                dia_semana=dia,
+                hora_inicio=form.hora_inicio.data,
+                hora_fim=form.hora_fim.data,
+            )
+            db.session.add(horario)
         db.session.commit()
         flash('Horário salvo com sucesso.', 'success')
         return redirect(url_for('vet_detail', veterinario_id=veterinario.id))

--- a/forms.py
+++ b/forms.py
@@ -278,8 +278,8 @@ class ClinicHoursForm(FlaskForm):
         validators=[DataRequired()],
         render_kw={"class": "form-select"},
     )
-    dia_semana = SelectField(
-        'Dia da Semana',
+    dias_semana = SelectMultipleField(
+        'Dias da Semana',
         choices=[
             ('Segunda', 'Segunda'),
             ('Terça', 'Terça'),
@@ -290,7 +290,7 @@ class ClinicHoursForm(FlaskForm):
             ('Domingo', 'Domingo'),
         ],
         validators=[DataRequired()],
-        render_kw={"class": "form-select"},
+        render_kw={"class": "form-select", "multiple": True},
     )
     hora_abertura = TimeField(
         'Hora de Abertura',
@@ -312,8 +312,8 @@ class VetScheduleForm(FlaskForm):
         validators=[DataRequired()],
         render_kw={"class": "form-select"},
     )
-    dia_semana = SelectField(
-        'Dia da Semana',
+    dias_semana = SelectMultipleField(
+        'Dias da Semana',
         choices=[
             ('Segunda', 'Segunda'),
             ('Terça', 'Terça'),
@@ -324,7 +324,7 @@ class VetScheduleForm(FlaskForm):
             ('Domingo', 'Domingo'),
         ],
         validators=[DataRequired()],
-        render_kw={"class": "form-select"},
+        render_kw={"class": "form-select", "multiple": True},
     )
     hora_inicio = TimeField(
         'Hora de Início',

--- a/templates/edit_clinic_hours.html
+++ b/templates/edit_clinic_hours.html
@@ -10,8 +10,14 @@
       {{ form.clinica_id(class="form-select") }}
     </div>
     <div class="mb-3">
-      {{ form.dia_semana.label }}
-      {{ form.dia_semana(class="form-select") }}
+      {{ form.dias_semana.label }}
+      {{ form.dias_semana(class="form-select", multiple=True, size=7) }}
+      <div class="mt-2">
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('all')">Todos</button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekday')">Dias Úteis</button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekend')">Fins de Semana</button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('clear')">Limpar</button>
+      </div>
     </div>
     <div class="mb-3">
       {{ form.hora_abertura.label }}
@@ -33,4 +39,17 @@
     {% endfor %}
   </ul>
 </div>
+<script>
+  function selectDays(mode) {
+    const select = document.getElementById('dias_semana');
+    const weekdays = ['Segunda','Terça','Quarta','Quinta','Sexta'];
+    const weekend = ['Sábado','Domingo'];
+    for (const opt of select.options) {
+      if (mode === 'all') opt.selected = true;
+      else if (mode === 'weekday') opt.selected = weekdays.includes(opt.value);
+      else if (mode === 'weekend') opt.selected = weekend.includes(opt.value);
+      else if (mode === 'clear') opt.selected = false;
+    }
+  }
+</script>
 {% endblock %}

--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -10,8 +10,14 @@
       {{ form.veterinario_id(class="form-select") }}
     </div>
     <div class="mb-3">
-      {{ form.dia_semana.label }}
-      {{ form.dia_semana(class="form-select") }}
+      {{ form.dias_semana.label }}
+      {{ form.dias_semana(class="form-select", multiple=True, size=7) }}
+      <div class="mt-2">
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('all')">Todos</button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekday')">Dias Úteis</button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekend')">Fins de Semana</button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('clear')">Limpar</button>
+      </div>
     </div>
     <div class="mb-3">
       {{ form.hora_inicio.label }}
@@ -33,4 +39,17 @@
     {% endfor %}
   </ul>
 </div>
+<script>
+  function selectDays(mode) {
+    const select = document.getElementById('dias_semana');
+    const weekdays = ['Segunda','Terça','Quarta','Quinta','Sexta'];
+    const weekend = ['Sábado','Domingo'];
+    for (const opt of select.options) {
+      if (mode === 'all') opt.selected = true;
+      else if (mode === 'weekday') opt.selected = weekdays.includes(opt.value);
+      else if (mode === 'weekend') opt.selected = weekend.includes(opt.value);
+      else if (mode === 'clear') opt.selected = false;
+    }
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow selecting multiple days when configuring clinic hours or vet schedules
- add quick-select buttons for all/weekday/weekend days
- update server-side handling to create entries for each selected day

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899f09b0fc0832ebb85ffd73391b65b