### PR TITLE
Add payment option for consultation budget via Mercado Pago

### DIFF
--- a/templates/partials/orcamento_form.html
+++ b/templates/partials/orcamento_form.html
@@ -62,6 +62,11 @@
     </tr>
   </tfoot>
 </table>
+<div class="text-end mt-3">
+  <a href="{{ url_for('pagar_orcamento', consulta_id=consulta.id) }}" class="btn btn-primary">
+    <i class="fa-solid fa-money-bill-wave me-1"></i> Pagar orçamento
+  </a>
+</div>
 
 <script>
 const consultaId = {{ consulta.id }};


### PR DESCRIPTION
## Summary
- add route to start Mercado Pago payment for consultation budget
- expose payment button in budget tab to redirect to Mercado Pago checkout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac69c41674832e8ba60af6f6002f8d