### PR TITLE
Permitir que veterinários agendem para outros animais

### DIFF
--- a/app.py
+++ b/app.py
@@ -4982,23 +4982,11 @@ def pedido_detail(order_id):
 @app.route('/appointments/new', methods=['GET', 'POST'])
 @login_required
 def schedule_appointment():
-    form = AppointmentForm()
-
-    animals = (
-        Animal.query
-        .join(HealthSubscription)
-        .filter(
-            HealthSubscription.user_id == current_user.id,
-            HealthSubscription.active == True,  # noqa: E712
-        )
-        .all()
+    is_vet = current_user.worker == 'veterinario'
+    form = AppointmentForm(
+        tutor=current_user if not is_vet else None,
+        is_veterinario=is_vet,
     )
-    form.animal_id.choices = [(a.id, a.name) for a in animals]
-
-    form.veterinario_id.choices = [
-        (v.id, v.user.name if v.user else str(v.id))
-        for v in Veterinario.query.order_by(Veterinario.id).all()
-    ]
 
     if form.validate_on_submit():
         scheduled_at = datetime.combine(form.date.data, form.time.data)
@@ -5007,9 +4995,12 @@ def schedule_appointment():
             flash('Horário indisponível para o veterinário selecionado.', 'danger')
             return render_template('schedule_appointment.html', form=form)
 
+        animal = Animal.query.get_or_404(form.animal_id.data)
+        tutor_id = current_user.id if not is_vet else animal.user_id
+
         appt = Appointment(
-            animal_id=form.animal_id.data,
-            tutor_id=current_user.id,
+            animal_id=animal.id,
+            tutor_id=tutor_id,
             veterinario_id=form.veterinario_id.data,
             scheduled_at=scheduled_at,
         )

--- a/forms.py
+++ b/forms.py
@@ -398,16 +398,34 @@ class AppointmentForm(FlaskForm):
 
     submit = SubmitField('Agendar')
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, tutor=None, is_veterinario=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from models import Animal, HealthSubscription, Veterinario
 
-        animals = (
-            Animal.query
-            .join(HealthSubscription)
-            .filter(HealthSubscription.active == True)
-            .all()
-        )
+        if is_veterinario:
+            animals = (
+                Animal.query
+                .join(HealthSubscription)
+                .filter(HealthSubscription.active == True)
+                .all()
+            )
+        elif tutor is not None:
+            animals = (
+                Animal.query
+                .join(HealthSubscription)
+                .filter(
+                    HealthSubscription.user_id == tutor.id,
+                    HealthSubscription.active == True,
+                )
+                .all()
+            )
+        else:
+            animals = (
+                Animal.query
+                .join(HealthSubscription)
+                .filter(HealthSubscription.active == True)
+                .all()
+            )
         self.animal_id.choices = [(a.id, a.name) for a in animals]
 
         veterinarios = Veterinario.query.all()

--- a/tests/test_appointment_vet.py
+++ b/tests/test_appointment_vet.py
@@ -1,0 +1,91 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import flask_login.utils as login_utils
+from app import app as flask_app, db
+from datetime import time
+from models import (
+    User,
+    Animal,
+    Veterinario,
+    Appointment,
+    HealthPlan,
+    HealthSubscription,
+    VetSchedule,
+)
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def login(monkeypatch, user):
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def test_veterinarian_can_schedule_for_other_users_animal(client, monkeypatch):
+    with flask_app.app_context():
+        tutor = User(id=1, name='Tutor', email='tutor@test')
+        tutor.set_password('x')
+        vet_user = User(id=2, name='Vet', email='vet@test', worker='veterinario')
+        vet_user.set_password('x')
+        animal = Animal(id=1, name='Rex', user_id=tutor.id)
+        plan = HealthPlan(id=1, name='Basic', price=10.0)
+        db.session.add_all([tutor, vet_user, animal, plan])
+        db.session.commit()
+        sub = HealthSubscription(
+            animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True
+        )
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123')
+        schedule = VetSchedule(
+            id=1,
+            veterinario_id=1,
+            dia_semana='Quarta',
+            hora_inicio=time(9, 0),
+            hora_fim=time(17, 0),
+        )
+        db.session.add_all([sub, vet, schedule])
+        db.session.commit()
+        animal_id = animal.id
+        vet_id = vet.id
+        tutor_id = tutor.id
+        vet_user_id = vet_user.id
+
+    fake_vet = type('U', (), {
+        'id': vet_user_id,
+        'worker': 'veterinario',
+        'role': 'adotante',
+        'name': 'Vet',
+        'is_authenticated': True,
+    })()
+    login(monkeypatch, fake_vet)
+    resp = client.post(
+        '/appointments/new',
+        data={
+            'animal_id': animal_id,
+            'veterinario_id': vet_id,
+            'date': '2024-05-01',
+            'time': '10:00',
+            'reason': 'Checkup',
+        },
+    )
+    assert resp.status_code == 302
+    with flask_app.app_context():
+        appt = Appointment.query.one()
+        assert appt.tutor_id == tutor_id
+        assert appt.animal_id == animal_id
+        assert appt.veterinario_id == vet_id


### PR DESCRIPTION
## Summary
- Permite que veterinários selecionem qualquer animal ao agendar consultas
- Ajusta formulário de agendamento para filtrar animais conforme o perfil do usuário
- Adiciona teste garantindo que veterinário agenda para animal de outro tutor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f3183e70832eb774827dbe39cfe2