### PR TITLE
Exibir aba Minha Clínica para todos veterinários

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -131,7 +131,7 @@ def clinicas_do_usuario():
     if current_user.role == "admin":
         return Clinica.query
 
-    if current_user.worker == "veterinario" and getattr(current_user, "veterinario", None):
+    if getattr(current_user, "veterinario", None) and current_user.veterinario.clinica_id:
         return Clinica.query.filter_by(id=current_user.veterinario.clinica_id)
 
     if current_user.clinica_id:

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -471,7 +471,7 @@
                             <ul class="dropdown-menu dropdown-menu-end">
                                 <li><a class="dropdown-item" href="{{ url_for('profile') }}"><i class="fas fa-user me-2 text-primary"></i> Meu Perfil</a></li>
                                 <li><a class="dropdown-item" href="{{ url_for('minhas_compras') }}"><i class="fas fa-box me-2 text-warning"></i> Minhas Compras</a></li>
-                                {% if current_user.worker == 'veterinario' and current_user.veterinario %}
+                                {% if current_user.veterinario %}
                                 <li><a class="dropdown-item" href="{{ url_for('minha_clinica') }}"><i class="fas fa-clinic-medical me-2 text-info"></i> Minha Clínica</a></li>
                                 {% endif %}
                 

--- a/tests/test_minha_clinica.py
+++ b/tests/test_minha_clinica.py
@@ -19,7 +19,7 @@ def test_minha_clinica_redirects(monkeypatch, app):
     with app.app_context():
         db.create_all()
         clinica = Clinica(nome="Pet Clinic")
-        user = User(name="Vet", email="vet@example.com", password_hash="x", worker="veterinario")
+        user = User(name="Vet", email="vet@example.com", password_hash="x")
         vet = Veterinario(user=user, crmv="123", clinica=clinica)
         db.session.add_all([clinica, user, vet])
         db.session.commit()
@@ -30,3 +30,20 @@ def test_minha_clinica_redirects(monkeypatch, app):
         resp = client.get('/minha-clinica')
         assert resp.status_code == 302
         assert f"/clinica/{clinica.id}" in resp.headers['Location']
+
+
+def test_layout_shows_minha_clinica_for_veterinario(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        clinica = Clinica(nome="Pet Clinic")
+        user = User(name="Vet", email="vet2@example.com", password_hash="x")
+        vet = Veterinario(user=user, crmv="123", clinica=clinica)
+        db.session.add_all([clinica, user, vet])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+        resp = client.get('/')
+        assert b'Minha Cl\xc3\xadnica' in resp.data


### PR DESCRIPTION
## Summary
- Remove dependência do campo `worker` ao recuperar clínicas do usuário
- Mostrar item "Minha Clínica" no menu para qualquer usuário com perfil de veterinário
- Ajustar e expandir testes para cobrir nova exibição da aba

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b06b798980832e92854a146439eba4