### PR TITLE
Add agenda and event APIs with FullCalendar integration

### DIFF
--- a/models.py
+++ b/models.py
@@ -675,6 +675,17 @@ event.listen(Appointment, 'before_update', Appointment._validate_subscription)
 event.listen(Appointment, 'before_insert', Appointment._set_clinica)
 event.listen(Appointment, 'before_update', Appointment._set_clinica)
 
+
+class Event(db.Model):
+    """Simple calendar event for agenda."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    start = db.Column(db.DateTime, nullable=False)
+    end = db.Column(db.DateTime, nullable=True)
+
+
+
 class Medicamento(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     nome = db.Column(db.String(100), nullable=False)

--- a/templates/agenda.html
+++ b/templates/agenda.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var calendarEl = document.getElementById('calendar');
+      var calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'dayGridMonth',
+        editable: true,
+        selectable: true,
+        events: '/api/events',
+        select: function(info) {
+          var title = prompt('Título do evento:');
+          if (title) {
+            fetch('/api/events', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({title: title, start: info.startStr, end: info.endStr})
+            }).then(function(){ calendar.refetchEvents(); });
+          }
+          calendar.unselect();
+        },
+        eventDrop: updateEvent,
+        eventResize: updateEvent,
+        eventClick: function(info) {
+          if (confirm('Excluir evento?')) {
+            fetch('/api/events/' + info.event.id, {method: 'DELETE'})
+              .then(function(){ calendar.refetchEvents(); });
+          }
+        }
+      });
+      function updateEvent(info) {
+        fetch('/api/events/' + info.event.id, {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            title: info.event.title,
+            start: info.event.start.toISOString(),
+            end: info.event.end ? info.event.end.toISOString() : null
+          })
+        }).then(function(){ calendar.refetchEvents(); });
+      }
+      calendar.render();
+    });
+  </script>
+</head>
+<body>
+  <div id="calendar"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple Event model for calendar entries
- implement `/agenda` page and REST endpoints for events with role checks
- include FullCalendar template for interactive scheduling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1847ed31c832e9d7c10f2c974fb79