### PR TITLE
Enable CSRF-protected fetch operations for agenda

### DIFF
--- a/templates/agenda.html
+++ b/templates/agenda.html
@@ -49,12 +49,68 @@ document.addEventListener('DOMContentLoaded', function() {
       selectable: true,
       events: '/api/events',
       eventClick: function(info) {
-        var modal = new bootstrap.Modal(document.getElementById('eventModal'));
-        modal.show();
+        if (confirm('Remover este evento?')) {
+          fetch('/api/events/' + info.event.id, {
+            method: 'DELETE',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRFToken': '{{ csrf_token() }}'
+            }
+          })
+          .then(function(response) {
+            if (!response.ok) throw new Error('Erro ao remover evento');
+            calendar.refetchEvents();
+          })
+          .catch(function(error) {
+            console.error(error);
+          });
+        }
       },
       select: function(info) {
-        var modal = new bootstrap.Modal(document.getElementById('newEventModal'));
-        modal.show();
+        var eventData = {
+          title: 'Novo Evento',
+          start: info.startStr,
+          end: info.endStr
+        };
+        fetch('/api/events', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': '{{ csrf_token() }}'
+          },
+          body: JSON.stringify(eventData)
+        })
+        .then(function(response) {
+          if (!response.ok) throw new Error('Erro ao criar evento');
+          return response.json();
+        })
+        .then(function(data) {
+          calendar.refetchEvents();
+        })
+        .catch(function(error) {
+          console.error(error);
+        });
+      },
+      eventDrop: function(info) {
+        var updatedData = {
+          start: info.event.startStr,
+          end: info.event.endStr
+        };
+        fetch('/api/events/' + info.event.id, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': '{{ csrf_token() }}'
+          },
+          body: JSON.stringify(updatedData)
+        })
+        .then(function(response) {
+          if (!response.ok) throw new Error('Erro ao atualizar evento');
+          calendar.refetchEvents();
+        })
+        .catch(function(error) {
+          console.error(error);
+        });
       }
     });
     calendar.render();


### PR DESCRIPTION
## Summary
- Replace modal placeholders with fetch calls for creating, updating, and deleting calendar events
- Send CSRF token in request headers and refresh calendar after each operation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1a418ac10832ea231f456a3579c92