### PR TITLE
Improve mobile layout for store

### DIFF
--- a/templates/loja.html
+++ b/templates/loja.html
@@ -10,16 +10,16 @@
       Os melhores produtos para o seu pet com entrega rápida e atendimento especializado!
     </p>
     
-    <div class="d-flex flex-column flex-sm-row justify-content-center gap-3 mt-4">
+    <div class="d-flex flex-row flex-wrap justify-content-center gap-3 mt-4">
       {% if has_orders %}
       <a href="{{ url_for('minhas_compras') }}"
-         class="btn btn-outline-primary btn-lg d-flex align-items-center w-100 w-sm-auto">
+         class="btn btn-outline-primary btn-lg d-flex align-items-center flex-fill flex-sm-grow-0">
         <i class="bi bi-box-seam me-2"></i> Minhas Compras
       </a>
       {% endif %}
 
       <a href="{{ url_for('ver_carrinho') }}"
-         class="btn btn-success btn-lg d-flex align-items-center position-relative w-100 w-sm-auto">
+         class="btn btn-success btn-lg d-flex align-items-center position-relative flex-fill flex-sm-grow-0">
         <i class="bi bi-cart3 me-2"></i> Ver Carrinho
         {% if cart_count and cart_count > 0 %}
         <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
@@ -31,8 +31,8 @@
   </div>
 
   <!-- Search & Filter Section (Nova adição) -->
-  <form method="get" class="row mb-4 mb-lg-5">
-    <div class="col-12 col-md-6 mb-3 mb-md-0">
+  <form method="get" class="row mb-4 mb-lg-5 align-items-stretch">
+    <div class="col-9 col-md-6 mb-3 mb-md-0">
       <div class="input-group">
         <span class="input-group-text bg-transparent border-end-0">
           <i class="bi bi-search text-muted"></i>
@@ -44,8 +44,20 @@
         </button>
       </div>
     </div>
-    <div class="col-12 col-md-6">
-      <select class="form-select" name="filter" aria-label="Filtrar produtos" onchange="this.form.submit()">
+    <div class="col-3 col-md-6 d-flex">
+      <div class="dropdown w-100 d-md-none">
+        <button class="btn btn-outline-secondary w-100 h-100 dropdown-toggle" type="button" id="filterDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+          Filtrar
+        </button>
+        <ul class="dropdown-menu w-100" aria-labelledby="filterDropdown">
+          <li><button class="dropdown-item" type="submit" name="filter" value="all">Todos os produtos</button></li>
+          <li><button class="dropdown-item" type="submit" name="filter" value="lowStock">Estoque baixo</button></li>
+          <li><button class="dropdown-item" type="submit" name="filter" value="new">Novos produtos</button></li>
+          <li><button class="dropdown-item" type="submit" name="filter" value="priceLow">Preço: menor para maior</button></li>
+          <li><button class="dropdown-item" type="submit" name="filter" value="priceHigh">Preço: maior para menor</button></li>
+        </ul>
+      </div>
+      <select class="form-select d-none d-md-block" name="filter" aria-label="Filtrar produtos" onchange="this.form.submit()">
         <option value="all" {% if selected_filter=='all' %}selected{% endif %}>Todos os produtos</option>
         <option value="lowStock" {% if selected_filter=='lowStock' %}selected{% endif %}>Estoque baixo</option>
         <option value="new" {% if selected_filter=='new' %}selected{% endif %}>Novos produtos</option>


### PR DESCRIPTION
## Summary
- Keep "Minhas Compras" and "Ver Carrinho" buttons side-by-side on mobile
- Replace mobile filter select with dropdown button next to search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad8551d134832ea463cda7ecfc91eb