### PR TITLE
Corrigir largura da navbar em telas pequenas

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -84,6 +84,7 @@
             background: var(--light-color);
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
             padding: 0 30px;
+            width: 100%;
         }
 
         .navbar-nav {
@@ -308,7 +309,7 @@
             }
 
             .navbar {
-                padding: 0 15px;
+                padding: 0 10px;
             }
 
             main.container {


### PR DESCRIPTION
## Resumo
- Impede que a navbar ultrapasse a largura da tela
- Ajusta o padding da navbar em dispositivos pequenos

## Testes
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad8afe8c30832eb48a1b456a12ec39