### PR TITLE
Add minha-clinica route and link to clinic details

### DIFF
--- a/app.py
+++ b/app.py
@@ -1589,6 +1589,19 @@ def clinicas():
     return render_template('clinicas.html', clinicas=clinicas)
 
 
+@app.route('/minha-clinica')
+@login_required
+def minha_clinica():
+    clinica_id = None
+    if current_user.worker == 'veterinario' and getattr(current_user, 'veterinario', None):
+        clinica_id = current_user.veterinario.clinica_id
+    elif current_user.clinica_id:
+        clinica_id = current_user.clinica_id
+    if not clinica_id:
+        abort(404)
+    return redirect(url_for('clinic_detail', clinica_id=clinica_id))
+
+
 @app.route('/clinica/<int:clinica_id>', methods=['GET', 'POST'])
 def clinic_detail(clinica_id):
     clinica = Clinica.query.get_or_404(clinica_id)

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -449,7 +449,7 @@
                                 <li><a class="dropdown-item" href="{{ url_for('profile') }}"><i class="fas fa-user me-2 text-primary"></i> Meu Perfil</a></li>
                                 <li><a class="dropdown-item" href="{{ url_for('minhas_compras') }}"><i class="fas fa-box me-2 text-warning"></i> Minhas Compras</a></li>
                                 {% if current_user.worker == 'veterinario' and current_user.veterinario %}
-                                <li><a class="dropdown-item" href="{{ url_for('clinic_detail', clinica_id=current_user.veterinario.clinica_id) }}"><i class="fas fa-clinic-medical me-2 text-info"></i> Minha Clínica</a></li>
+                                <li><a class="dropdown-item" href="{{ url_for('minha_clinica') }}"><i class="fas fa-clinic-medical me-2 text-info"></i> Minha Clínica</a></li>
                                 {% endif %}
                 
                                 <li><a class="dropdown-item" href="{{ url_for('logout') }}"><i class="fas fa-sign-out-alt me-2 text-danger"></i> Sair</a></li>

--- a/tests/test_minha_clinica.py
+++ b/tests/test_minha_clinica.py
@@ -1,0 +1,32 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, Clinica, Veterinario
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_minha_clinica_redirects(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        clinica = Clinica(nome="Pet Clinic")
+        user = User(name="Vet", email="vet@example.com", password_hash="x", worker="veterinario")
+        vet = Veterinario(user=user, crmv="123", clinica=clinica)
+        db.session.add_all([clinica, user, vet])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+        resp = client.get('/minha-clinica')
+        assert resp.status_code == 302
+        assert f"/clinica/{clinica.id}" in resp.headers['Location']


### PR DESCRIPTION
## Summary
- add '/minha-clinica' endpoint that redirects to current user's clinic detail
- link navbar "Minha Clínica" to new endpoint
- test redirect behavior for logged in veterinarians

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6382c40c832e91c7955a050b4b6a