### PR TITLE
Allow document deletion by vet or admin

### DIFF
--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -136,7 +136,14 @@
       {% for d in animal.documentos %}
       <li class="list-group-item d-flex justify-content-between align-items-center">
         <span>{{ d.filename }}</span>
-        <a href="{{ d.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary">Abrir</a>
+        <div>
+          <a href="{{ d.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary">Abrir</a>
+          {% if current_user.role == 'admin' or (current_user.worker == 'veterinario' and current_user.id == d.veterinario_id) %}
+          <form action="{{ url_for('delete_document', animal_id=animal.id, doc_id=d.id) }}" method="post" class="d-inline">
+            <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Excluir documento?')">Excluir</button>
+          </form>
+          {% endif %}
+        </div>
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- add route to delete animal documents from S3 and database
- show delete button in animal page when vet uploader or admin
- test document deletion permissions for vet and admin

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac4a3082ac832e9055b75ba7050015