### PR TITLE
Require clinic id for printing vaccine and exam blocks

### DIFF
--- a/app.py
+++ b/app.py
@@ -2693,7 +2693,13 @@ def imprimir_vacinas(animal_id):
         if vet and vet.clinica:
             clinica = vet.clinica
     if not clinica:
-        clinica = getattr(animal, "clinica", None) or Clinica.query.first()
+        clinica = getattr(animal, "clinica", None)
+    if not clinica:
+        clinica_id = request.args.get("clinica_id", type=int)
+        if clinica_id:
+            clinica = Clinica.query.get_or_404(clinica_id)
+    if not clinica:
+        abort(400, description="É necessário informar uma clínica.")
     return render_template("imprimir_vacinas.html", animal=animal, clinica=clinica)
 
 
@@ -3151,8 +3157,18 @@ def imprimir_bloco_exames(bloco_id):
     bloco = BlocoExames.query.get_or_404(bloco_id)
     animal = bloco.animal
     tutor = animal.owner
-
-    clinica = current_user.veterinario.clinica if current_user.veterinario else Clinica.query.first()
+    clinica = None
+    vet = getattr(current_user, 'veterinario', None)
+    if vet and vet.clinica:
+        clinica = vet.clinica
+    if not clinica:
+        clinica = getattr(animal, 'clinica', None)
+    if not clinica:
+        clinica_id = request.args.get('clinica_id', type=int)
+        if clinica_id:
+            clinica = Clinica.query.get_or_404(clinica_id)
+    if not clinica:
+        abort(400, description="É necessário informar uma clínica.")
 
     return render_template('imprimir_exames.html', bloco=bloco, animal=animal, tutor=tutor, clinica=clinica)
 

--- a/tests/test_imprimir_bloco_exames.py
+++ b/tests/test_imprimir_bloco_exames.py
@@ -1,0 +1,41 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, Animal, Clinica, BlocoExames
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_imprimir_bloco_exames_requer_clinica(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        tutor = User(name="Tutor", email="tutor@example.com")
+        tutor.set_password('x')
+        animal = Animal(name="Rex", owner=tutor)
+        bloco = BlocoExames(animal=animal)
+        clinica = Clinica(nome="Pet Clinic")
+        db.session.add_all([tutor, animal, bloco, clinica])
+        db.session.commit()
+        bloco_id = bloco.id
+        clinica_id = clinica.id
+
+    client = app.test_client()
+    with client:
+        client.post('/login', data={'email': 'tutor@example.com', 'password': 'x'}, follow_redirects=True)
+        resp = client.get(f'/imprimir_bloco_exames/{bloco_id}')
+        assert resp.status_code == 400
+        resp = client.get(f'/imprimir_bloco_exames/{bloco_id}?clinica_id={clinica_id}')
+        assert resp.status_code == 200
+        assert b'Pet Clinic' in resp.data
+
+    with app.app_context():
+        db.drop_all()

--- a/tests/test_vacinas.py
+++ b/tests/test_vacinas.py
@@ -13,7 +13,7 @@ def app():
     yield flask_app
 
 
-def test_imprimir_vacinas_no_login(app):
+def test_imprimir_vacinas_requer_clinica(app):
     with app.app_context():
         db.create_all()
         owner = User(name="Tutor", email="tutor@example.com", password_hash="x")
@@ -23,6 +23,8 @@ def test_imprimir_vacinas_no_login(app):
         db.session.commit()
         client = app.test_client()
         resp = client.get(f"/animal/{animal.id}/vacinas/imprimir")
+        assert resp.status_code == 400
+        resp = client.get(f"/animal/{animal.id}/vacinas/imprimir?clinica_id={clinica.id}")
         assert resp.status_code == 200
         assert b"Rex" in resp.data
         assert b"Pet Clinic" in resp.data


### PR DESCRIPTION
## Summary
- Require explicit clinic selection for vaccine and exam block print routes
- Add tests for missing clinic scenarios and explicit clinic selection

## Testing
- `pytest tests/test_vacinas.py tests/test_imprimir_bloco_exames.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcff41750832e9e2449ac2f09fa01