### PR TITLE
Ensure medication name persists in free text prescriptions

### DIFF
--- a/templates/editar_bloco.html
+++ b/templates/editar_bloco.html
@@ -60,18 +60,18 @@ function renderListaEdicao() {
           <input class="form-check-input" type="checkbox" id="modoLivre-${i}" ${m.modoLivre ? 'checked' : ''} onchange="toggleModoLivre(${i}, this.checked)">
           <label class="form-check-label" for="modoLivre-${i}">Texto livre</label>
         </div>
+        <div class="form-group mb-3 position-relative">
+          <label>Medicamento</label>
+          <input class="form-control medicamento-input" placeholder="Nome do medicamento" data-index="${i}" value="${m.medicamento}" oninput="medicamentos[${i}].medicamento = this.value">
+          <small class="form-text text-muted">Digite para buscar sugestões.</small>
+          <ul class="list-group position-absolute w-100 mt-1 sugestoes" style="z-index:10;"></ul>
+        </div>
         ${m.modoLivre ? `
           <div class="form-group">
             <label>Prescrição</label>
             <textarea class="form-control" rows="3" placeholder="Digite a prescrição completa" oninput="medicamentos[${i}].textoLivre = this.value">${m.textoLivre}</textarea>
           </div>
         ` : `
-          <div class="form-group mb-3 position-relative">
-            <label>Medicamento</label>
-            <input class="form-control medicamento-input" placeholder="Nome do medicamento" data-index="${i}" value="${m.medicamento}" oninput="medicamentos[${i}].medicamento = this.value">
-            <small class="form-text text-muted">Digite para buscar sugestões.</small>
-            <ul class="list-group position-absolute w-100 mt-1 sugestoes" style="z-index:10;"></ul>
-          </div>
           <div class="row g-2 mb-3">
             <div class="col-md-4">
               <label>Dosagem</label>
@@ -86,7 +86,6 @@ function renderListaEdicao() {
               <input class="form-control" placeholder="Ex: 7 dias" value="${m.duracao}" oninput="medicamentos[${i}].duracao = this.value">
             </div>
           </div>
-
         `}
       </div>
     `;


### PR DESCRIPTION
## Summary
- Show medication name input even when 'Texto livre' mode is selected during block prescription editing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88e552b40832ea54ca9a4894d3e0c