### PR TITLE
Align search button beside search bar on store page

### DIFF
--- a/templates/loja.html
+++ b/templates/loja.html
@@ -32,17 +32,17 @@
 
   <!-- Search & Filter Section (Nova adição) -->
   <form method="get" class="row mb-4 mb-lg-5 align-items-stretch">
-    <div class="col-9 col-md-6 mb-3 mb-md-0">
-      <div class="input-group">
+    <div class="col-9 col-md-6 mb-3 mb-md-0 d-flex">
+      <div class="input-group flex-grow-1">
         <span class="input-group-text bg-transparent border-end-0">
           <i class="bi bi-search text-muted"></i>
         </span>
         <input type="text" name="q" value="{{ search_term }}" class="form-control border-start-0" placeholder="Buscar produtos..." aria-label="Buscar produtos">
-        <button class="btn btn-primary" type="submit">
-          <i class="bi bi-search d-inline d-md-none"></i>
-          <span class="d-none d-md-inline">Pesquisar</span>
-        </button>
       </div>
+      <button class="btn btn-primary ms-2" type="submit">
+        <i class="bi bi-search d-inline d-md-none"></i>
+        <span class="d-none d-md-inline">Pesquisar</span>
+      </button>
     </div>
     <div class="col-3 col-md-6 d-flex">
       <div class="dropdown w-100 d-md-none">


### PR DESCRIPTION
## Summary
- Ensure the store search button sits beside the search input by restructuring the form layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad879e6d00832e9c1c722c4bbc7a72