### PR TITLE
Display animal age in months when under a year

### DIFF
--- a/models.py
+++ b/models.py
@@ -285,10 +285,18 @@ class Animal(db.Model):
 
     @property
     def age_display(self):
-        years = self.age_years
-        if years is not None:
-            return f"{years} ano{'s' if years != 1 else ''}"
-        return self.age
+        if self.date_of_birth:
+            delta = relativedelta(date.today(), self.date_of_birth)
+            if delta.years > 0:
+                return f"{delta.years} ano{'s' if delta.years != 1 else ''}"
+            return f"{delta.months} mes{'es' if delta.months != 1 else ''}"
+        if self.age:
+            try:
+                years = int(self.age.split()[0])
+                return f"{years} ano{'s' if years != 1 else ''}"
+            except (ValueError, AttributeError, IndexError):
+                return self.age
+        return None
 
     def __str__(self):
         return f"{self.name} ({self.species.name if self.species else self.species})"

--- a/tests/test_age_display.py
+++ b/tests/test_age_display.py
@@ -1,0 +1,14 @@
+from datetime import date
+from dateutil.relativedelta import relativedelta
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from models import Animal
+
+
+def test_age_display_months():
+    animal = Animal(name="Filhote", user_id=1, date_of_birth=date.today() - relativedelta(months=5))
+    assert animal.age_display == "5 meses"


### PR DESCRIPTION
## Summary
- Show animal ages under a year in months instead of `0 anos`
- Add regression test for month-based age display

## Testing
- `pytest tests/test_age_display.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeec376890832eaa10a33b58eb4ce9