### PR TITLE
Enable appointment creation and editing from clinic page

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -227,6 +227,7 @@
       {% with clinic_id = clinica.id %}
         {% include 'partials/schedule_toggle.html' %}
       {% endwith %}
+      <a href="{{ url_for('appointments') }}" class="btn btn-primary mb-3">Novo Agendamento</a>
       <table class="table">
         <thead>
           <tr>
@@ -248,6 +249,9 @@
                   <a href="{{ url_for('ficha_tutor', tutor_id=a.tutor_id) }}" class="btn btn-sm btn-outline-secondary">👤 Ficha Tutor</a>
                   {% if current_user.worker in ['veterinario', 'colaborador'] %}
                   <a href="{{ url_for('consulta_direct', animal_id=a.animal_id) }}" class="btn btn-sm btn-outline-success">🩺 Iniciar Consulta</a>
+                  {% endif %}
+                  {% if current_user.role == 'admin' or current_user.worker in ['veterinario', 'colaborador'] or current_user.id == a.tutor_id %}
+                  <a href="{{ url_for('edit_appointment', appointment_id=a.id) }}" class="btn btn-sm btn-outline-warning">✏️ Editar</a>
                   {% endif %}
                 </div>
               </td>

--- a/tests/test_clinic_appointment_links.py
+++ b/tests/test_clinic_appointment_links.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import pytest
+import flask_login.utils as login_utils
+from datetime import datetime
+
+os.environ.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import app as flask_app, db
+from models import (
+    User,
+    Clinica,
+    Veterinario,
+    Animal,
+    Appointment,
+    HealthPlan,
+    HealthSubscription,
+)
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+def test_clinic_page_has_new_and_edit_links(client, monkeypatch):
+    with flask_app.app_context():
+        admin = User(name="Admin", email="admin_links@example.com", password_hash="x", role="admin")
+        clinic = Clinica(nome="Clinica", owner=admin)
+        tutor = User(name="Tutor", email="t@example.com", password_hash="x")
+        animal = Animal(name="Rex", owner=tutor, clinica=clinic)
+        vet_user = User(name="Vet", email="v@example.com", password_hash="x", worker="veterinario")
+        vet = Veterinario(user=vet_user, crmv="123", clinica=clinic)
+        plan = HealthPlan(name="Basic", price=10.0)
+        db.session.add_all([admin, clinic, tutor, animal, vet_user, vet, plan])
+        db.session.commit()
+        sub = HealthSubscription(animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True)
+        db.session.add(sub)
+        db.session.commit()
+        appt = Appointment(
+            animal_id=animal.id,
+            tutor_id=tutor.id,
+            veterinario_id=vet.id,
+            scheduled_at=datetime(2024, 1, 1, 10, 0),
+            clinica_id=clinic.id,
+        )
+        db.session.add(appt)
+        db.session.commit()
+        appt_id = appt.id
+        clinic_id = clinic.id
+        admin_id = admin.id
+    monkeypatch.setattr(login_utils, '_get_user', lambda: User.query.get(admin_id))
+    resp = client.get(f'/clinica/{clinic_id}')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert 'Novo Agendamento' in html
+    assert f'/appointments/{appt_id}/edit' in html


### PR DESCRIPTION
## Summary
- allow creating appointments directly from clinic agenda
- permit editing existing appointments via clinic schedule
- cover clinic appointment links with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1eb438cd4832e9f7fbb936dfb01da