### PR TITLE
Prevent layout overflow

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -45,11 +45,19 @@
             padding: 0;
         }
 
+        img {
+            max-width: 100%;
+            height: auto;
+            display: block;
+        }
+
         body {
             font-family: 'Poppins', sans-serif;
             background: linear-gradient(to bottom right, var(--light-color), #ffffff);
             color: #333;
             line-height: 1.6;
+            overflow-wrap: anywhere;
+            word-break: break-word;
             padding-top: calc(var(--topbar-height) + env(safe-area-inset-top));
             padding-bottom: env(safe-area-inset-bottom);
             padding-left: env(safe-area-inset-left);
@@ -172,6 +180,12 @@
             border-radius: 8px;
             padding: 8px 16px;
             font-weight: 500;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            white-space: normal;
+            word-break: break-word;
+            max-width: 100%;
         }
 
         .btn:hover {


### PR DESCRIPTION
## Summary
- allow body text and images to wrap to avoid layout overflow
- ensure buttons wrap text and stay within their container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a3f5adeb8832e8aa50f9dd0812a64