### PR TITLE
Add record and consultation links to appointment lists

### DIFF
--- a/templates/appointments.html
+++ b/templates/appointments.html
@@ -43,11 +43,13 @@
           {{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.veterinario.user.name }}
           {% if appt.animal %} - {{ appt.animal.name }}{% endif %}
         </span>
-        {% if current_user.worker in ['veterinario', 'colaborador'] %}
-        <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success">
-          🩺 Iniciar Consulta
-        </a>
-        {% endif %}
+        <div class="btn-group">
+          <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary">📋 Ficha Animal</a>
+          <a href="{{ url_for('tutor_detail', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary">👤 Ficha Tutor</a>
+          {% if current_user.worker in ['veterinario', 'colaborador'] %}
+          <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success">🩺 Iniciar Consulta</a>
+          {% endif %}
+        </div>
       </li>
     {% else %}
       <li class="list-group-item">Nenhum agendamento encontrado.</li>

--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -109,8 +109,13 @@
   <h3>Consultas Agendadas</h3>
   <ul class="list-group">
     {% for appt in appointments %}
-      <li class="list-group-item">
-        {{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }} ({{ appt.tutor.name }})
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }} ({{ appt.tutor.name }})</span>
+        <div class="btn-group">
+          <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary">📋 Ficha Animal</a>
+          <a href="{{ url_for('tutor_detail', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary">👤 Ficha Tutor</a>
+          <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success">🩺 Iniciar Consulta</a>
+        </div>
       </li>
     {% else %}
       <li class="list-group-item">Nenhuma consulta agendada.</li>


### PR DESCRIPTION
## Summary
- add buttons to view animal and tutor records for each appointment
- allow starting consultations directly from scheduled appointments listings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a392f3b00832e91cf29de3c7b9d8d