### PR TITLE
Add clinic staff management with permission assignments

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -40,7 +40,12 @@
 
     <div class="tab-content">
       <div class="tab-pane fade show active" id="veterinarios" role="tabpanel">
-        <h3 class="mt-4">Funcionários</h3>
+        <div class="d-flex justify-content-between align-items-center mt-4">
+          <h3 class="mb-0">Funcionários</h3>
+          {% if current_user.id == clinica.owner_id %}
+          <a href="{{ url_for('clinic_staff', clinica_id=clinica.id) }}" class="btn btn-sm btn-outline-secondary">Gerenciar Funcionários</a>
+          {% endif %}
+        </div>
         <ul class="list-unstyled">
           {% for v in veterinarios %}
             <li class="border rounded p-3 mb-3">

--- a/templates/clinic_staff_list.html
+++ b/templates/clinic_staff_list.html
@@ -1,0 +1,35 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container mt-4">
+  <h2>Funcionários de {{ clinic.nome }}</h2>
+  <form method="post" class="mb-4">
+    <div class="input-group">
+      <input type="email" name="email" class="form-control" placeholder="Email do usuário" required>
+      <button class="btn btn-primary" type="submit">Adicionar</button>
+    </div>
+  </form>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Nome</th>
+        <th>Email</th>
+        <th>Ações</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for s in staff_members %}
+      <tr>
+        <td>{{ s.user.name }}</td>
+        <td>{{ s.user.email }}</td>
+        <td>
+          <a href="{{ url_for('clinic_staff_permissions', clinica_id=clinic.id, user_id=s.user.id) }}" class="btn btn-sm btn-outline-primary">Permissões</a>
+        </td>
+      </tr>
+      {% else %}
+      <tr><td colspan="3">Nenhum funcionário.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `/clinica/<id>/funcionarios` endpoint to list and add staff members
- Link staff management from clinic detail page and provide permissions page
- Cover staff addition flow with tests

## Testing
- `pytest tests/test_clinic_staff_permissions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f7137e70832eb213049150c9adcf