### PR TITLE
Handle circular FK between Clinica and User

### DIFF
--- a/models.py
+++ b/models.py
@@ -153,8 +153,12 @@ class User(UserMixin, db.Model):
     added_by = db.relationship('User', remote_side=[id], backref='users_added')  # 🆕
 
 
-
-    clinica_id = db.Column(db.Integer, db.ForeignKey('clinica.id'), nullable=True)
+    # Usamos use_alter=True para evitar ciclos de FK com Clinica
+    clinica_id = db.Column(
+        db.Integer,
+        db.ForeignKey('clinica.id', use_alter=True, name='fk_user_clinica'),
+        nullable=True,
+    )
     clinica = db.relationship('Clinica', backref='usuarios', foreign_keys=[clinica_id])
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -523,8 +527,16 @@ class Clinica(db.Model):
     photo_offset_x = db.Column(db.Float, default=0.0)
     photo_offset_y = db.Column(db.Float, default=0.0)
 
-    owner_id = db.Column(db.Integer, db.ForeignKey('user.id'))
-    owner = db.relationship('User', backref=db.backref('clinicas', foreign_keys='Clinica.owner_id'), foreign_keys=[owner_id])
+    owner_id = db.Column(
+        db.Integer,
+        db.ForeignKey('user.id', use_alter=True, name='fk_clinica_owner'),
+    )
+    owner = db.relationship(
+        'User',
+        backref=db.backref('clinicas', foreign_keys='Clinica.owner_id'),
+        foreign_keys=[owner_id],
+        post_update=True,
+    )
 
     veterinarios = db.relationship('Veterinario', backref='clinica', lazy=True)
 


### PR DESCRIPTION
## Summary
- mark Clinica.owner_id and User.clinica_id foreign keys with `use_alter` to avoid circular dependency warnings
- update Clinica.owner relationship with `post_update` for safer ORM operations

## Testing
- `flask db migrate -m "test"` *(fails: connection to server at "c2hbg00ac72j9d.cluster-czrs8kj4isg7.us-east-1.rds.amazonaws.com" failed: Network is unreachable)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68add4b303c8832e846ac68013ae836a