### PR TITLE
feat: toggle admin view for all animals

### DIFF
--- a/templates/animals.html
+++ b/templates/animals.html
@@ -14,6 +14,16 @@
 <div class="container mt-4">
   <h2 class="mb-4 text-center">🐾 Animais 🐾</h2>
 
+  {% if is_admin %}
+  <div class="text-end mb-3">
+    {% if show_all %}
+    <a href="{{ url_for('list_animals') }}" class="btn btn-outline-secondary rounded-pill">Ver como usuário</a>
+    {% else %}
+    <a href="{{ url_for('list_animals', show_all=1) }}" class="btn btn-outline-secondary rounded-pill">Ver todos os animais</a>
+    {% endif %}
+  </div>
+  {% endif %}
+
   <!-- Filtro -->
   <form id="filterForm" method="GET" action="{{ url_for('list_animals') }}" class="mb-4">
     <div class="row g-2 justify-content-center">


### PR DESCRIPTION
## Summary
- allow admins to toggle visibility between all animals and standard user view
- add admin-only button on animals page for switching views
- test admin view toggle to ensure adopted animals appear when requested

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2193821c8832eae724cb5cf6ffb0a