### PR TITLE
Add multi-clinic dashboard and schedule conflict checks

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -152,3 +152,18 @@ def clinicas_do_usuario():
 
     return Clinica.query.filter_by(owner_id=current_user.id)
 
+
+def has_schedule_conflict(veterinario_id, dia_semana, hora_inicio, hora_fim, exclude_id=None):
+    """Verifica se já existe horário que conflita para o veterinário."""
+    from models import VetSchedule
+
+    query = VetSchedule.query.filter_by(
+        veterinario_id=veterinario_id, dia_semana=dia_semana
+    )
+    if exclude_id is not None:
+        query = query.filter(VetSchedule.id != exclude_id)
+    for existente in query.all():
+        if not (hora_fim <= existente.hora_inicio or hora_inicio >= existente.hora_fim):
+            return True
+    return False
+

--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -129,6 +129,22 @@
     {% endfor %}
   </ul>
 
+  {% if colleagues %}
+  <h3>Agendas dos Colegas</h3>
+  {% for col in colleagues %}
+    <h5>{{ col.user.name }}</h5>
+    <ul class="list-group mb-3">
+      {% for ap in colleague_appointments[col.id] %}
+        <li class="list-group-item">
+          {{ ap.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ ap.animal.name }} ({{ ap.tutor.name }})
+        </li>
+      {% else %}
+        <li class="list-group-item">Nenhuma consulta agendada.</li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+  {% endif %}
+
   <!-- Modal de detalhes da consulta -->
   <div class="modal fade" id="appointmentModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">

--- a/templates/multi_clinic_dashboard.html
+++ b/templates/multi_clinic_dashboard.html
@@ -1,0 +1,31 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container mt-4">
+  <h2>Minhas Clínicas</h2>
+  {% for item in clinics %}
+  <div class="card mb-3">
+    <div class="card-body">
+      <h3>{{ item.clinic.nome }}</h3>
+      <a href="{{ url_for('clinic_detail', clinica_id=item.clinic.id) }}" class="btn btn-primary btn-sm mb-3">Acessar</a>
+      <h5>Equipe</h5>
+      <ul>
+        {% for v in item.staff %}
+        <li>{{ v.user.name }}</li>
+        {% else %}
+        <li>Nenhum veterinário.</li>
+        {% endfor %}
+      </ul>
+      <h5>Próximos Agendamentos</h5>
+      <ul>
+        {% for ap in item.appointments %}
+        <li>{{ ap.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ ap.animal.name }}</li>
+        {% else %}
+        <li>Nenhum agendamento.</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/tests/test_colleague_schedule.py
+++ b/tests/test_colleague_schedule.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import flask_login.utils as login_utils
+
+from app import app as flask_app, db
+from models import User, Clinica, Veterinario
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    flask_app.jinja_env.globals['csrf_token'] = lambda: ''
+    yield flask_app
+
+
+def test_colleague_schedules_visible(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        clinica = Clinica(nome="Pet Clinic")
+        main_user = User(name="Main", email="m@example.com", password_hash="x", worker='veterinario')
+        main_vet = Veterinario(user=main_user, crmv="1", clinica=clinica)
+        col_user = User(name="Col", email="c@example.com", password_hash="x", worker='veterinario')
+        col_vet = Veterinario(user=col_user, crmv="2", clinica=clinica)
+        db.session.add_all([clinica, main_user, main_vet, col_user, col_vet])
+        db.session.commit()
+        monkeypatch.setattr(login_utils, '_get_user', lambda: main_user)
+        resp = client.get('/appointments')
+        assert resp.status_code == 200
+        assert b'Col' in resp.data


### PR DESCRIPTION
## Summary
- add multi-clinic dashboard for users managing multiple clinics
- block overlapping veterinarian schedules when creating or editing time slots
- expose colleagues' agendas on the veterinarian schedule page for coordination

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1c7a7e978832e815b5a2fe8534692