### PR TITLE
Unify appointments pages and streamline navigation

### DIFF
--- a/templates/appointment_confirmation.html
+++ b/templates/appointment_confirmation.html
@@ -4,6 +4,6 @@
 <div class="container mt-4">
   <h2>Consulta agendada!</h2>
   <p>Sua consulta foi marcada para {{ appointment.scheduled_at|datetime_brazil }} com o veterinário {{ appointment.veterinario.user.name if appointment.veterinario and appointment.veterinario.user else appointment.veterinario_id }}.</p>
-  <a href="{{ url_for('list_appointments') }}" class="btn btn-primary">Ver agendamentos</a>
+  <a href="{{ url_for('appointments') }}" class="btn btn-primary">Ver agendamentos</a>
 </div>
 {% endblock %}

--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -145,7 +145,7 @@
 
     if (isEdit) {
       title.textContent = 'Editar Horário';
-      form.action = `/admin/veterinario/{{ veterinario.id }}/agenda/${data.id}/edit`;
+      form.action = `/appointments/{{ veterinario.id }}/schedule/${data.id}/edit`;
       select.multiple = false;
       [...select.options].forEach(opt => opt.selected = opt.value === data.dia);
       horaInicio.value = data.horaInicio;
@@ -154,7 +154,7 @@
       intervaloFim.value = data.intervaloFim;
     } else {
       title.textContent = 'Adicionar Horário';
-      form.action = `/admin/veterinario/{{ veterinario.id }}/agenda`;
+      form.action = `{{ url_for('appointments') }}`;
       select.multiple = true;
     }
     container.classList.remove('d-none');

--- a/templates/index.html
+++ b/templates/index.html
@@ -99,7 +99,7 @@
                     🏥 Clínica
                 </a>
 
-                <a href="{{ url_for('edit_vet_schedule', veterinario_id=current_user.veterinario.id) }}"
+                <a href="{{ url_for('appointments') }}"
                    class="btn btn-outline-warning rounded-pill shadow-sm px-4 py-2"
                    data-bs-toggle="tooltip" title="Administre sua agenda de atendimentos.">
                     🗓️ Agenda

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -396,12 +396,6 @@
                             <i class="fas fa-shopping-bag me-1 text-warning"></i> Loja
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('list_appointments') }}">
-                            <i class="fas fa-calendar-alt me-1 text-primary"></i> Agendamentos
-                        </a>
-                    </li>
-
                     {% if current_user.is_authenticated %}
                         {% if current_user.worker == 'veterinario' or current_user.role == 'admin' %}
                             <li class="nav-item">


### PR DESCRIPTION
## Summary
- Merge vet schedule management and appointment list into a single `/appointments` route
- Remove duplicate Agendamentos link from the navbar and update related templates
- Adjust schedule edit/delete endpoints to match the unified page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a33ad6d14832ebf888ebf0948d3f8