### PR TITLE
fix: improve responsive layout of delivery overview buttons

### DIFF
--- a/templates/admin/delivery_overview.html
+++ b/templates/admin/delivery_overview.html
@@ -25,8 +25,8 @@
   <ul class="list-group shadow-sm mb-4">
     {% for r in reqs %}
       {% set ord = r.order %}
-      <li class="list-group-item d-flex justify-content-between flex-column flex-md-row align-items-start align-items-md-center">
-        <div class="me-3">
+      <li class="list-group-item d-flex flex-column flex-md-row flex-md-wrap align-items-start align-items-md-center gap-2 justify-content-md-between">
+        <div class="me-3 flex-grow-1">
           <div class="fw-semibold">
             Pedido #{{ r.order_id }}
             <span class="badge {{ cls_badge }} ms-2">{{ lbl_badge }}</span>
@@ -47,7 +47,7 @@
           </div>
         </div>
 
-        <div class="d-flex flex-wrap gap-1 mt-2 mt-md-0">
+        <div class="d-flex flex-wrap gap-1 mt-2 mt-md-0 ms-md-auto">
           <a href="{{ url_for('admin_delivery_detail', req_id=r.id) }}"
              class="btn btn-sm btn-outline-primary">
              Ver detalhes


### PR DESCRIPTION
## Summary
- allow delivery overview card actions to wrap on medium+ screens
- ensure button group aligns right without overflowing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f7029fc0832e8f5a10e667404227