### PR TITLE
Isolate consulta data per clinic

### DIFF
--- a/models.py
+++ b/models.py
@@ -432,6 +432,7 @@ class Consulta(db.Model):
         db.ForeignKey('user.id', ondelete='CASCADE'),
         nullable=False,
     )  # veterinário
+    clinica_id = db.Column(db.Integer, db.ForeignKey('clinica.id'), nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Campos principais da consulta
@@ -452,6 +453,7 @@ class Consulta(db.Model):
         foreign_keys=[created_by],
         backref=db.backref('consultas', cascade='all, delete-orphan'),
     )
+    clinica = db.relationship('Clinica', backref=db.backref('consultas', cascade='all, delete-orphan'))
 
     @property
     def total_orcamento(self):


### PR DESCRIPTION
## Summary
- Scope `Consulta` records by clinic while keeping tutor/animal/ration data global
- Adjust consulta routes to filter and create consultations per clinic
- Allow cross-clinic access to consultation page and add tests for isolation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17d07a6a0832e98a89c0e177a0ebf