### PR TITLE
Paginate animal and tutor listings

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -259,9 +259,11 @@
 
     </div>
     <div class="tab-pane fade" id="animais" role="tabpanel">
+      {% set pagination = animais_pagination %}
       {% include 'partials/animais_adicionados.html' %}
     </div>
     <div class="tab-pane fade" id="tutores" role="tabpanel">
+      {% set pagination = tutores_pagination %}
       {% include 'partials/tutores_adicionados.html' %}
     </div>
     <div class="tab-pane fade" id="orcamento" role="tabpanel">

--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -28,8 +28,8 @@
     </div>
 
     <div id="animal-cards" class="row g-3">
-      {% if animais_adicionados %}
-        {% for animal in animais_adicionados %}
+      {% if pagination and pagination.items %}
+        {% for animal in pagination.items %}
         <div class="col-md-6 d-flex" data-name="{{ animal.name|lower }}" data-date="{{ animal.date_added.isoformat() if animal.date_added else '' }}" data-age="{{ animal.age_years or 0 }}">
           <div class="card shadow-sm rounded-4 h-100 flex-fill">
             {% if animal.image %}

--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -25,8 +25,8 @@
       </div>
     </div>
     <div id="tutor-cards" class="row g-3">
-      {% if tutores_adicionados %}
-        {% for tutor in tutores_adicionados %}
+      {% if pagination and pagination.items %}
+        {% for tutor in pagination.items %}
         <div class="col-md-6 d-flex" data-name="{{ tutor.name|lower }}" data-date="{{ tutor.created_at.isoformat() if tutor.created_at else '' }}" data-cpf="{{ tutor.cpf or '' }}" data-phone="{{ tutor.phone or '' }}" {% if tutor.date_of_birth %}data-dob="{{ tutor.date_of_birth.isoformat() }}"{% endif %}>
 <div class="card shadow-sm rounded-4 h-100 flex-fill position-relative">
   {% if tutor.worker|lower == 'veterinario' %}


### PR DESCRIPTION
## Summary
- use pagination for animal and tutor queries in clinic view
- render animals and tutors partials directly from Pagination objects
- pass real pagination objects instead of placeholders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3a7764688832eb39a96d211f874eb