### PR TITLE
Add button to open clinic detail

### DIFF
--- a/templates/clinicas.html
+++ b/templates/clinicas.html
@@ -5,7 +5,10 @@
   <h2>Clínicas</h2>
   <ul class="list-unstyled">
     {% for c in clinicas %}
-      <li><a href="{{ url_for('clinic_detail', clinica_id=c.id) }}">{{ c.nome }}</a></li>
+      <li class="d-flex justify-content-between align-items-center mb-2">
+        <span>{{ c.nome }}</span>
+        <a href="{{ url_for('clinic_detail', clinica_id=c.id) }}" class="btn btn-primary btn-sm">Ver detalhes</a>
+      </li>
     {% else %}
       <li>Nenhuma clínica cadastrada.</li>
     {% endfor %}


### PR DESCRIPTION
## Summary
- show a "Ver detalhes" button for each clinic on the clinics page

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689a6bd0bce4832ea1573cd8622e5229