### PR TITLE
Fix search results order on animal and tutor pages

### DIFF
--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -118,6 +118,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function applySort() {
     const value = sortSelect.value;
     const visible = cards.filter(card => card.style.display !== 'none');
+    const hidden = cards.filter(card => card.style.display === 'none');
     visible.sort((a, b) => {
       switch (value) {
         case 'name_asc':
@@ -136,6 +137,7 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
     visible.forEach(card => container.appendChild(card));
+    hidden.forEach(card => container.appendChild(card));
   }
 
   filterInput.addEventListener('input', () => { applyFilter(); applySort(); });

--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -129,6 +129,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function applySort() {
     const value = sortSelect.value;
     const visible = cards.filter(card => card.style.display !== 'none');
+    const hidden = cards.filter(card => card.style.display === 'none');
     visible.sort((a, b) => {
       switch (value) {
         case 'name_desc':
@@ -147,6 +148,7 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
     visible.forEach(card => container.appendChild(card));
+    hidden.forEach(card => container.appendChild(card));
   }
 
   filterInput.addEventListener('input', () => { applyFilter(); applySort(); });


### PR DESCRIPTION
## Summary
- ensure filtered animals appear at top by reordering hidden cards
- apply same visible-first sorting for tutors listing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1f2a84c38832e80594aa80b945c93