### PR TITLE
Restrict clinic detail access to authorized clinics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1812,7 +1812,16 @@ def clinic_detail(clinica_id):
     if _is_admin():
         clinica = Clinica.query.get_or_404(clinica_id)
     else:
-        clinica = clinicas_do_usuario().filter_by(id=clinica_id).first_or_404()
+        # Para usuários não administradores, garantimos que a clínica
+        # consultada pertence ao conjunto de clínicas acessíveis ao
+        # usuário atual. O uso de ``filter`` com ``Clinica.id`` evita
+        # possíveis ambiguidades de ``filter_by`` e assegura que o
+        # ``clinica_id`` da URL seja respeitado corretamente.
+        clinica = (
+            clinicas_do_usuario()
+            .filter(Clinica.id == clinica_id)
+            .first_or_404()
+        )
     hours_form = ClinicHoursForm()
     clinic_form = ClinicForm(obj=clinica)
     vets_form = ClinicAddVeterinarianForm()

--- a/tests/test_clinic_access.py
+++ b/tests/test_clinic_access.py
@@ -34,6 +34,21 @@ def test_user_cannot_access_other_clinic(monkeypatch, app):
         assert resp.status_code == 404
 
 
+def test_user_sees_own_clinic(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        c1 = Clinica(nome="Clinic One")
+        user = User(name="User", email="user3@example.com", password_hash="x")
+        vet = Veterinario(user=user, crmv="123", clinica=c1)
+        db.session.add_all([c1, user, vet])
+        db.session.commit()
+        login(monkeypatch, user)
+        resp = client.get(f"/clinica/{c1.id}")
+        assert resp.status_code == 200
+        assert b"Clinic One" in resp.data
+
+
 def test_admin_can_access_any_clinic(monkeypatch, app):
     client = app.test_client()
     with app.app_context():


### PR DESCRIPTION
## Summary
- tighten clinic detail lookup to use explicit filter on clinic id within user's accessible clinics
- add test confirming users view only their own clinic details

## Testing
- `pytest tests/test_clinic_access.py tests/test_minha_clinica.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0735b04fc832e8ad736619c46ca73