### PR TITLE
Show clinic animals and tutors on clinic detail

### DIFF
--- a/app.py
+++ b/app.py
@@ -1959,6 +1959,18 @@ def clinic_detail(clinica_id):
             db.session.commit()
             flash('Horário do funcionário salvo com sucesso.', 'success')
             return redirect(url_for('clinic_detail', clinica_id=clinica.id))
+    animais_adicionados = (
+        Animal.query
+        .filter_by(clinica_id=clinica_id)
+        .filter(Animal.removido_em == None)
+        .all()
+    )
+    tutores_adicionados = (
+        User.query
+        .filter_by(clinica_id=clinica_id)
+        .filter(or_(User.worker != 'veterinario', User.worker == None))
+        .all()
+    )
     appointments = (
         Appointment.query
         .filter_by(clinica_id=clinica_id)
@@ -1983,6 +1995,9 @@ def clinic_detail(clinica_id):
         appointments_grouped=appointments_grouped,
         grouped_vet_schedules=grouped_vet_schedules,
         pode_editar=pode_editar,
+        animais_adicionados=animais_adicionados,
+        tutores_adicionados=tutores_adicionados,
+        pagination=None,
     )
 
 

--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -25,16 +25,16 @@
       </button>
     </li>
     <li class="nav-item" role="presentation">
-      <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('list_animals') }}">
+      <button class="nav-link d-flex align-items-center gap-2" id="animais-tab" data-bs-toggle="tab" data-bs-target="#animais" type="button" role="tab">
         <span class="icon-circle bg-danger text-white"><i class="fa-solid fa-paw"></i></span>
         <span class="fw-semibold">Animais</span>
-      </a>
+      </button>
     </li>
     <li class="nav-item" role="presentation">
-      <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('tutores') }}">
+      <button class="nav-link d-flex align-items-center gap-2" id="tutores-tab" data-bs-toggle="tab" data-bs-target="#tutores" type="button" role="tab">
         <span class="icon-circle bg-info text-white"><i class="fa-solid fa-user"></i></span>
         <span class="fw-semibold">Tutores</span>
-      </a>
+      </button>
     </li>
     <li class="nav-item" role="presentation">
       <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('loja') }}">
@@ -258,6 +258,12 @@
         </tbody>
       </table>
 
+    </div>
+    <div class="tab-pane fade" id="animais" role="tabpanel">
+      {% include 'partials/animais_adicionados.html' %}
+    </div>
+    <div class="tab-pane fade" id="tutores" role="tabpanel">
+      {% include 'partials/tutores_adicionados.html' %}
     </div>
   </div>
 </div>

--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -3,10 +3,12 @@
   <div style="width: 100%; max-width: 700px;">
     <div class="d-flex justify-content-between align-items-center mb-3">
       <h4 class="mb-0">🐾 Animais</h4>
+      {% if scope is defined %}
       <div class="btn-group btn-group-sm">
         <a href="{{ url_for('novo_animal', scope='all') }}" class="btn btn-outline-primary {% if scope != 'mine' %}active{% endif %}">Todos</a>
         <a href="{{ url_for('novo_animal', scope='mine') }}" class="btn btn-outline-primary {% if scope == 'mine' %}active{% endif %}">Meus</a>
       </div>
+      {% endif %}
     </div>
     <div class="row g-3">
       {% if animais_adicionados %}
@@ -41,7 +43,7 @@
       {% endif %}
     </div>
 
-    {% if pagination.pages > 1 %}
+    {% if pagination and pagination.pages > 1 %}
     <div class="d-flex justify-content-center mt-4">
       <nav aria-label="Navegação de páginas">
         <ul class="pagination">

--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -2,10 +2,12 @@
   <div style="width: 100%; max-width: 700px;">
     <div class="d-flex justify-content-between align-items-center mb-3">
       <h4 class="mb-0">👥 Tutores</h4>
+      {% if scope is defined %}
       <div class="btn-group btn-group-sm">
         <a href="{{ url_for('tutores', scope='all') }}" class="btn btn-outline-primary {% if scope != 'mine' %}active{% endif %}">Todos</a>
         <a href="{{ url_for('tutores', scope='mine') }}" class="btn btn-outline-primary {% if scope == 'mine' %}active{% endif %}">Meus</a>
       </div>
+      {% endif %}
     </div>
     <div class="row g-3">
       {% if tutores_adicionados %}


### PR DESCRIPTION
## Summary
- Display clinic-specific animals and tutors on the clinic detail page
- Convert animals and tutors sections into tabbed cards with existing partials
- Make animal and tutor partials reusable by hiding filters when not needed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1ebca83dc832e882dd3cedd05a183