### PR TITLE
Fix animal selection in appointment scheduling

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -400,32 +400,15 @@ class AppointmentForm(FlaskForm):
 
     def __init__(self, tutor=None, is_veterinario=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        from models import Animal, HealthSubscription, Veterinario
+        from models import Animal, Veterinario
 
         if is_veterinario:
-            animals = (
-                Animal.query
-                .join(HealthSubscription)
-                .filter(HealthSubscription.active == True)
-                .all()
-            )
+            animals = Animal.query.all()
         elif tutor is not None:
-            animals = (
-                Animal.query
-                .join(HealthSubscription)
-                .filter(
-                    HealthSubscription.user_id == tutor.id,
-                    HealthSubscription.active == True,
-                )
-                .all()
-            )
+            animals = Animal.query.filter_by(user_id=tutor.id).all()
         else:
-            animals = (
-                Animal.query
-                .join(HealthSubscription)
-                .filter(HealthSubscription.active == True)
-                .all()
-            )
+            animals = Animal.query.all()
+
         self.animal_id.choices = [(a.id, a.name) for a in animals]
 
         veterinarios = Veterinario.query.all()

--- a/tests/test_appointment_vet.py
+++ b/tests/test_appointment_vet.py
@@ -16,6 +16,7 @@ from models import (
     HealthSubscription,
     VetSchedule,
 )
+from forms import AppointmentForm
 
 
 @pytest.fixture
@@ -89,3 +90,36 @@ def test_veterinarian_can_schedule_for_other_users_animal(client, monkeypatch):
         assert appt.tutor_id == tutor_id
         assert appt.animal_id == animal_id
         assert appt.veterinario_id == vet_id
+
+
+def test_tutor_sees_only_their_animals_in_form(client):
+    with flask_app.app_context():
+        tutor1 = User(id=1, name='Tutor1', email='t1@test')
+        tutor1.set_password('x')
+        tutor2 = User(id=2, name='Tutor2', email='t2@test')
+        tutor2.set_password('x')
+        animal1 = Animal(id=1, name='Rex', user_id=tutor1.id)
+        animal2 = Animal(id=2, name='Fido', user_id=tutor2.id)
+        db.session.add_all([tutor1, tutor2, animal1, animal2])
+        db.session.commit()
+        form = AppointmentForm(tutor=tutor1)
+        assert (animal1.id, animal1.name) in form.animal_id.choices
+        assert (animal2.id, animal2.name) not in form.animal_id.choices
+
+
+def test_veterinarian_sees_all_animals_in_form(client):
+    with flask_app.app_context():
+        tutor1 = User(id=1, name='Tutor1', email='t1@test')
+        tutor1.set_password('x')
+        tutor2 = User(id=2, name='Tutor2', email='t2@test')
+        tutor2.set_password('x')
+        animal1 = Animal(id=1, name='Rex', user_id=tutor1.id)
+        animal2 = Animal(id=2, name='Fido', user_id=tutor2.id)
+        vet_user = User(id=3, name='Vet', email='vet@test', worker='veterinario')
+        vet_user.set_password('x')
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123')
+        db.session.add_all([tutor1, tutor2, animal1, animal2, vet_user, vet])
+        db.session.commit()
+        form = AppointmentForm(is_veterinario=True)
+        assert (animal1.id, animal1.name) in form.animal_id.choices
+        assert (animal2.id, animal2.name) in form.animal_id.choices


### PR DESCRIPTION
## Summary
- Show all animals to veterinarians and only their own animals to tutors when scheduling appointments
- Test form choices for both roles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f704264c832e9cceccdcb3031520