### PR TITLE
Permite editar instruções gerais

### DIFF
--- a/app.py
+++ b/app.py
@@ -2920,6 +2920,7 @@ def atualizar_bloco_prescricao(bloco_id):
 
     data = request.get_json(silent=True) or {}
     novos_medicamentos = data.get('medicamentos', [])
+    instrucoes = data.get('instrucoes_gerais')
 
     # Limpa os medicamentos atuais do bloco
     for p in bloco.prescricoes:
@@ -2938,6 +2939,7 @@ def atualizar_bloco_prescricao(bloco_id):
         )
         db.session.add(nova)
 
+    bloco.instrucoes_gerais = instrucoes
     db.session.commit()
     return jsonify({'success': True})
 

--- a/templates/editar_bloco.html
+++ b/templates/editar_bloco.html
@@ -7,6 +7,11 @@
     <!-- Lista Temporária de Medicamentos (com edição) -->
     <div id="prescricao-lista" class="mb-3"></div>
 
+    <div class="form-group mb-3">
+      <label for="instrucoes-gerais">Instruções Gerais</label>
+      <textarea id="instrucoes-gerais" class="form-control" rows="3">{{ bloco.instrucoes_gerais or '' }}</textarea>
+    </div>
+
     <button class="btn btn-outline-primary mb-3" onclick="adicionarMedicamento()">➕ Adicionar Medicamento</button>
     <button class="btn btn-success" onclick="salvarEdicaoBloco({{ bloco.id }})">💾 Salvar alterações</button>
   </div>
@@ -24,6 +29,7 @@ let medicamentos = [
     },
   {% endfor %}
 ];
+
 
 function renderListaEdicao() {
   const container = document.getElementById('prescricao-lista');
@@ -75,10 +81,11 @@ function removerMedicamento(index) {
 }
 
 function salvarEdicaoBloco(bloco_id) {
+  const instrucoesGerais = document.getElementById('instrucoes-gerais').value;
   fetch(`/bloco_prescricao/${bloco_id}/atualizar`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ medicamentos })
+    body: JSON.stringify({ medicamentos, instrucoes_gerais: instrucoesGerais })
   })
   .then(res => res.json())
   .then(data => {


### PR DESCRIPTION
## Summary
- Add UI field to edit general instructions for prescription blocks and send them to the server
- Persist updated general instructions when editing a prescription block

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a44c1c6694832eae4db1547977ba04