### PR TITLE
Remove duplicate tutors link from navbar

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -423,11 +423,6 @@
                         {% endif %}
                         {% if current_user.worker == 'veterinario' %}
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('tutores') }}">
-                                    <i class="fas fa-users me-1 text-primary"></i> Tutores
-                                </a>
-                            </li>
-                            <li class="nav-item">
                                 <a class="nav-link" href="{{ url_for('add_animal') }}">
                                     <i class="fas fa-plus-circle me-1 text-success"></i> Meu novo Animal
                                 </a>


### PR DESCRIPTION
## Summary
- remove redundant "Tutores" option from top navbar

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a3791df50832ea45788587db1ae59