### PR TITLE
Handle missing clinic info when editing appointments

### DIFF
--- a/app.py
+++ b/app.py
@@ -5804,7 +5804,15 @@ def edit_appointment(appointment_id):
             user_clinic = current_user.veterinario.clinica_id
         else:
             user_clinic = current_user.clinica_id
-        if appointment.clinica_id != user_clinic:
+
+        # Some legacy appointments might not have `clinica_id` stored.
+        # In that case, fall back to the clinic of the assigned veterinarian
+        # to validate access instead of denying with a 403.
+        appointment_clinic = appointment.clinica_id
+        if appointment_clinic is None and appointment.veterinario:
+            appointment_clinic = appointment.veterinario.clinica_id
+
+        if appointment_clinic != user_clinic:
             abort(403)
     elif current_user.role != 'admin' and appointment.tutor_id != current_user.id:
         abort(403)

--- a/tests/test_appointment_edit.py
+++ b/tests/test_appointment_edit.py
@@ -84,3 +84,54 @@ def test_vet_can_edit_appointment_date_time_and_vet(client, monkeypatch):
         assert appt.veterinario_id == 2
         assert appt.scheduled_at == datetime(2024,5,2,11,30)
         assert appt.notes == 'Trazer exames'
+
+
+def test_vet_can_edit_appointment_missing_clinic_id(client, monkeypatch):
+    """Ensure vets can edit legacy appointments without clinic ID."""
+    with flask_app.app_context():
+        clinic = Clinica(id=1, nome='Clinica')
+        tutor = User(id=1, name='Tutor', email='tutor@test')
+        tutor.set_password('x')
+        vet_user1 = User(id=2, name='Vet1', email='vet1@test', worker='veterinario')
+        vet_user1.set_password('x')
+        vet_user2 = User(id=3, name='Vet2', email='vet2@test', worker='veterinario')
+        vet_user2.set_password('x')
+        animal = Animal(id=1, name='Rex', user_id=tutor.id, clinica_id=clinic.id)
+        plan = HealthPlan(id=1, name='Basic', price=10.0)
+        sub = HealthSubscription(animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True)
+        vet1 = Veterinario(id=1, user_id=vet_user1.id, crmv='123', clinica_id=clinic.id)
+        vet2 = Veterinario(id=2, user_id=vet_user2.id, crmv='456', clinica_id=clinic.id)
+        schedule1 = VetSchedule(id=1, veterinario_id=vet1.id, dia_semana='Quinta', hora_inicio=dtime(9,0), hora_fim=dtime(17,0))
+        schedule2 = VetSchedule(id=2, veterinario_id=vet2.id, dia_semana='Quinta', hora_inicio=dtime(9,0), hora_fim=dtime(17,0))
+        db.session.add_all([clinic, tutor, vet_user1, vet_user2, animal, plan, sub, vet1, vet2, schedule1, schedule2])
+        db.session.commit()
+        appt = Appointment(id=1, animal_id=animal.id, tutor_id=tutor.id, veterinario_id=vet1.id, scheduled_at=datetime(2024,5,1,10,0))
+        db.session.add(appt)
+        db.session.commit()
+        # Simulate legacy data with missing clinica_id
+        db.session.execute(db.text('UPDATE appointment SET clinica_id=NULL WHERE id=:id'), {'id': appt.id})
+        db.session.commit()
+        appt_id = appt.id
+        vet1_user_id = vet_user1.id
+        clinic_id = clinic.id
+    fake_vet = type('U', (), {
+        'id': vet1_user_id,
+        'worker': 'veterinario',
+        'role': 'adotante',
+        'name': 'Vet1',
+        'is_authenticated': True,
+        'veterinario': type('V', (), {'id': 1, 'clinica_id': clinic_id})()
+    })()
+    login(monkeypatch, fake_vet)
+    resp = client.post(f'/appointments/{appt_id}/edit', json={
+        'date': '2024-05-02',
+        'time': '11:30',
+        'veterinario_id': 2,
+        'notes': 'Trazer exames'
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+    with flask_app.app_context():
+        appt = Appointment.query.get(appt_id)
+        assert appt.veterinario_id == 2
+        assert appt.scheduled_at == datetime(2024,5,2,11,30)


### PR DESCRIPTION
## Summary
- tolerate appointments missing `clinica_id` by falling back to the veterinarian's clinic during authorization
- add regression test ensuring vets can update legacy appointments without clinic IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1cab132bc832ea145ceb58989e5f8