### PR TITLE
Add document upload tab within consultation workflow

### DIFF
--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -94,6 +94,12 @@
         <span class="fw-semibold">Orçamento</span>
       </button>
     </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link d-flex align-items-center gap-2" id="documentos-tab" data-bs-toggle="tab" data-bs-target="#documentos" type="button" role="tab">
+        <span class="icon-circle bg-dark text-white"><i class="fa-solid fa-file"></i></span>
+        <span class="fw-semibold">Documentos</span>
+      </button>
+    </li>
   {% endif %}
 </ul>
 
@@ -176,6 +182,13 @@
       <div class="card shadow-sm">
         <div class="card-body">
           {% include 'partials/orcamento_form.html' %}
+        </div>
+      </div>
+    </div>
+    <div class="tab-pane fade" id="documentos" role="tabpanel">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          {% include 'partials/documentos.html' %}
         </div>
       </div>
     </div>

--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -130,38 +130,9 @@
   {% endif %}
 
   <!-- DOCUMENTOS -->
-  <h6 class="mt-4 text-muted">📁 Documentos</h6>
-  {% if animal.documentos %}
-    <ul class="list-group mb-2">
-      {% for d in animal.documentos %}
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <span>{{ d.filename }}</span>
-        <div>
-          <a href="{{ d.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary">Abrir</a>
-          {% if current_user.role == 'admin' or (current_user.worker == 'veterinario' and current_user.id == d.veterinario_id) %}
-          <form action="{{ url_for('delete_document', animal_id=animal.id, doc_id=d.id) }}" method="post" class="d-inline">
-            <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Excluir documento?')">Excluir</button>
-          </form>
-          {% endif %}
-        </div>
-      </li>
-      {% endfor %}
-    </ul>
-  {% else %}
-    <p class="text-muted">Nenhum documento enviado.</p>
-  {% endif %}
-
-  {% if current_user.worker == 'veterinario' %}
-  <form action="{{ url_for('upload_document', animal_id=animal.id) }}" method="post" enctype="multipart/form-data" class="mt-2">
-    <div class="mb-2">
-      <input type="file" name="documento" class="form-control form-control-sm" required>
-    </div>
-    <div class="mb-2">
-      <input type="text" name="descricao" class="form-control form-control-sm" placeholder="Descrição (opcional)">
-    </div>
-    <button class="btn btn-sm btn-outline-success">📤 Enviar</button>
-  </form>
-  {% endif %}
+  <div class="mt-4">
+    {% include 'partials/documentos.html' %}
+  </div>
 
   </div>
 

--- a/templates/partials/documentos.html
+++ b/templates/partials/documentos.html
@@ -1,0 +1,32 @@
+<h5 class="mb-3">Documentos</h5>
+{% if animal.documentos %}
+  <ul class="list-group mb-3">
+    {% for d in animal.documentos %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ d.filename }}</span>
+        <div>
+          <a href="{{ d.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary">Abrir</a>
+          {% if current_user.role == 'admin' or (current_user.worker == 'veterinario' and current_user.id == d.veterinario_id) %}
+          <form action="{{ url_for('delete_document', animal_id=animal.id, doc_id=d.id) }}" method="post" class="d-inline">
+            <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Excluir documento?')">Excluir</button>
+          </form>
+          {% endif %}
+        </div>
+      </li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <p class="text-muted">Nenhum documento enviado.</p>
+{% endif %}
+
+{% if current_user.worker == 'veterinario' %}
+<form action="{{ url_for('upload_document', animal_id=animal.id) }}" method="post" enctype="multipart/form-data" class="mt-2">
+  <div class="mb-2">
+    <input type="file" name="documento" class="form-control form-control-sm" required>
+  </div>
+  <div class="mb-2">
+    <input type="text" name="descricao" class="form-control form-control-sm" placeholder="Descrição (opcional)">
+  </div>
+  <button class="btn btn-sm btn-outline-success">📤 Enviar</button>
+</form>
+{% endif %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1600,6 +1600,29 @@ def test_upload_document(monkeypatch, app):
         assert AnimalDocumento.query.filter_by(animal_id=animal_id).count() == 1
 
 
+def test_consulta_page_shows_documentos_tab(app, monkeypatch):
+    client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        tutor = User(id=1, name='Tutor', email='t@t')
+        tutor.set_password('x')
+        vet = User(id=2, name='Vet', email='v@v', worker='veterinario')
+        vet.set_password('x')
+        animal = Animal(id=1, name='Dog', user_id=tutor.id)
+        db.session.add_all([tutor, vet, animal])
+        db.session.commit()
+        animal_id = animal.id
+        vet_id = vet.id
+
+    import flask_login.utils as login_utils
+    monkeypatch.setattr(login_utils, '_get_user', lambda: User.query.get(vet_id))
+
+    resp = client.get(f'/consulta/{animal_id}')
+    assert resp.status_code == 200
+    assert 'Documentos' in resp.get_data(as_text=True)
+
+
 def test_delete_document_by_veterinarian(app, monkeypatch):
     with app.app_context():
         db.drop_all()


### PR DESCRIPTION
## Summary
- allow veterinarians to manage documents directly from the consultation screen via a new tab after Orçamento
- extract document listing and upload UI into a reusable partial
- cover new tab with regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac4d32602c832e85ede10e0cf96e19