### PR TITLE
Refine clinic staff UI with hidden edit options

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -80,74 +80,87 @@
       </div>
       {% endif %}
 
-      <h3 class="mt-4">Veterinários</h3>
-      <ul class="list-unstyled">
-        {% for v in veterinarios %}
-          <li>
-            {{ v.user.name }} (CRMV: {{ v.crmv }})
-            {% if pode_editar %}
-            <form method="post" action="{{ url_for('remove_veterinario', clinica_id=clinica.id, veterinario_id=v.id) }}" class="d-inline">
-              {{ vet_schedule_forms[v.id].csrf_token }}
-              <button type="submit" class="btn btn-sm btn-outline-danger ms-2">Remover</button>
-            </form>
-            {% endif %}
-            <ul class="ms-3">
-              {% for h in v.horarios %}
-                <li>
-                  {{ h.dia_semana }}: {{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}
-                  {% if pode_editar %}
-                  <form method="post" action="{{ url_for('delete_vet_schedule_clinic', clinica_id=clinica.id, veterinario_id=v.id, horario_id=h.id) }}" class="d-inline">
-                    {{ vet_schedule_forms[v.id].csrf_token }}
-                    <button type="submit" class="btn btn-sm btn-outline-danger ms-2">Excluir</button>
-                  </form>
-                  {% endif %}
-                </li>
-              {% else %}
-                <li>Sem horários cadastrados.</li>
-              {% endfor %}
-            </ul>
-            {% if pode_editar %}
-            <form method="post" class="ms-3 mb-3">
-              {{ vet_schedule_forms[v.id].hidden_tag() }}
-              <div style="display:none;">{{ vet_schedule_forms[v.id].veterinario_id() }}</div>
-              <div class="mb-2">
-                {{ vet_schedule_forms[v.id].dias_semana.label }}
-                {{ vet_schedule_forms[v.id].dias_semana(class="form-select", multiple=True, size=7) }}
+        <h3 class="mt-4">Funcionários</h3>
+        <ul class="list-unstyled">
+          {% for v in veterinarios %}
+            <li class="border rounded p-3 mb-3">
+              <div class="d-flex justify-content-between align-items-center">
+                <div><strong>{{ v.user.name }}</strong> (CRMV: {{ v.crmv }})</div>
+                {% if pode_editar %}
+                <button class="btn btn-sm btn-outline-primary" onclick="toggleVetOptions({{ v.id }})">Editar</button>
+                {% endif %}
               </div>
-              <div class="mb-2">
-                {{ vet_schedule_forms[v.id].hora_inicio.label }}
-                {{ vet_schedule_forms[v.id].hora_inicio(class="form-control") }}
+              <ul class="ms-3 mt-2">
+                {% for h in v.horarios %}
+                  <li>{{ h.dia_semana }}: {{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}</li>
+                {% else %}
+                  <li>Sem horários cadastrados.</li>
+                {% endfor %}
+              </ul>
+              {% if pode_editar %}
+              <div id="vet-options-{{ v.id }}" style="display:none;" class="mt-2">
+                <form method="post" action="{{ url_for('remove_veterinario', clinica_id=clinica.id, veterinario_id=v.id) }}" class="mb-3">
+                  {{ vet_schedule_forms[v.id].csrf_token }}
+                  <button type="submit" class="btn btn-sm btn-outline-danger">Remover</button>
+                </form>
+                <ul class="ms-3 mb-3">
+                  {% for h in v.horarios %}
+                    <li>
+                      {{ h.dia_semana }}: {{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}
+                      <form method="post" action="{{ url_for('delete_vet_schedule_clinic', clinica_id=clinica.id, veterinario_id=v.id, horario_id=h.id) }}" class="d-inline">
+                        {{ vet_schedule_forms[v.id].csrf_token }}
+                        <button type="submit" class="btn btn-sm btn-outline-danger ms-2">Excluir</button>
+                      </form>
+                    </li>
+                  {% else %}
+                    <li>Sem horários cadastrados.</li>
+                  {% endfor %}
+                </ul>
+                <form method="post" class="ms-3 mb-3">
+                  {{ vet_schedule_forms[v.id].hidden_tag() }}
+                  <div style="display:none;">{{ vet_schedule_forms[v.id].veterinario_id() }}</div>
+                  <div class="mb-2">
+                    {{ vet_schedule_forms[v.id].dias_semana.label }}
+                    {{ vet_schedule_forms[v.id].dias_semana(class="form-select", multiple=True, size=7) }}
+                  </div>
+                  <div class="mb-2">
+                    {{ vet_schedule_forms[v.id].hora_inicio.label }}
+                    {{ vet_schedule_forms[v.id].hora_inicio(class="form-control") }}
+                  </div>
+                  <div class="mb-2">
+                    {{ vet_schedule_forms[v.id].hora_fim.label }}
+                    {{ vet_schedule_forms[v.id].hora_fim(class="form-control") }}
+                  </div>
+                  <div class="mb-2">
+                    {{ vet_schedule_forms[v.id].intervalo_inicio.label }}
+                    {{ vet_schedule_forms[v.id].intervalo_inicio(class="form-control") }}
+                  </div>
+                  <div class="mb-2">
+                    {{ vet_schedule_forms[v.id].intervalo_fim.label }}
+                    {{ vet_schedule_forms[v.id].intervalo_fim(class="form-control") }}
+                  </div>
+                  {{ vet_schedule_forms[v.id].submit(class="btn btn-primary btn-sm") }}
+                </form>
               </div>
-              <div class="mb-2">
-                {{ vet_schedule_forms[v.id].hora_fim.label }}
-                {{ vet_schedule_forms[v.id].hora_fim(class="form-control") }}
-              </div>
-              <div class="mb-2">
-                {{ vet_schedule_forms[v.id].intervalo_inicio.label }}
-                {{ vet_schedule_forms[v.id].intervalo_inicio(class="form-control") }}
-              </div>
-              <div class="mb-2">
-                {{ vet_schedule_forms[v.id].intervalo_fim.label }}
-                {{ vet_schedule_forms[v.id].intervalo_fim(class="form-control") }}
-              </div>
-              {{ vet_schedule_forms[v.id].submit(class="btn btn-primary btn-sm") }}
-            </form>
-            {% endif %}
-          </li>
-        {% else %}
-          <li>Nenhum veterinário associado.</li>
-        {% endfor %}
-      </ul>
-      {% if pode_editar and vets_form.veterinario_id.choices %}
-      <form method="post" class="mb-4">
-        {{ vets_form.hidden_tag() }}
-        <div class="mb-3">
-          {{ vets_form.veterinario_id.label }}
-          {{ vets_form.veterinario_id(class="form-select") }}
+              {% endif %}
+            </li>
+          {% else %}
+            <li>Nenhum veterinário associado.</li>
+          {% endfor %}
+        </ul>
+        {% if pode_editar and vets_form.veterinario_id.choices %}
+        <button class="btn btn-secondary mt-3" onclick="toggleAddVet()">Adicionar Veterinário</button>
+        <div id="add-vet" class="mt-3" style="display:none;">
+          <form method="post" class="mb-4">
+            {{ vets_form.hidden_tag() }}
+            <div class="mb-3">
+              {{ vets_form.veterinario_id.label }}
+              {{ vets_form.veterinario_id(class="form-select") }}
+            </div>
+            {{ vets_form.submit(class="btn btn-primary") }}
+          </form>
         </div>
-        {{ vets_form.submit(class="btn btn-primary") }}
-      </form>
-      {% endif %}
+        {% endif %}
     </div>
 
     <div class="tab-pane fade" id="agendamentos" role="tabpanel">
@@ -275,19 +288,29 @@
 </div>
 
 <script>
-function toggleEditInfo() {
-  const section = document.getElementById('edit-info');
-  section.style.display = section.style.display === 'none' ? 'block' : 'none';
-}
-function toggleEditHours() {
-  const section = document.getElementById('edit-hours');
-  section.style.display = section.style.display === 'none' ? 'block' : 'none';
-}
-function selectDays(mode) {
-  const select = document.getElementById('dias_semana');
-  const weekdays = ['Segunda','Terça','Quarta','Quinta','Sexta'];
-  const weekend = ['Sábado','Domingo'];
-  for (const opt of select.options) {
+  function toggleEditInfo() {
+    const section = document.getElementById('edit-info');
+    section.style.display = section.style.display === 'none' ? 'block' : 'none';
+  }
+  function toggleEditHours() {
+    const section = document.getElementById('edit-hours');
+    section.style.display = section.style.display === 'none' ? 'block' : 'none';
+  }
+  function toggleVetOptions(id) {
+    const section = document.getElementById(`vet-options-${id}`);
+    if (section) {
+      section.style.display = section.style.display === 'none' ? 'block' : 'none';
+    }
+  }
+  function toggleAddVet() {
+    const section = document.getElementById('add-vet');
+    section.style.display = section.style.display === 'none' ? 'block' : 'none';
+  }
+  function selectDays(mode) {
+    const select = document.getElementById('dias_semana');
+    const weekdays = ['Segunda','Terça','Quarta','Quinta','Sexta'];
+    const weekend = ['Sábado','Domingo'];
+    for (const opt of select.options) {
     if (mode === 'all') opt.selected = true;
     else if (mode === 'weekday') opt.selected = weekdays.includes(opt.value);
     else if (mode === 'weekend') opt.selected = weekend.includes(opt.value);


### PR DESCRIPTION
## Summary
- Present clinic staff with a cleaner card layout
- Hide staff management forms behind JavaScript toggles for a tidier interface
- Add helper scripts to reveal editing sections on demand

## Testing
- `pytest tests/test_clinic_access.py::test_user_cannot_access_other_clinic -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1cfea5b0c832e9e10c489ee6c57c4