### PR TITLE
Enable async animal deletion without leaving admin view

### DIFF
--- a/app.py
+++ b/app.py
@@ -1127,13 +1127,19 @@ def deletar_animal(animal_id):
     animal = get_animal_or_404(animal_id)
 
     if animal.removido_em:
-        flash('Animal já foi removido anteriormente.', 'warning')
-        return redirect(url_for('ficha_animal', animal_id=animal.id))
+        message = 'Animal já foi removido anteriormente.'
+        if 'application/json' in request.headers.get('Accept', ''):
+            return jsonify(message=message, category='warning'), 400
+        flash(message, 'warning')
+        return redirect(request.referrer or url_for('ficha_animal', animal_id=animal.id))
 
     animal.removido_em = datetime.utcnow()
     db.session.commit()
-    flash('Animal marcado como removido. Histórico preservado.', 'success')
-    return redirect(url_for('list_animals'))
+    message = 'Animal marcado como removido. Histórico preservado.'
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(message=message, category='success', deleted=True)
+    flash(message, 'success')
+    return redirect(request.referrer or url_for('list_animals'))
 
 
 @app.route('/termo/interesse/<int:animal_id>/<int:user_id>', methods=['GET', 'POST'])

--- a/templates/animals.html
+++ b/templates/animals.html
@@ -78,7 +78,7 @@
         {# pula esse animal #}
       {% else %}
         {# renderiza normalmente #}
-      <div class="col">
+      <div class="col" id="animal-card-{{ animal.id }}">
         <div class="card h-100 shadow-sm border-0 rounded-4 position-relative {% if animal.modo == 'perdido' %}border border-danger{% endif %}">
 
           {% if animal.image %}
@@ -156,13 +156,11 @@
                 ✏️ Editar
               </a>
               {% endif %}
-                        {% if is_admin %}
+          {% if is_admin %}
           <form method="POST" action="{{ url_for('deletar_animal', animal_id=animal.id) }}"
-                onsubmit="return confirm('Excluir permanentemente este animal?');"
-                class="btn btn-outline-secondary btn-sm rounded-pill">
-            <button type="submit" title="Excluir">
-              ❌
-            </button>
+                class="btn btn-outline-secondary btn-sm rounded-pill delete-animal-form"
+                data-animal-id="{{ animal.id }}">
+            <button type="submit" title="Excluir">❌</button>
           </form>
           {% endif %}
             </div>
@@ -253,9 +251,28 @@
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('filterForm');
-    if (!form) return;
-    form.querySelectorAll('select,input').forEach(el => {
-      el.addEventListener('change', () => form.submit());
+    if (form) {
+      form.querySelectorAll('select,input').forEach(el => {
+        el.addEventListener('change', () => form.submit());
+      });
+    }
+
+    document.querySelectorAll('.delete-animal-form').forEach(f => {
+      f.addEventListener('submit', async e => {
+        e.preventDefault();
+        if (!confirm('Excluir permanentemente este animal?')) return;
+        const resp = await fetch(f.action, {
+          method: 'POST',
+          headers: { 'Accept': 'application/json' }
+        });
+        if (resp.ok) {
+          const card = document.getElementById(`animal-card-${f.dataset.animalId}`);
+          if (card) card.remove();
+        } else {
+          const data = await resp.json().catch(() => ({}));
+          alert(data.message || 'Erro ao excluir animal.');
+        }
+      });
     });
   });
 </script>

--- a/tests/test_deletar_animal.py
+++ b/tests/test_deletar_animal.py
@@ -1,0 +1,41 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import app as app_module
+from app import app as flask_app, db
+from models import User, Animal
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:"
+    )
+    yield flask_app
+
+
+def test_deletar_animal_json(monkeypatch, app):
+    client = app.test_client()
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(id=1, name='Admin', email='admin@test', role='admin', worker='veterinario')
+        admin.set_password('x')
+        animal = Animal(id=1, name='Dog', user_id=admin.id)
+        db.session.add_all([admin, animal])
+        db.session.commit()
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: admin)
+
+    resp = client.post('/animal/1/deletar', headers={'Accept': 'application/json'})
+    assert resp.status_code == 200
+    assert resp.json['deleted'] is True
+
+    with app.app_context():
+        assert Animal.query.get(1).removido_em is not None


### PR DESCRIPTION
## Summary
- Support JSON responses for animal deletion and redirect back to current page
- Remove deleted animal cards via JavaScript to avoid page reload
- Add regression test for JSON-based animal deletion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22081d564832ebfb5436101f25fdf