### PR TITLE
Add JavaScript-based appointment editor

### DIFF
--- a/templates/appointments.html
+++ b/templates/appointments.html
@@ -51,6 +51,9 @@
           {% if current_user.worker in ['veterinario', 'colaborador'] %}
           <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success">🩺 Iniciar Consulta</a>
           {% endif %}
+          {% if current_user.role == 'admin' or current_user.worker in ['veterinario', 'colaborador'] or current_user.id == appt.tutor_id %}
+          <a href="{{ url_for('edit_appointment', appointment_id=appt.id) }}" class="btn btn-sm btn-outline-warning">✏️ Editar</a>
+          {% endif %}
         </div>
       </li>
     {% else %}

--- a/templates/edit_appointment.html
+++ b/templates/edit_appointment.html
@@ -1,0 +1,58 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container mt-4">
+  <h2>Editar Consulta</h2>
+  <form id="edit-form">
+    <div class="mb-3">
+      <label for="date" class="form-label">Data</label>
+      <input type="date" id="date" class="form-control" value="{{ appointment.scheduled_at.date() }}">
+    </div>
+    <div class="mb-3">
+      <label for="time" class="form-label">Horário</label>
+      <input type="time" id="time" class="form-control" value="{{ appointment.scheduled_at.strftime('%H:%M') }}">
+    </div>
+    <div class="mb-3">
+      <label for="veterinario" class="form-label">Veterinário</label>
+      <select id="veterinario" class="form-select">
+        {% for vet in veterinarios %}
+          <option value="{{ vet.id }}" {% if vet.id == appointment.veterinario_id %}selected{% endif %}>
+            {{ vet.user.name if vet.user else vet.id }}
+          </option>
+        {% endfor %}
+      </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Salvar</button>
+    <a href="{{ url_for('appointments') }}" class="btn btn-secondary">Cancelar</a>
+  </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.getElementById('edit-form').addEventListener('submit', async function(e) {
+  e.preventDefault();
+  const data = {
+    date: document.getElementById('date').value,
+    time: document.getElementById('time').value,
+    veterinario_id: document.getElementById('veterinario').value
+  };
+  const resp = await fetch('', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': '{{ csrf_token() if csrf_token is defined else "" }}'
+    },
+    body: JSON.stringify(data)
+  });
+  if (resp.ok) {
+    window.location.href = '{{ url_for("appointments") }}';
+  } else {
+    let err = 'Erro ao salvar';
+    try { const data = await resp.json(); if (data.message) err = data.message; } catch (e) {}
+    alert(err);
+  }
+});
+</script>
+{% endblock %}

--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -115,6 +115,7 @@
           <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary">📋 Ficha Animal</a>
           <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary">👤 Ficha Tutor</a>
           <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success">🩺 Iniciar Consulta</a>
+          <a href="{{ url_for('edit_appointment', appointment_id=appt.id) }}" class="btn btn-sm btn-outline-warning">✏️ Editar</a>
         </div>
       </li>
     {% else %}

--- a/tests/test_appointment_edit.py
+++ b/tests/test_appointment_edit.py
@@ -1,0 +1,84 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import flask_login.utils as login_utils
+from app import app as flask_app, db
+from datetime import datetime, time as dtime
+from models import (
+    User,
+    Animal,
+    Veterinario,
+    Appointment,
+    HealthPlan,
+    HealthSubscription,
+    VetSchedule,
+    Clinica,
+)
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def login(monkeypatch, user):
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def test_vet_can_edit_appointment_date_time_and_vet(client, monkeypatch):
+    with flask_app.app_context():
+        clinic = Clinica(id=1, nome='Clinica')
+        tutor = User(id=1, name='Tutor', email='tutor@test')
+        tutor.set_password('x')
+        vet_user1 = User(id=2, name='Vet1', email='vet1@test', worker='veterinario')
+        vet_user1.set_password('x')
+        vet_user2 = User(id=3, name='Vet2', email='vet2@test', worker='veterinario')
+        vet_user2.set_password('x')
+        animal = Animal(id=1, name='Rex', user_id=tutor.id, clinica_id=clinic.id)
+        plan = HealthPlan(id=1, name='Basic', price=10.0)
+        sub = HealthSubscription(animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True)
+        vet1 = Veterinario(id=1, user_id=vet_user1.id, crmv='123', clinica_id=clinic.id)
+        vet2 = Veterinario(id=2, user_id=vet_user2.id, crmv='456', clinica_id=clinic.id)
+        schedule1 = VetSchedule(id=1, veterinario_id=vet1.id, dia_semana='Quinta', hora_inicio=dtime(9,0), hora_fim=dtime(17,0))
+        schedule2 = VetSchedule(id=2, veterinario_id=vet2.id, dia_semana='Quinta', hora_inicio=dtime(9,0), hora_fim=dtime(17,0))
+        db.session.add_all([clinic, tutor, vet_user1, vet_user2, animal, plan, sub, vet1, vet2, schedule1, schedule2])
+        db.session.commit()
+        appt = Appointment(id=1, animal_id=animal.id, tutor_id=tutor.id, veterinario_id=vet1.id, scheduled_at=datetime(2024,5,1,10,0), clinica_id=clinic.id)
+        db.session.add(appt)
+        db.session.commit()
+        appt_id = appt.id
+        vet1_user_id = vet_user1.id
+        clinic_id = clinic.id
+    fake_vet = type('U', (), {
+        'id': vet1_user_id,
+        'worker': 'veterinario',
+        'role': 'adotante',
+        'name': 'Vet1',
+        'is_authenticated': True,
+        'veterinario': type('V', (), {'id': 1, 'clinica_id': clinic_id})()
+    })()
+    login(monkeypatch, fake_vet)
+    resp = client.post(f'/appointments/{appt_id}/edit', json={
+        'date': '2024-05-02',
+        'time': '11:30',
+        'veterinario_id': 2
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+    with flask_app.app_context():
+        appt = Appointment.query.get(appt_id)
+        assert appt.veterinario_id == 2
+        assert appt.scheduled_at == datetime(2024,5,2,11,30)


### PR DESCRIPTION
## Summary
- add edit appointment route and template with JS-powered form
- link scheduled appointments to the new editor
- cover editing logic with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1c282277c832e996903e0168a5ff4