### PR TITLE
Move ration report link into deliveries page

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -122,9 +122,12 @@
     </div>
   </div>
 
-  <div class="text-center mt-4">
+  <div class="text-center mt-4 d-flex flex-column flex-md-row justify-content-center gap-2">
     <a class="btn btn-outline-secondary" href="{{ url_for('delivery_archive') }}">
       <i class="fas fa-archive me-1"></i> Arquivadas: pedidos arquivados
+    </a>
+    <a class="btn btn-outline-danger" href="{{ url_for('relatorio_racoes') }}">
+      <i class="fas fa-box me-1 text-warning"></i> Relatório de Rações
     </a>
   </div>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -387,11 +387,6 @@
                 <ul class="navbar-nav align-items-center gap-2">
                     {% if current_user.is_authenticated and current_user.role == "admin" %}
                         <li class="nav-item">
-                            <a class="nav-link text-danger" href="{{ url_for('relatorio_racoes') }}">
-                            <i class="fas fa-box me-1 text-warning"></i> Relatório de Rações
-                            </a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('delivery_overview') }}">
                             <i class="fas fa-chart-line me-1 text-primary"></i> Entregas
                             </a>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1517,6 +1517,23 @@ def test_archive_and_unarchive_delivery(monkeypatch, app):
         assert DeliveryRequest.query.get(1).archived is False
 
 
+def test_delivery_overview_shows_relatorio_racoes_link(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(id=1, name='Admin', email='a@a', password_hash='x', role='admin')
+        db.session.add(admin)
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: admin)
+        monkeypatch.setattr(app_module, '_is_admin', lambda: True)
+
+        resp = client.get('/admin/delivery_overview')
+        assert b'href="/relatorio/racoes"' in resp.data
+
+
 def test_delivery_requests_hide_archived(monkeypatch, app):
     client = app.test_client()
     with app.app_context():


### PR DESCRIPTION
## Summary
- Remove "Relatório de Rações" from the global navbar
- Add button to access ration report inside deliveries overview
- Test that deliveries overview exposes link to ration report

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a3886b9a8832eb222f75a1a4b4e79