### PR TITLE
Fix missing import for VetSpecialtyForm

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,7 +172,7 @@ from forms import (
     DeliveryRequestForm, AddToCartForm, SubscribePlanForm,
     ProductUpdateForm, ProductPhotoForm, ChangePasswordForm,
     DeleteAccountForm, ClinicForm, ClinicHoursForm, VetScheduleForm,
-    AppointmentForm, AppointmentDeleteForm
+    VetSpecialtyForm, AppointmentForm, AppointmentDeleteForm
 )
 from helpers import calcular_idade, parse_data_nascimento, is_slot_available
 


### PR DESCRIPTION
## Summary
- import `VetSpecialtyForm` in `app.py` so editing veterinarian specialties works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a3cd62930832e86f678fd06cd6064