### PR TITLE
Restrict clinic dashboard to staff or owners

### DIFF
--- a/app.py
+++ b/app.py
@@ -1836,34 +1836,7 @@ def clinicas():
 def minha_clinica():
     clinicas = clinicas_do_usuario().all()
     if not clinicas:
-        form = ClinicForm()
-        if form.validate_on_submit():
-            clinica = Clinica(
-                nome=form.nome.data,
-                cnpj=form.cnpj.data,
-                endereco=form.endereco.data,
-                telefone=form.telefone.data,
-                email=form.email.data,
-                owner_id=current_user.id,
-            )
-            file = form.logotipo.data
-            if file:
-                filename = f"{uuid.uuid4().hex}_{secure_filename(file.filename)}"
-                image_url = upload_to_s3(file, filename, folder="clinicas")
-                if image_url:
-                    clinica.logotipo = image_url
-                    clinica.photo_rotation = form.photo_rotation.data
-                    clinica.photo_zoom = form.photo_zoom.data
-                    clinica.photo_offset_x = form.photo_offset_x.data
-                    clinica.photo_offset_y = form.photo_offset_y.data
-            db.session.add(clinica)
-            db.session.commit()
-            if current_user.veterinario:
-                current_user.veterinario.clinica_id = clinica.id
-            current_user.clinica_id = clinica.id
-            db.session.commit()
-            return redirect(url_for('clinic_detail', clinica_id=clinica.id))
-        return render_template('create_clinic.html', form=form)
+        abort(404)
 
     if _is_admin() and current_user.clinica_id:
         return redirect(url_for('clinic_detail', clinica_id=current_user.clinica_id))

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -471,7 +471,7 @@
                             <ul class="dropdown-menu dropdown-menu-end">
                                 <li><a class="dropdown-item" href="{{ url_for('profile') }}"><i class="fas fa-user me-2 text-primary"></i> Meu Perfil</a></li>
                                 <li><a class="dropdown-item" href="{{ url_for('minhas_compras') }}"><i class="fas fa-box me-2 text-warning"></i> Minhas Compras</a></li>
-                                {% if current_user.veterinario %}
+                                {% if current_user.is_authenticated and (current_user.role == 'admin' or current_user.clinic_roles or current_user.clinicas) %}
                                 <li><a class="dropdown-item" href="{{ url_for('minha_clinica') }}"><i class="fas fa-clinic-medical me-2 text-info"></i> Minha Clínica</a></li>
                                 {% endif %}
                 

--- a/tests/test_minha_clinica.py
+++ b/tests/test_minha_clinica.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 from app import app as flask_app, db
-from models import User, Clinica, Veterinario
+from models import User, Clinica, Veterinario, ClinicStaff
 
 
 @pytest.fixture
@@ -21,7 +21,8 @@ def test_minha_clinica_redirects(monkeypatch, app):
         clinica = Clinica(nome="Pet Clinic")
         user = User(name="Vet", email="vet@example.com", password_hash="x")
         vet = Veterinario(user=user, crmv="123", clinica=clinica)
-        db.session.add_all([clinica, user, vet])
+        staff = ClinicStaff(clinic=clinica, user=user)
+        db.session.add_all([clinica, user, vet, staff])
         db.session.commit()
 
         import flask_login.utils as login_utils
@@ -62,7 +63,8 @@ def test_layout_shows_minha_clinica_for_veterinario(monkeypatch, app):
         clinica = Clinica(nome="Pet Clinic")
         user = User(name="Vet", email="vet2@example.com", password_hash="x")
         vet = Veterinario(user=user, crmv="123", clinica=clinica)
-        db.session.add_all([clinica, user, vet])
+        staff = ClinicStaff(clinic=clinica, user=user)
+        db.session.add_all([clinica, user, vet, staff])
         db.session.commit()
 
         import flask_login.utils as login_utils
@@ -95,3 +97,39 @@ def test_minha_clinica_admin_defaults_to_own_clinic(monkeypatch, app):
         resp = client.get('/minha-clinica')
         assert resp.status_code == 302
         assert f"/clinica/{mine.id}" in resp.headers['Location']
+
+
+def test_tutor_cannot_access_minha_clinica(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        clinic = Clinica(nome="Clinic")
+        owner = User(name="Owner", email="owner2@example.com", password_hash="x")
+        tutor = User(name="Tutor", email="tutor@example.com", password_hash="y")
+        db.session.add_all([clinic, owner, tutor])
+        db.session.commit()
+        clinic.owner_id = owner.id
+        tutor.clinica_id = clinic.id
+        db.session.add_all([clinic, tutor])
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: tutor)
+
+        resp = client.get('/minha-clinica')
+        assert resp.status_code == 404
+
+
+def test_layout_hides_minha_clinica_for_tutor(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        user = User(name="Tutor", email="t2@example.com", password_hash="x")
+        db.session.add(user)
+        db.session.commit()
+
+        import flask_login.utils as login_utils
+        monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+        resp = client.get('/')
+        assert b'Minha Cl\xc3\xadnica' not in resp.data


### PR DESCRIPTION
## Summary
- Require ClinicStaff membership or ownership to resolve clinics for a user
- Block non-staff users from `/minha-clinica` and only show link when authorized
- Add tests ensuring tutors can't access clinic dashboard or see its link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37531bac0832ea7dc15214512a959