### PR TITLE
Improve responsive layout

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -35,6 +35,10 @@
             --transition-speed: 0.3s;
         }
 
+        html {
+            font-size: clamp(14px, 1vw + 0.5rem, 18px);
+        }
+
         * {
             box-sizing: border-box;
             margin: 0;
@@ -65,15 +69,15 @@
 
         .navbar-brand {
             font-weight: 600;
-            font-size: 1.5rem;
+            font-size: clamp(1.25rem, 2vw + 1rem, 1.75rem);
             color: var(--dark-color);
             display: flex;
             align-items: center;
         }
 
         .navbar-brand img {
-            height: 40px;
-            width: 40px;
+            height: clamp(32px, 4vw, 40px);
+            width: clamp(32px, 4vw, 40px);
             border-radius: 50%;
             object-fit: cover;
             margin-right: 10px;
@@ -81,7 +85,7 @@
         }
 
         .nav-link {
-            font-size: 1rem;
+            font-size: clamp(0.9rem, 1vw + 0.6rem, 1rem);
             font-weight: 500;
             color: var(--dark-color);
             padding: 10px 15px !important;
@@ -132,6 +136,9 @@
         main.container {
             flex: 1;
             padding: 30px 15px;
+            width: 100%;
+            max-width: 1200px;
+            margin: 0 auto;
         }
 
         /* Alert Styles */
@@ -254,9 +261,33 @@
                 box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
                 margin-top: 10px;
             }
-            
+
             .nav-link {
                 margin-bottom: 5px;
+            }
+        }
+
+        @media (max-width: 576px) {
+            body {
+                font-size: 0.95rem;
+            }
+
+            .navbar {
+                padding: 0 15px;
+            }
+
+            main.container {
+                padding: 20px 10px;
+            }
+        }
+
+        @media (min-width: 1200px) {
+            .navbar {
+                padding: 0 60px;
+            }
+
+            main.container {
+                padding: 40px 30px;
             }
         }
 


### PR DESCRIPTION
## Summary
- enhance base typography and navigation sizing with responsive CSS
- center main content and add adaptive padding for small and large screens
- introduce mobile and widescreen breakpoints for layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a31b2fb10832ebba3e4b9cb6170b4