### PR TITLE
Fix CSRF token in edit schedule template

### DIFF
--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -273,7 +273,7 @@
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-CSRFToken': '{{ csrf_token() }}'
+        'X-CSRFToken': '{{ csrf_token() if csrf_token is defined else '' }}'
       },
       body: JSON.stringify({
         date: date,


### PR DESCRIPTION
## Summary
- Avoid undefined errors by only injecting CSRF token when provided

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1c8b55618832e9ab0b8624ec79602