### PR TITLE
feat: share documents via WhatsApp

### DIFF
--- a/templates/partials/documentos.html
+++ b/templates/partials/documentos.html
@@ -2,17 +2,20 @@
 {% if animal.documentos %}
   <ul class="list-group mb-3">
     {% for d in animal.documentos %}
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <span>{{ d.filename }}</span>
-        <div>
-          <a href="{{ d.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary">Abrir</a>
-          {% if current_user.role == 'admin' or (current_user.worker == 'veterinario' and current_user.id == d.veterinario_id) %}
-          <form action="{{ url_for('delete_document', animal_id=animal.id, doc_id=d.id) }}" method="post" class="d-inline">
-            <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Excluir documento?')">Excluir</button>
-          </form>
-          {% endif %}
-        </div>
-      </li>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <span>{{ d.filename }}</span>
+          <div>
+            <a href="{{ d.file_url }}" target="_blank" class="btn btn-sm btn-outline-primary">Abrir</a>
+            {% if tutor.phone %}
+              <a href="https://api.whatsapp.com/send?phone={{ tutor.phone|digits_only }}&text={{ ('Olá ' ~ tutor.name ~ '! Segue o documento: ' ~ d.file_url)|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
+            {% endif %}
+            {% if current_user.role == 'admin' or (current_user.worker == 'veterinario' and current_user.id == d.veterinario_id) %}
+            <form action="{{ url_for('delete_document', animal_id=animal.id, doc_id=d.id) }}" method="post" class="d-inline">
+              <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Excluir documento?')">Excluir</button>
+            </form>
+            {% endif %}
+          </div>
+        </li>
     {% endfor %}
   </ul>
 {% else %}


### PR DESCRIPTION
## Summary
- add WhatsApp share link for animal documents
- test WhatsApp link rendering when tutor has phone

## Testing
- `python -m pytest tests/test_routes.py::test_documentos_whatsapp_button_rendered -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac616f44f8832ea7633baf874c32b9