### PR TITLE
Handle vaccines without dates

### DIFF
--- a/models.py
+++ b/models.py
@@ -228,6 +228,10 @@ class Animal(db.Model):
     price = db.Column(db.Float, nullable=True)
     vacinas = db.relationship('Vacina', backref='animal', cascade='all, delete-orphan')
 
+    @property
+    def vacinas_ordenadas(self):
+        return sorted(self.vacinas, key=lambda v: v.data or date.min, reverse=True)
+
     user_id = db.Column(
         db.Integer,
         db.ForeignKey('user.id', ondelete='CASCADE'),

--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -113,7 +113,7 @@
 <h6 class="mt-4 text-muted">💉 Vacinas Aplicadas</h6>
 {% if animal.vacinas %}
   <ul class="list-group mb-2">
-    {% for v in animal.vacinas|sort(attribute='data', reverse=True) %}
+    {% for v in animal.vacinas_ordenadas %}
     <li class="list-group-item d-flex justify-content-between align-items-center">
       <div>
         <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.data|format_datetime_brazil('%d/%m/%Y') if v.data else 'Data não registrada' }}

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -63,7 +63,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for vacina in animal.vacinas|sort(attribute='data', reverse=True) %}
+      {% for vacina in animal.vacinas_ordenadas %}
       <tr>
         <td>{{ vacina.data.strftime('%d/%m/%Y') if vacina.data else '—' }}</td>
         <td>{{ vacina.nome }}</td>

--- a/templates/partials/historico_vacinas.html
+++ b/templates/partials/historico_vacinas.html
@@ -4,7 +4,7 @@
     <h5 class="card-title">💉 Histórico de Vacinas</h5>
 
     <ul class="list-group list-group-flush mb-2">
-      {% for vacina in animal.vacinas|sort(attribute='data', reverse=True) %}
+      {% for vacina in animal.vacinas_ordenadas %}
       <li class="list-group-item" data-vacina-id="{{ vacina.id }}">
         <div class="vacina-info">
           <strong class="vacina-nome">{{ vacina.nome }}</strong>


### PR DESCRIPTION
## Summary
- avoid TypeError when sorting vaccines with missing dates by adding `vacinas_ordenadas` property
- render vaccine lists using sorted collection that tolerates absent dates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a13b7297c832e9ce990151b0850ca