### PR TITLE
Fix consulta edit text auto-expand

### DIFF
--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -101,5 +101,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Inicializa o auto-expand
   setupAutoExpand();
+
+  // Reaplica auto-expand ao exibir a aba de consulta
+  const tabs = document.getElementById('consultaTabs');
+  if (tabs) {
+    tabs.addEventListener('shown.bs.tab', function(event) {
+      if (event.target.getAttribute('data-bs-target') === '#consulta-info') {
+        setupAutoExpand();
+      }
+    });
+  }
 });
 </script>


### PR DESCRIPTION
## Summary
- Reapply textarea auto-expansion when switching to the consulta tab to display full text during edits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aee832fe1c832e95440f9393e3f77f