### PR TITLE
fix: avoid breaking text in buttons

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -194,10 +194,10 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            white-space: normal;
-            word-break: break-word;
+            white-space: nowrap;
+            word-break: normal;
             max-width: 100%;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             text-align: center;
         }
 


### PR DESCRIPTION
## Summary
- prevent buttons from breaking words by using `nowrap`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6f41bbce8832eab61b1fbff8a5885