### PR TITLE
Hide photo editor until user opts to change image

### DIFF
--- a/templates/components/photo_cropper.html
+++ b/templates/components/photo_cropper.html
@@ -5,48 +5,59 @@
 {% else %}
   {% set placeholder_url = url_for('static', filename='default_user.png') %}
 {% endif %}
-<div class="photo-cropper text-center">
-  <div id="{{ id }}-container" class="img-thumbnail shadow-sm mb-3 position-relative overflow-hidden" style="width: {{ size }}px; height: {{ size }}px; border-radius: 1rem; background-color: #f8f9fa;">
-    <img id="{{ id }}-img" src="{{ image_url if image_url else placeholder_url }}" style="width:100%; height:100%; object-fit: cover; cursor: grab; transition: transform 0.2s ease; {% if not image_url %}opacity:0.5;{% endif %} transform: translate({{ offset_x_field.data or 0 }}px, {{ offset_y_field.data or 0 }}px) rotate({{ rot_field.data or 0 }}deg) scale({{ zoom_field.data or 1 }});" alt="Imagem">
-    {% if not image_url %}
-    <div class="position-absolute top-50 start-50 translate-middle text-center" style="pointer-events: none;">
-      <i class="fas fa-camera fa-3x text-secondary"></i>
-      <p class="mt-2 text-secondary fw-light">Adicionar foto</p>
-    </div>
-    {% endif %}
-  </div>
-  
-  {{ file_field(class='d-none', id=id, accept='image/*') }}
-  <button type="button" class="btn btn-primary btn-sm mb-3" onclick="document.getElementById('{{ id }}').click()">
-    <i class="fas fa-upload me-1"></i> Escolher imagem
+<div class="photo-cropper-wrapper text-center">
+  {% if image_url %}
+  <button type="button" id="{{ id }}-toggle" class="btn btn-outline-secondary btn-sm mb-2">
+    <i class="fas fa-edit me-1"></i> Alterar imagem
   </button>
-  
-  <div id="{{ id }}-controls" class="d-flex flex-wrap justify-content-center gap-2 my-2{% if not image_url %} d-none{% endif %}">
-    <button type="button" id="{{ id }}-rotate-left" class="btn btn-light btn-sm border" title="Girar 90° à esquerda">
-      <i class="fas fa-undo"></i>
+  {% endif %}
+  <div id="{{ id }}-editor" class="photo-cropper{% if image_url %} d-none{% endif %}">
+    <div id="{{ id }}-container" class="img-thumbnail shadow-sm mb-3 position-relative overflow-hidden" style="width: {{ size }}px; height: {{ size }}px; border-radius: 1rem; background-color: #f8f9fa;">
+      <img id="{{ id }}-img" src="{{ image_url if image_url else placeholder_url }}" style="width:100%; height:100%; object-fit: cover; cursor: grab; transition: transform 0.2s ease; {% if not image_url %}opacity:0.5;{% endif %} transform: translate({{ offset_x_field.data or 0 }}px, {{ offset_y_field.data or 0 }}px) rotate({{ rot_field.data or 0 }}deg) scale({{ zoom_field.data or 1 }});" alt="Imagem">
+      {% if not image_url %}
+      <div class="position-absolute top-50 start-50 translate-middle text-center" style="pointer-events: none;">
+        <i class="fas fa-camera fa-3x text-secondary"></i>
+        <p class="mt-2 text-secondary fw-light">Adicionar foto</p>
+      </div>
+      {% endif %}
+    </div>
+
+    {{ file_field(class='d-none', id=id, accept='image/*') }}
+    <button type="button" class="btn btn-primary btn-sm mb-3" onclick="document.getElementById('{{ id }}').click()">
+      <i class="fas fa-upload me-1"></i> Escolher imagem
     </button>
-    <button type="button" id="{{ id }}-rotate-right" class="btn btn-light btn-sm border" title="Girar 90° à direita">
-      <i class="fas fa-redo"></i>
-    </button>
-    <button type="button" id="{{ id }}-zoom-out" class="btn btn-light btn-sm border" title="Diminuir zoom">
-      <i class="fas fa-search-minus"></i>
-    </button>
-    <button type="button" id="{{ id }}-zoom-in" class="btn btn-light btn-sm border" title="Aumentar zoom">
-      <i class="fas fa-search-plus"></i>
-    </button>
-    <button type="button" id="{{ id }}-reset" class="btn btn-light btn-sm border" title="Redefinir">
-      <i class="fas fa-sync-alt"></i>
-    </button>
+
+    <div id="{{ id }}-controls" class="d-flex flex-wrap justify-content-center gap-2 my-2{% if not image_url %} d-none{% endif %}">
+      <button type="button" id="{{ id }}-rotate-left" class="btn btn-light btn-sm border" title="Girar 90° à esquerda">
+        <i class="fas fa-undo"></i>
+      </button>
+      <button type="button" id="{{ id }}-rotate-right" class="btn btn-light btn-sm border" title="Girar 90° à direita">
+        <i class="fas fa-redo"></i>
+      </button>
+      <button type="button" id="{{ id }}-zoom-out" class="btn btn-light btn-sm border" title="Diminuir zoom">
+        <i class="fas fa-search-minus"></i>
+      </button>
+      <button type="button" id="{{ id }}-zoom-in" class="btn btn-light btn-sm border" title="Aumentar zoom">
+        <i class="fas fa-search-plus"></i>
+      </button>
+      <button type="button" id="{{ id }}-reset" class="btn btn-light btn-sm border" title="Redefinir">
+        <i class="fas fa-sync-alt"></i>
+      </button>
+    </div>
+
+    {{ rot_field(class='d-none', id=id + '-rotation') }}
+    {{ zoom_field(class='d-none', id=id + '-zoom') }}
+    {{ offset_x_field(class='d-none', id=id + '-offset_x') }}
+    {{ offset_y_field(class='d-none', id=id + '-offset_y') }}
   </div>
-  
-  {{ rot_field(class='d-none', id=id + '-rotation') }}
-  {{ zoom_field(class='d-none', id=id + '-zoom') }}
-  {{ offset_x_field(class='d-none', id=id + '-offset_x') }}
-  {{ offset_y_field(class='d-none', id=id + '-offset_y') }}
 </div>
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {
+    const editor = document.getElementById('{{ id }}-editor');
+    const toggleBtn = document.getElementById('{{ id }}-toggle');
+    toggleBtn?.addEventListener('click', () => editor.classList.toggle('d-none'));
+
     const img = document.getElementById('{{ id }}-img');
     const container = document.getElementById('{{ id }}-container');
     const fileInput = document.getElementById('{{ id }}');


### PR DESCRIPTION
## Summary
- hide photo_cropper UI behind a button when an image already exists
- add JavaScript toggle to reveal the editor on demand

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1f6ade380832ea6be0dacc6e62cb7