### PR TITLE
Mostrar instruções gerais no histórico de prescrições

### DIFF
--- a/templates/partials/historico_prescricoes.html
+++ b/templates/partials/historico_prescricoes.html
@@ -23,6 +23,12 @@
         {% endfor %}
       </ul>
 
+      {% if bloco.instrucoes_gerais %}
+      <div class="alert alert-secondary py-2" role="alert">
+        <strong>Orientações e Cuidados:</strong> {{ bloco.instrucoes_gerais }}
+      </div>
+      {% endif %}
+
       <!-- Botões de ação -->
       <div class="d-flex flex-wrap gap-2">
         <form method="POST"


### PR DESCRIPTION
## Summary
- exibir orientações e cuidados nos blocos do histórico de prescrições

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a44da59d74832eb887cbb69b5bd461