### PR TITLE
Restrict clinic access to authorized users

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,7 +187,12 @@ from forms import (
     DeleteAccountForm, ClinicForm, ClinicHoursForm, ClinicAddVeterinarianForm,
     VetScheduleForm, VetSpecialtyForm, AppointmentForm, AppointmentDeleteForm
 )
-from helpers import calcular_idade, parse_data_nascimento, is_slot_available
+from helpers import (
+    calcular_idade,
+    parse_data_nascimento,
+    is_slot_available,
+    clinicas_do_usuario,
+)
 
 # ----------------------------------------------------------------
 # 7)  Login & serializer
@@ -1689,30 +1694,25 @@ def buscar_tutores():
 
 @app.route('/clinicas')
 def clinicas():
-    clinicas = Clinica.query.all()
+    clinicas = clinicas_do_usuario().all()
     return render_template('clinicas.html', clinicas=clinicas)
 
 
 @app.route('/minha-clinica')
 @login_required
 def minha_clinica():
-    clinica_id = None
-    if current_user.worker == 'veterinario' and getattr(current_user, 'veterinario', None):
-        clinica_id = current_user.veterinario.clinica_id
-    elif current_user.clinica_id:
-        clinica_id = current_user.clinica_id
-    if not clinica_id:
+    clinica = clinicas_do_usuario().first()
+    if not clinica:
         abort(404)
-    return redirect(url_for('clinic_detail', clinica_id=clinica_id))
+    return redirect(url_for('clinic_detail', clinica_id=clinica.id))
 
 
 @app.route('/clinica/<int:clinica_id>', methods=['GET', 'POST'])
 def clinic_detail(clinica_id):
-    clinica = Clinica.query.get_or_404(clinica_id)
+    clinica = clinicas_do_usuario().filter_by(id=clinica_id).first_or_404()
     hours_form = ClinicHoursForm()
     clinic_form = ClinicForm(obj=clinica)
     vets_form = ClinicAddVeterinarianForm()
-    hours_form.clinica_id.choices = [(c.id, c.nome) for c in Clinica.query.all()]
     vets_form.veterinario_id.choices = [
         (v.id, v.user.name)
         for v in Veterinario.query.filter_by(clinica_id=None).all()

--- a/forms.py
+++ b/forms.py
@@ -318,6 +318,14 @@ class ClinicHoursForm(FlaskForm):
     )
     submit = SubmitField('Salvar')
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        from helpers import clinicas_do_usuario
+
+        self.clinica_id.choices = [
+            (c.id, c.nome) for c in clinicas_do_usuario().all()
+        ]
+
 
 class ClinicAddVeterinarianForm(FlaskForm):
     veterinario_id = SelectField(

--- a/helpers.py
+++ b/helpers.py
@@ -1,6 +1,7 @@
 import requests
 
 from flask import redirect, render_template, session
+from flask_login import current_user
 from functools import wraps
 
 
@@ -111,4 +112,23 @@ def is_slot_available(veterinario_id, scheduled_at):
         .first()
     )
     return conflict is None
+
+
+def clinicas_do_usuario():
+    """Retorna query de ``Clinica`` filtrada pelo usuário atual."""
+    from models import Clinica
+
+    if not current_user.is_authenticated:
+        return Clinica.query.filter(False)
+
+    if current_user.role == "admin":
+        return Clinica.query
+
+    if current_user.worker == "veterinario" and getattr(current_user, "veterinario", None):
+        return Clinica.query.filter_by(id=current_user.veterinario.clinica_id)
+
+    if current_user.clinica_id:
+        return Clinica.query.filter_by(id=current_user.clinica_id)
+
+    return Clinica.query.filter_by(owner_id=current_user.id)
 


### PR DESCRIPTION
## Summary
- Add `clinicas_do_usuario` helper to centralize clinic filtering
- Use helper in clinic routes to show only user-authorized clinics
- Limit ClinicHoursForm choices to authorized clinics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcff50158832e9838717d95d14ab0