### PR TITLE
Handle missing health subscription when scheduling appointments

### DIFF
--- a/app.py
+++ b/app.py
@@ -5029,6 +5029,10 @@ def schedule_appointment():
         animal = Animal.query.get_or_404(form.animal_id.data)
         tutor_id = current_user.id if not is_vet else animal.user_id
 
+        if not Appointment.has_active_subscription(animal.id, tutor_id):
+            flash('O animal não possui uma assinatura de plano de saúde ativa.', 'danger')
+            return render_template('schedule_appointment.html', form=form)
+
         appt = Appointment(
             animal_id=animal.id,
             tutor_id=tutor_id,


### PR DESCRIPTION
## Summary
- Prevent server error when scheduling appointments by verifying an active health subscription before committing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899faa5f200832ea8600cee53df232b