### PR TITLE
Add exam model justifications and auto-fill support

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -427,6 +427,14 @@ class ProductAdmin(MyModelView):
 
 
 # --------------------------------------------------------------------------
+# Exame Modelo Admin
+# --------------------------------------------------------------------------
+class ExameModeloAdminView(MyModelView):
+    column_searchable_list = ('nome', 'justificativa')
+    form_columns = ('nome', 'justificativa')
+
+
+# --------------------------------------------------------------------------
 # Função de inicialização do painel
 # --------------------------------------------------------------------------
 def init_admin(app):
@@ -457,7 +465,7 @@ def init_admin(app):
     admin.add_view(VetScheduleAdmin(VetSchedule, db.session, name='Agenda do Veterinário'))
     admin.add_view(VeterinarioAdmin(Veterinario, db.session))
     admin.add_view(MyModelView(Specialty, db.session, name='Especialidades'))
-    admin.add_view(MyModelView(ExameModelo, db.session))
+    admin.add_view(ExameModeloAdminView(ExameModelo, db.session))
     admin.add_view(MyModelView(Consulta, db.session))
     admin.add_view(MyModelView(VacinaModelo, db.session))
     admin.add_view(MyModelView(ApresentacaoMedicamento, db.session))

--- a/app.py
+++ b/app.py
@@ -3005,7 +3005,10 @@ def salvar_bloco_exames(animal_id):
 def buscar_exames():
     q = request.args.get('q', '').lower()
     exames = ExameModelo.query.filter(ExameModelo.nome.ilike(f'%{q}%')).all()
-    return jsonify([{'id': e.id, 'nome': e.nome} for e in exames])
+    return jsonify([
+        {'id': e.id, 'nome': e.nome, 'justificativa': e.justificativa}
+        for e in exames
+    ])
 
 
 @app.route('/imprimir_bloco_exames/<int:bloco_id>')

--- a/migrations/versions/55f4adceaf5d_add_justificativa_to_exame_modelo.py
+++ b/migrations/versions/55f4adceaf5d_add_justificativa_to_exame_modelo.py
@@ -1,0 +1,25 @@
+"""add justificativa to exame_modelo
+
+Revision ID: 55f4adceaf5d
+Revises: 1a2b3c4d5e6f
+Create Date: 2025-10-23 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '55f4adceaf5d'
+down_revision = '1a2b3c4d5e6f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('exame_modelo', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('justificativa', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('exame_modelo', schema=None) as batch_op:
+        batch_op.drop_column('justificativa')

--- a/models.py
+++ b/models.py
@@ -653,6 +653,7 @@ class ApresentacaoMedicamento(db.Model):
 class ExameModelo(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     nome = db.Column(db.String(120), nullable=False)  # ex: Hemograma, Raio-X...
+    justificativa = db.Column(db.Text)
 
 class BlocoExames(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/templates/editar_bloco_exames.html
+++ b/templates/editar_bloco_exames.html
@@ -103,6 +103,8 @@ function sugerirExames(input) {
         li.textContent = item.nome;
         li.onclick = () => {
           input.value = item.nome;
+          const card = input.closest('.card-body');
+          card.querySelector('.exame-justificativa').value = item.justificativa || '';
           lista.innerHTML = '';
         };
         lista.appendChild(li);

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -71,6 +71,7 @@
             li.textContent = item.nome;
             li.onclick = () => {
               inputExame.value = item.nome;
+              document.getElementById('justificativa-exame').value = item.justificativa || '';
               sugestoes.innerHTML = '';
             };
             sugestoes.appendChild(li);

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -162,6 +162,8 @@ function sugerirExames(input) {
         li.textContent = item.nome;
         li.onclick = () => {
           input.value = item.nome;
+          const card = input.closest('.exame-card');
+          card.querySelector('.exame-justificativa').value = item.justificativa || '';
           lista.innerHTML = '';
         };
         lista.appendChild(li);


### PR DESCRIPTION
## Summary
- allow storing generic justifications for exam templates in admin
- expose justification in search endpoint and auto-fill on selection
- create migration for new `justificativa` field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a450338c5c832e9ec9b2f24d53988a