### PR TITLE
Implement WhatsApp messaging with Twilio and add transfer error handling

### DIFF
--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+# Ensure in-memory DB before importing app
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import app
+from app import enviar_mensagem_whatsapp
+
+from unittest.mock import Mock
+
+def test_enviar_mensagem_whatsapp(monkeypatch):
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TWILIO_WHATSAPP_FROM", "whatsapp:+123")
+
+    messages_create = Mock()
+    client_instance = Mock(messages=Mock(create=messages_create))
+    client_class = Mock(return_value=client_instance)
+    monkeypatch.setattr(app, "Client", client_class)
+
+    enviar_mensagem_whatsapp("ola", "whatsapp:+456")
+
+    client_class.assert_called_once_with("sid", "token")
+    messages_create.assert_called_once_with(
+        body="ola", from_="whatsapp:+123", to="whatsapp:+456"
+    )
+


### PR DESCRIPTION
## Summary
- Add `enviar_mensagem_whatsapp` using Twilio credentials from environment
- Improve tutorship transfer route with error handling and logging
- Cover WhatsApp sending with unit test mocking Twilio client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac6170e65c832eacfbadfd0f240acc