### PR TITLE
Implement pagination for clinic lists

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -242,10 +242,14 @@
 
     </div>
     <div class="tab-pane fade" id="animais" role="tabpanel">
-      {% include 'partials/animais_adicionados.html' %}
+      {% with pagination=animais_pagination %}
+        {% include 'partials/animais_adicionados.html' %}
+      {% endwith %}
     </div>
     <div class="tab-pane fade" id="tutores" role="tabpanel">
-      {% include 'partials/tutores_adicionados.html' %}
+      {% with pagination=tutores_pagination %}
+        {% include 'partials/tutores_adicionados.html' %}
+      {% endwith %}
     </div>
     <div class="tab-pane fade" id="orcamento" role="tabpanel">
       <p>Nenhum orçamento cadastrado.</p>

--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -28,8 +28,8 @@
     </div>
 
     <div id="animal-cards" class="row g-3">
-      {% if animais_adicionados %}
-        {% for animal in animais_adicionados %}
+      {% if pagination and pagination.items %}
+        {% for animal in pagination.items %}
         <div class="col-md-6 d-flex" data-name="{{ animal.name|lower }}" data-date="{{ animal.date_added.isoformat() if animal.date_added else '' }}" data-age="{{ animal.age_years or 0 }}">
           <div class="card shadow-sm rounded-4 h-100 flex-fill">
             {% if animal.image %}
@@ -64,9 +64,10 @@
     <div class="d-flex justify-content-center mt-4">
       <nav aria-label="Navegação de páginas">
         <ul class="pagination">
+          {% set view_args = request.view_args or {} %}
           {% if pagination.has_prev %}
             <li class="page-item">
-              <a class="page-link" href="{{ url_for('novo_animal', page=pagination.prev_num, scope=scope) }}">Anterior</a>
+              <a class="page-link" href="{{ url_for(request.endpoint, page=pagination.prev_num, scope=scope if scope is defined else None, **view_args) }}">Anterior</a>
             </li>
           {% else %}
             <li class="page-item disabled">
@@ -76,13 +77,13 @@
 
           {% for p in range(1, pagination.pages + 1) %}
             <li class="page-item {% if p == pagination.page %}active{% endif %}">
-              <a class="page-link" href="{{ url_for('novo_animal', page=p, scope=scope) }}">{{ p }}</a>
+              <a class="page-link" href="{{ url_for(request.endpoint, page=p, scope=scope if scope is defined else None, **view_args) }}">{{ p }}</a>
             </li>
           {% endfor %}
 
           {% if pagination.has_next %}
             <li class="page-item">
-              <a class="page-link" href="{{ url_for('novo_animal', page=pagination.next_num, scope=scope) }}">Próxima</a>
+              <a class="page-link" href="{{ url_for(request.endpoint, page=pagination.next_num, scope=scope if scope is defined else None, **view_args) }}">Próxima</a>
             </li>
           {% else %}
             <li class="page-item disabled">

--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -25,8 +25,8 @@
       </div>
     </div>
     <div id="tutor-cards" class="row g-3">
-      {% if tutores_adicionados %}
-        {% for tutor in tutores_adicionados %}
+      {% if pagination and pagination.items %}
+        {% for tutor in pagination.items %}
         <div class="col-md-6 d-flex" data-name="{{ tutor.name|lower }}" data-date="{{ tutor.created_at.isoformat() if tutor.created_at else '' }}" data-cpf="{{ tutor.cpf or '' }}" data-phone="{{ tutor.phone or '' }}" {% if tutor.date_of_birth %}data-dob="{{ tutor.date_of_birth.isoformat() }}"{% endif %}>
 <div class="card shadow-sm rounded-4 h-100 flex-fill position-relative">
   {% if tutor.worker|lower == 'veterinario' %}
@@ -69,9 +69,10 @@
     <div class="d-flex justify-content-center mt-4">
       <nav>
         <ul class="pagination">
+          {% set view_args = request.view_args or {} %}
           {% if pagination.has_prev %}
           <li class="page-item">
-            <a class="page-link" href="{{ url_for('tutores', page=pagination.prev_num, scope=scope) }}">Anterior</a>
+            <a class="page-link" href="{{ url_for(request.endpoint, page=pagination.prev_num, scope=scope if scope is defined else None, **view_args) }}">Anterior</a>
           </li>
           {% else %}
           <li class="page-item disabled"><span class="page-link">Anterior</span></li>
@@ -82,7 +83,7 @@
               {% if page_num == pagination.page %}
                 <li class="page-item active"><span class="page-link">{{ page_num }}</span></li>
               {% else %}
-                <li class="page-item"><a class="page-link" href="{{ url_for('tutores', page=page_num, scope=scope) }}">{{ page_num }}</a></li>
+                <li class="page-item"><a class="page-link" href="{{ url_for(request.endpoint, page=page_num, scope=scope if scope is defined else None, **view_args) }}">{{ page_num }}</a></li>
               {% endif %}
             {% else %}
               <li class="page-item disabled"><span class="page-link">…</span></li>
@@ -91,7 +92,7 @@
 
           {% if pagination.has_next %}
           <li class="page-item">
-            <a class="page-link" href="{{ url_for('tutores', page=pagination.next_num, scope=scope) }}">Próxima</a>
+            <a class="page-link" href="{{ url_for(request.endpoint, page=pagination.next_num, scope=scope if scope is defined else None, **view_args) }}">Próxima</a>
           </li>
           {% else %}
           <li class="page-item disabled"><span class="page-link">Próxima</span></li>


### PR DESCRIPTION
## Summary
- Paginate animals and tutors on clinic detail using request args
- Update list partials to render Pagination objects with navigation links
- Provide separate pagination objects for animals and tutors in clinic detail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b37699ca7c832e879f5f8e4cdc640d