### PR TITLE
Improve store layout and styling

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -56,8 +56,6 @@
             background: linear-gradient(to bottom right, var(--light-color), #ffffff);
             color: #333;
             line-height: 1.6;
-            overflow-wrap: anywhere;
-            word-break: break-word;
             padding-top: calc(var(--topbar-height) + env(safe-area-inset-top));
             padding-bottom: env(safe-area-inset-bottom);
             padding-left: env(safe-area-inset-left);
@@ -76,6 +74,8 @@
 
         p {
             margin-bottom: 1rem;
+            overflow-wrap: anywhere;
+            word-break: break-word;
         }
 
         /* Navbar Styles */

--- a/templates/loja.html
+++ b/templates/loja.html
@@ -32,7 +32,7 @@
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
     {% for product in products %}
     <div class="col">
-      <div class="card h-100 border-0 shadow-sm overflow-hidden product-card">
+      <div class="card h-100 border-0 overflow-hidden product-card">
         <!-- Product Image -->
         <a href="{{ url_for('produto_detail', product_id=product.id) }}" class="position-relative overflow-hidden d-block" style="height: 220px;">
           {% if product.image_url %}
@@ -50,9 +50,15 @@
               <i class="bi bi-image text-muted fs-1"></i>
             </div>
           {% endif %}
+          {% if product.stock is not none and product.stock < 5 %}
+          <div class="product-badge position-absolute top-0 end-0 bg-warning text-dark p-2 small">
+            <i class="bi bi-exclamation-triangle"></i> Estoque baixo
+          </div>
+          {% else %}
           <div class="product-badge position-absolute top-0 end-0 bg-danger text-white p-2 small">
             <i class="bi bi-tag"></i> Novo
           </div>
+          {% endif %}
         </a>
         
         <!-- Product Info -->
@@ -61,12 +67,12 @@
           <p class="card-text text-muted small flex-grow-1">
             {{ product.description|truncate(100) }}
           </p>
-          
-          <div class="d-flex justify-content-between align-items-center mt-3">
-            <span class="h5 text-success fw-bold mb-0">
+
+          <div class="d-flex justify-content-between align-items-center mt-3 gap-3">
+            <span class="h5 text-success fw-bold mb-0 product-price">
               R$ {{ '%.2f'|format(product.price)|replace('.', ',') }}
             </span>
-            
+
             <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}"
                   method="post" class="ms-2 js-cart-form">
               {{ form.hidden_tag() }}
@@ -123,13 +129,19 @@
   .product-card {
     transition: all 0.3s ease;
     border-radius: 12px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08);
   }
-  
+
   .product-card:hover {
     transform: translateY(-5px);
-    box-shadow: 0 10px 20px rgba(0,0,0,0.1);
+    box-shadow: 0 10px 20px rgba(0,0,0,0.12);
   }
-  
+
+  .product-price {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
   .product-badge {
     border-bottom-left-radius: 8px;
   }


### PR DESCRIPTION
## Summary
- prevent product price from wrapping by default
- add dynamic stock badge and refine product card styling
- limit global word breaking to paragraph text

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f59e2d08832ebf5d8145b0b8202e