### PR TITLE
Refina layout dos cards de produtos

### DIFF
--- a/templates/loja.html
+++ b/templates/loja.html
@@ -32,7 +32,7 @@
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
     {% for product in products %}
     <div class="col">
-      <div class="card h-100 border-0 overflow-hidden product-card">
+      <div class="card h-100 border-0 product-card d-flex flex-column">
         <!-- Product Image -->
         <a href="{{ url_for('produto_detail', product_id=product.id) }}" class="position-relative overflow-hidden d-block" style="height: 220px;">
           {% if product.image_url %}
@@ -68,13 +68,13 @@
             {{ product.description|truncate(100) }}
           </p>
 
-          <div class="d-flex justify-content-between align-items-center mt-3 gap-3">
-            <span class="h5 text-success fw-bold mb-0 product-price">
+          <div class="mt-auto">
+            <span class="h5 text-success fw-bold mb-3 d-block product-price">
               R$ {{ '%.2f'|format(product.price)|replace('.', ',') }}
             </span>
 
             <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}"
-                  method="post" class="ms-2 js-cart-form">
+                  method="post" class="js-cart-form">
               {{ form.hidden_tag() }}
               <div class="d-flex align-items-center">
                 <div class="quantity-selector me-2">
@@ -82,11 +82,10 @@
                   {{ form.quantity(class="form-control quantity-input", min="1", value="1") }}
                   <button type="button" class="quantity-btn plus">+</button>
                 </div>
-                  <button type="submit" class="btn add-to-cart-btn d-flex align-items-center gap-2 shadow-sm">
-                    <i class="bi bi-cart-plus fs-5"></i>
-                    <span class="fw-semibold">Adicionar +</span>
-                  </button>
-
+                <button type="submit" class="btn add-to-cart-btn d-flex align-items-center gap-2 shadow-sm flex-grow-1">
+                  <i class="bi bi-cart-plus fs-5"></i>
+                  <span class="fw-semibold">Adicionar +</span>
+                </button>
               </div>
             </form>
           </div>


### PR DESCRIPTION
## Summary
- Reestrutura cards de produtos para usar layout flex em colunas
- Reposiciona preço e formulário para exibir botão de adicionar sem cortes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8917a2dfc832eac9ed35f646902ff