### PR TITLE
Restrict clinic data visibility to clinic staff

### DIFF
--- a/tests/test_clinic_access.py
+++ b/tests/test_clinic_access.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 from app import app as flask_app, db
-from models import User, Clinica, Veterinario
+from models import User, Clinica, Veterinario, Animal
 
 
 @pytest.fixture
@@ -45,4 +45,38 @@ def test_admin_can_access_any_clinic(monkeypatch, app):
         db.session.commit()
         login(monkeypatch, admin)
         resp = client.get(f"/clinica/{c2.id}")
+        assert resp.status_code == 200
+
+
+def test_vet_cannot_access_other_clinic_consulta(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        c1 = Clinica(nome="Clinic One")
+        c2 = Clinica(nome="Clinic Two")
+        tutor = User(name="Tutor", email="tutor@example.com", password_hash="x")
+        animal = Animal(name="Rex", owner=tutor, clinica=c2)
+        user = User(name="User", email="user2@example.com", password_hash="x", worker="veterinario")
+        vet = Veterinario(user=user, crmv="123", clinica=c1)
+        db.session.add_all([c1, c2, tutor, animal, user, vet])
+        db.session.commit()
+        login(monkeypatch, user)
+        resp = client.get(f"/consulta/{animal.id}")
+        assert resp.status_code == 404
+
+
+def test_admin_can_access_any_consulta(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        c1 = Clinica(nome="Clinic One")
+        c2 = Clinica(nome="Clinic Two")
+        admin = User(name="Admin", email="admin2@example.com", password_hash="x", role="admin", worker="veterinario")
+        tutor = User(name="Tutor", email="tutor2@example.com", password_hash="y")
+        animal = Animal(name="Rex", owner=tutor, clinica=c2)
+        vet_admin = Veterinario(user=admin, crmv="999", clinica=c1)
+        db.session.add_all([c1, c2, admin, tutor, animal, vet_admin])
+        db.session.commit()
+        login(monkeypatch, admin)
+        resp = client.get(f"/consulta/{animal.id}")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add helper functions to enforce clinic-based access restrictions
- guard consultation routes so only staff from the same clinic can view data
- add tests ensuring cross-clinic access is blocked except for admins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b06fc89b24832eb3b1332090fc82a4