### PR TITLE
Handle invalid vaccine date input

### DIFF
--- a/app.py
+++ b/app.py
@@ -2575,7 +2575,14 @@ def salvar_vacinas(animal_id):
 
     try:
         for v in data["vacinas"]:
-            data_formatada = datetime.strptime(v.get("data"), "%Y-%m-%d").date() if v.get("data") else None
+            data_str = v.get("data")
+            if data_str:
+                try:
+                    data_formatada = datetime.strptime(data_str, "%Y-%m-%d").date()
+                except ValueError:
+                    data_formatada = None
+            else:
+                data_formatada = None
 
             vacina = Vacina(
                 animal_id=animal_id,
@@ -2655,8 +2662,12 @@ def editar_vacina(vacina_id):
         vacina.tipo = data.get("tipo", vacina.tipo)
         vacina.observacoes = data.get("observacoes", vacina.observacoes)
 
-        if data.get("data"):
-            vacina.data = datetime.strptime(data["data"], "%Y-%m-%d").date()
+        data_str = data.get("data")
+        if data_str:
+            try:
+                vacina.data = datetime.strptime(data_str, "%Y-%m-%d").date()
+            except ValueError:
+                vacina.data = None
 
         db.session.commit()
         return jsonify({"success": True})

--- a/tests/test_vacinas.py
+++ b/tests/test_vacinas.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 from app import app as flask_app, db
-from models import User, Animal, Clinica
+from models import User, Animal, Clinica, Vacina
 
 @pytest.fixture
 def app():
@@ -26,3 +26,25 @@ def test_imprimir_vacinas_no_login(app):
         assert resp.status_code == 200
         assert b"Rex" in resp.data
         assert b"Pet Clinic" in resp.data
+
+
+def test_salvar_vacina_data_invalida(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        owner = User(name="Tutor", email="tutor@example.com", password_hash="x")
+        animal = Animal(name="Rex", owner=owner)
+        db.session.add_all([owner, animal])
+        db.session.commit()
+
+        client = app.test_client()
+        payload = {"vacinas": [{"nome": "Antirrabica", "tipo": "Teste", "data": "111111-11-11"}]}
+        resp = client.post(f"/animal/{animal.id}/vacinas", json=payload)
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+
+        vacina = Vacina.query.filter_by(animal_id=animal.id).first()
+        assert vacina is not None
+        assert vacina.data is None


### PR DESCRIPTION
## Summary
- tolerate malformed vaccine dates when creating records
- allow editing vaccines with invalid dates without crashing
- add regression test covering invalid vaccine date handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a0dff8b7c832eb382634e3722575b