### PR TITLE
Enable clinic owners to manage staff schedules

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -108,13 +108,54 @@
     {% for v in veterinarios %}
       <li>
         {{ v.user.name }} (CRMV: {{ v.crmv }})
+        {% if pode_editar %}
+        <form method="post" action="{{ url_for('remove_veterinario', clinica_id=clinica.id, veterinario_id=v.id) }}" class="d-inline">
+          {{ vet_schedule_forms[v.id].csrf_token }}
+          <button type="submit" class="btn btn-sm btn-outline-danger ms-2">Remover</button>
+        </form>
+        {% endif %}
         <ul class="ms-3">
           {% for h in v.horarios %}
-            <li>{{ h.dia_semana }}: {{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}</li>
+            <li>
+              {{ h.dia_semana }}: {{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}
+              {% if pode_editar %}
+              <form method="post" action="{{ url_for('delete_vet_schedule_clinic', clinica_id=clinica.id, veterinario_id=v.id, horario_id=h.id) }}" class="d-inline">
+                {{ vet_schedule_forms[v.id].csrf_token }}
+                <button type="submit" class="btn btn-sm btn-outline-danger ms-2">Excluir</button>
+              </form>
+              {% endif %}
+            </li>
           {% else %}
             <li>Sem horários cadastrados.</li>
           {% endfor %}
         </ul>
+        {% if pode_editar %}
+        <form method="post" class="ms-3 mb-3">
+          {{ vet_schedule_forms[v.id].hidden_tag() }}
+          <div style="display:none;">{{ vet_schedule_forms[v.id].veterinario_id() }}</div>
+          <div class="mb-2">
+            {{ vet_schedule_forms[v.id].dias_semana.label }}
+            {{ vet_schedule_forms[v.id].dias_semana(class="form-select", multiple=True, size=7) }}
+          </div>
+          <div class="mb-2">
+            {{ vet_schedule_forms[v.id].hora_inicio.label }}
+            {{ vet_schedule_forms[v.id].hora_inicio(class="form-control") }}
+          </div>
+          <div class="mb-2">
+            {{ vet_schedule_forms[v.id].hora_fim.label }}
+            {{ vet_schedule_forms[v.id].hora_fim(class="form-control") }}
+          </div>
+          <div class="mb-2">
+            {{ vet_schedule_forms[v.id].intervalo_inicio.label }}
+            {{ vet_schedule_forms[v.id].intervalo_inicio(class="form-control") }}
+          </div>
+          <div class="mb-2">
+            {{ vet_schedule_forms[v.id].intervalo_fim.label }}
+            {{ vet_schedule_forms[v.id].intervalo_fim(class="form-control") }}
+          </div>
+          {{ vet_schedule_forms[v.id].submit(class="btn btn-primary btn-sm") }}
+        </form>
+        {% endif %}
       </li>
     {% else %}
       <li>Nenhum veterinário associado.</li>

--- a/tests/test_clinic_employee_schedule.py
+++ b/tests/test_clinic_employee_schedule.py
@@ -1,0 +1,55 @@
+import pytest
+from app import app as flask_app, db
+from models import User, Clinica, Veterinario, VetSchedule
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_owner_manage_employees(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        owner = User(name="Owner", email="owner@example.com", password_hash="x")
+        clinica = Clinica(nome="Clinica", owner=owner)
+        vet_user = User(name="Vet", email="vet@example.com", password_hash="x")
+        vet = Veterinario(user=vet_user, crmv="123", clinica=clinica)
+        db.session.add_all([owner, clinica, vet_user, vet])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: owner)
+
+        resp = client.post(
+            f'/clinica/{clinica.id}',
+            data={
+                f'schedule_{vet.id}-veterinario_id': str(vet.id),
+                f'schedule_{vet.id}-dias_semana': ['Segunda'],
+                f'schedule_{vet.id}-hora_inicio': '09:00',
+                f'schedule_{vet.id}-hora_fim': '10:00',
+                f'schedule_{vet.id}-intervalo_inicio': '',
+                f'schedule_{vet.id}-intervalo_fim': '',
+                f'schedule_{vet.id}-submit': 'Salvar',
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert VetSchedule.query.filter_by(veterinario_id=vet.id).count() == 1
+
+        schedule = VetSchedule.query.filter_by(veterinario_id=vet.id).first()
+        resp = client.post(
+            f'/clinica/{clinica.id}/veterinario/{vet.id}/schedule/{schedule.id}/delete',
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert VetSchedule.query.filter_by(veterinario_id=vet.id).count() == 0
+
+        resp = client.post(
+            f'/clinica/{clinica.id}/veterinario/{vet.id}/remove',
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert vet.clinica_id is None


### PR DESCRIPTION
## Summary
- Allow clinic owners to assign schedules to veterinarians
- Let clinic owners remove staff and delete schedules from clinic page
- Add tests covering employee schedule management

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1c30018b0832ea3b1b3d8742f7a8e