### PR TITLE
Improve responsive text and buttons for small screens

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -67,6 +67,17 @@
             flex-direction: column;
         }
 
+        h1, h2, h3, h4, h5, h6 {
+            font-weight: 600;
+            line-height: 1.2;
+            overflow-wrap: anywhere;
+            margin-bottom: 0.75rem;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
         /* Navbar Styles */
         .navbar {
             min-height: var(--topbar-height);
@@ -186,6 +197,12 @@
             white-space: normal;
             word-break: break-word;
             max-width: 100%;
+            flex-wrap: wrap;
+            text-align: center;
+        }
+
+        .btn i {
+            margin-right: 0.25rem;
         }
 
         .btn:hover {
@@ -296,6 +313,11 @@
 
             main.container {
                 padding: 20px 10px;
+            }
+
+            main .btn {
+                width: 100%;
+                margin-bottom: 10px;
             }
         }
 


### PR DESCRIPTION
## Summary
- add global heading and paragraph styles for better text wrapping
- allow buttons to wrap text, center content and expand on small screens

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6f1e1d658832ebcb9a5f7f5975cad