### PR TITLE
Prevent free-text from being stored with structured prescriptions

### DIFF
--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -201,14 +201,15 @@
 
     const nome = document.getElementById('nome-medicamento').value.trim();
     const modoPersonalizado = document.getElementById('modo-personalizado').checked;
-    const observacoes = document.getElementById('instrucao-unica').value.trim();
-    
+
+    let observacoes = '';
     let texto = '';
     let dose = '';
     let frequencia = '';
     let duracao = '';
 
     if (modoPersonalizado) {
+      observacoes = document.getElementById('instrucao-unica').value.trim();
       texto = observacoes;
     } else {
       frequencia = document.getElementById('frequencia').value.trim();


### PR DESCRIPTION
## Summary
- Ignore free-text observations when dosage/frequency/duration are filled and vice versa
- Clear observation values when adding detailed prescriptions in the UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4578c8c90832ea7ac184b62f46e7c