### PR TITLE
Enable editable clinic logo

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -278,6 +278,10 @@ class ClinicForm(FlaskForm):
     telefone = StringField('Telefone', validators=[Optional()])
     email = StringField('Email', validators=[Optional(), Email()])
     logotipo = FileField('Imagem da Clínica', validators=[FileAllowed(['jpg', 'jpeg', 'png', 'gif'], 'Apenas imagens!')])
+    photo_rotation = IntegerField('Rotação', default=0, validators=[Optional()])
+    photo_zoom = DecimalField('Zoom', places=2, default=1.0, validators=[Optional()])
+    photo_offset_x = DecimalField('Offset X', places=0, default=0, validators=[Optional()])
+    photo_offset_y = DecimalField('Offset Y', places=0, default=0, validators=[Optional()])
     submit = SubmitField('Salvar')
 
 

--- a/migrations/versions/1a2b3c4d5e6f_add_clinic_photo_fields.py
+++ b/migrations/versions/1a2b3c4d5e6f_add_clinic_photo_fields.py
@@ -1,0 +1,31 @@
+"""add clinic photo fields
+
+Revision ID: 1a2b3c4d5e6f
+Revises: b27a5b6156e3
+Create Date: 2025-02-15 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1a2b3c4d5e6f'
+down_revision = 'b27a5b6156e3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('clinica', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('photo_rotation', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('photo_zoom', sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column('photo_offset_x', sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column('photo_offset_y', sa.Float(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('clinica', schema=None) as batch_op:
+        batch_op.drop_column('photo_offset_y')
+        batch_op.drop_column('photo_offset_x')
+        batch_op.drop_column('photo_zoom')
+        batch_op.drop_column('photo_rotation')

--- a/models.py
+++ b/models.py
@@ -490,6 +490,10 @@ class Clinica(db.Model):
     telefone = db.Column(db.String(20))
     email = db.Column(db.String(120))
     logotipo = db.Column(db.String(200))  # caminho para imagem do logo
+    photo_rotation = db.Column(db.Integer, default=0)
+    photo_zoom = db.Column(db.Float, default=1.0)
+    photo_offset_x = db.Column(db.Float, default=0.0)
+    photo_offset_y = db.Column(db.Float, default=0.0)
 
     owner_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     owner = db.relationship('User', backref=db.backref('clinicas', foreign_keys='Clinica.owner_id'), foreign_keys=[owner_id])

--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -1,10 +1,11 @@
 {% extends "layout.html" %}
+{% from 'components/photo_cropper.html' import photo_cropper %}
 
 {% block main %}
 <div class="container mt-4">
   <h2>{{ clinica.nome }}</h2>
   {% if clinica.logotipo %}
-  <img src="{{ clinica.logotipo }}" alt="Imagem da Clínica" class="img-fluid mb-3" style="max-height: 200px;">
+  <img src="{{ clinica.logotipo }}" alt="Imagem da Clínica" class="img-fluid mb-3" style="max-height: 200px; object-fit: cover; transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }});">
   {% endif %}
   {% if clinica.endereco %}<p><strong>Endereço:</strong> {{ clinica.endereco }}</p>{% endif %}
   {% if clinica.telefone %}<p><strong>Telefone:</strong> {{ clinica.telefone }}</p>{% endif %}
@@ -37,8 +38,7 @@
       </div>
       <div class="mb-3">
         {{ clinic_form.logotipo.label }}
-        {{ clinic_form.logotipo(class="form-control", onchange="previewLogo(this)") }}
-        <img id="logo-preview" src="{{ clinica.logotipo }}" class="img-fluid mt-2" style="max-height:150px; {% if not clinica.logotipo %}display:none;{% endif %}">
+        {{ photo_cropper(clinic_form.logotipo, clinic_form.photo_rotation, clinic_form.photo_zoom, clinic_form.photo_offset_x, clinic_form.photo_offset_y, clinica.logotipo, 150, 'clinic_logo', 'user') }}
       </div>
       {{ clinic_form.submit(class="btn btn-primary") }}
     </form>
@@ -124,16 +124,5 @@ function selectDays(mode) {
   }
 }
 
-function previewLogo(input) {
-  const preview = document.getElementById('logo-preview');
-  const file = input.files[0];
-  if (file) {
-    preview.src = URL.createObjectURL(file);
-    preview.style.display = 'block';
-  } else {
-    preview.src = '';
-    preview.style.display = 'none';
-  }
-}
 </script>
 {% endblock %}

--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -22,9 +22,9 @@
     {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
                      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica">
+      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica">
+      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -20,9 +20,9 @@
     {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
                      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica">
+      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica">
+      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -20,9 +20,9 @@
     {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
                      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica">
+      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica">
+      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -19,9 +19,9 @@
     {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
                      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica">
+      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica">
+      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 


### PR DESCRIPTION
## Summary
- allow editing of clinic logos with the shared photo cropper
- store logo transform settings on the Clinica model
- apply logo transforms across clinic print templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3fa21640832e9ef163ade174bc29