### PR TITLE
Allow button text wrapping to prevent overflow

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -194,11 +194,11 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            white-space: nowrap;
-            word-break: normal;
-            max-width: 100%;
-            flex-wrap: nowrap;
             text-align: center;
+            max-width: 100%;
+            flex-wrap: wrap;
+            white-space: normal;
+            word-break: break-word;
         }
 
         .btn i {


### PR DESCRIPTION
## Summary
- allow button text to wrap so long labels don't overflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad863b04ac832e9b2ec3f3f76fee9a