### PR TITLE
Show scheduled appointments on vet agenda page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1743,12 +1743,20 @@ def edit_vet_schedule(veterinario_id):
     horarios = VetSchedule.query.filter_by(
         veterinario_id=veterinario.id
     ).all()
+
+    appointments = (
+        Appointment.query.filter_by(veterinario_id=veterinario.id)
+        .order_by(Appointment.scheduled_at)
+        .all()
+    )
+
     return render_template(
         'edit_vet_schedule.html',
         schedule_form=schedule_form,
         appointment_form=appointment_form,
         veterinario=veterinario,
         horarios=horarios,
+        appointments=appointments,
     )
 
 

--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -105,6 +105,17 @@
       <li>Nenhum horário cadastrado.</li>
     {% endfor %}
   </ul>
+
+  <h3>Consultas Agendadas</h3>
+  <ul class="list-group">
+    {% for appt in appointments %}
+      <li class="list-group-item">
+        {{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }} ({{ appt.tutor.name }})
+      </li>
+    {% else %}
+      <li class="list-group-item">Nenhuma consulta agendada.</li>
+    {% endfor %}
+  </ul>
 </div>
 <script>
   function selectDays(mode) {


### PR DESCRIPTION
## Summary
- Fetch veterinarian appointments in `edit_vet_schedule` and pass to template
- Display upcoming appointments on vet schedule management page

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689a12ce919c832e9b2c8b4b7af3ec74