### PR TITLE
Add per-veterinarian filter for animals and tutors

### DIFF
--- a/app.py
+++ b/app.py
@@ -2225,7 +2225,25 @@ def tutores():
 
     # — GET com paginação —
     page = request.args.get('page', 1, type=int)
-    if current_user.clinica_id:
+    scope = request.args.get('scope', 'all')
+    if scope == 'mine':
+        query = User.query
+        if current_user.clinica_id:
+            query = query.filter(User.clinica_id == current_user.clinica_id)
+        conditions = [User.added_by_id == current_user.id]
+        if current_user.veterinario:
+            conditions.append(
+                User.appointments.any(
+                    Appointment.veterinario_id == current_user.veterinario.id
+                )
+            )
+        pagination = (
+            query.filter(or_(*conditions))
+            .order_by(User.created_at.desc())
+            .paginate(page=page, per_page=9)
+        )
+        tutores_adicionados = pagination.items
+    elif current_user.clinica_id:
         last_appt = (
             db.session.query(
                 Appointment.tutor_id,
@@ -2256,7 +2274,8 @@ def tutores():
     return render_template(
         'tutores.html',
         tutores_adicionados=tutores_adicionados,
-        pagination=pagination
+        pagination=pagination,
+        scope=scope
     )
 
 
@@ -3696,7 +3715,24 @@ def novo_animal():
 
     # GET: lista de animais adicionados para exibição
     page = request.args.get('page', 1, type=int)
-    if current_user.clinica_id:
+    scope = request.args.get('scope', 'all')
+    if scope == 'mine':
+        query = Animal.query.filter(Animal.removido_em == None)
+        if current_user.clinica_id:
+            query = query.filter(Animal.clinica_id == current_user.clinica_id)
+        conditions = [Animal.added_by_id == current_user.id]
+        if current_user.veterinario:
+            conditions.append(
+                Animal.appointments.any(
+                    Appointment.veterinario_id == current_user.veterinario.id
+                )
+            )
+        pagination = (
+            query.filter(or_(*conditions))
+            .order_by(Animal.date_added.desc())
+            .paginate(page=page, per_page=9)
+        )
+    elif current_user.clinica_id:
         last_appt = (
             db.session.query(
                 Appointment.animal_id,
@@ -3740,7 +3776,8 @@ def novo_animal():
         animais_adicionados=animais_adicionados,
         pagination=pagination,
         species_list=species_list,
-        breed_list=breed_list
+        breed_list=breed_list,
+        scope=scope
     )
 
 

--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -1,7 +1,13 @@
 <!-- partials/animais_adicionados.html -->
 <div class="container d-flex justify-content-center my-5">
   <div style="width: 100%; max-width: 700px;">
-    <h4 class="mb-3">🐾 Animais da Clínica</h4>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h4 class="mb-0">🐾 Animais</h4>
+      <div class="btn-group btn-group-sm">
+        <a href="{{ url_for('novo_animal', scope='all') }}" class="btn btn-outline-primary {% if scope != 'mine' %}active{% endif %}">Todos</a>
+        <a href="{{ url_for('novo_animal', scope='mine') }}" class="btn btn-outline-primary {% if scope == 'mine' %}active{% endif %}">Meus</a>
+      </div>
+    </div>
     <div class="row g-3">
       {% if animais_adicionados %}
         {% for animal in animais_adicionados %}
@@ -41,7 +47,7 @@
         <ul class="pagination">
           {% if pagination.has_prev %}
             <li class="page-item">
-              <a class="page-link" href="{{ url_for('novo_animal', page=pagination.prev_num) }}">Anterior</a>
+              <a class="page-link" href="{{ url_for('novo_animal', page=pagination.prev_num, scope=scope) }}">Anterior</a>
             </li>
           {% else %}
             <li class="page-item disabled">
@@ -51,13 +57,13 @@
 
           {% for p in range(1, pagination.pages + 1) %}
             <li class="page-item {% if p == pagination.page %}active{% endif %}">
-              <a class="page-link" href="{{ url_for('novo_animal', page=p) }}">{{ p }}</a>
+              <a class="page-link" href="{{ url_for('novo_animal', page=p, scope=scope) }}">{{ p }}</a>
             </li>
           {% endfor %}
 
           {% if pagination.has_next %}
             <li class="page-item">
-              <a class="page-link" href="{{ url_for('novo_animal', page=pagination.next_num) }}">Próxima</a>
+              <a class="page-link" href="{{ url_for('novo_animal', page=pagination.next_num, scope=scope) }}">Próxima</a>
             </li>
           {% else %}
             <li class="page-item disabled">

--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -1,6 +1,12 @@
 <div class="container d-flex justify-content-center my-5">
   <div style="width: 100%; max-width: 700px;">
-    <h4 class="mb-3">👥 Tutores da Clínica</h4>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h4 class="mb-0">👥 Tutores</h4>
+      <div class="btn-group btn-group-sm">
+        <a href="{{ url_for('tutores', scope='all') }}" class="btn btn-outline-primary {% if scope != 'mine' %}active{% endif %}">Todos</a>
+        <a href="{{ url_for('tutores', scope='mine') }}" class="btn btn-outline-primary {% if scope == 'mine' %}active{% endif %}">Meus</a>
+      </div>
+    </div>
     <div class="row g-3">
       {% if tutores_adicionados %}
         {% for tutor in tutores_adicionados %}
@@ -48,7 +54,7 @@
         <ul class="pagination">
           {% if pagination.has_prev %}
           <li class="page-item">
-            <a class="page-link" href="?page={{ pagination.prev_num }}">Anterior</a>
+            <a class="page-link" href="{{ url_for('tutores', page=pagination.prev_num, scope=scope) }}">Anterior</a>
           </li>
           {% else %}
           <li class="page-item disabled"><span class="page-link">Anterior</span></li>
@@ -59,7 +65,7 @@
               {% if page_num == pagination.page %}
                 <li class="page-item active"><span class="page-link">{{ page_num }}</span></li>
               {% else %}
-                <li class="page-item"><a class="page-link" href="?page={{ page_num }}">{{ page_num }}</a></li>
+                <li class="page-item"><a class="page-link" href="{{ url_for('tutores', page=page_num, scope=scope) }}">{{ page_num }}</a></li>
               {% endif %}
             {% else %}
               <li class="page-item disabled"><span class="page-link">…</span></li>
@@ -68,7 +74,7 @@
 
           {% if pagination.has_next %}
           <li class="page-item">
-            <a class="page-link" href="?page={{ pagination.next_num }}">Próxima</a>
+            <a class="page-link" href="{{ url_for('tutores', page=pagination.next_num, scope=scope) }}">Próxima</a>
           </li>
           {% else %}
           <li class="page-item disabled"><span class="page-link">Próxima</span></li>


### PR DESCRIPTION
## Summary
- allow selecting between clinic-wide and vet-specific animals and tutors
- add toggle buttons and preserve filter across pagination

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1c99e6760832e9f57fa7285e6bae3