### PR TITLE
Add budget dashboard with client and animal summaries

### DIFF
--- a/app.py
+++ b/app.py
@@ -2120,6 +2120,58 @@ def orcamentos(clinica_id):
     return render_template('orcamentos.html', clinica=clinica, orcamentos=lista)
 
 
+@app.route('/dashboard/orcamentos')
+@login_required
+def dashboard_orcamentos():
+    from collections import defaultdict
+    from models import Consulta, Orcamento, Payment, PaymentStatus
+
+    consultas = Consulta.query.filter(Consulta.orcamento_items.any()).all()
+    dados_consultas = []
+    for consulta in consultas:
+        pagamento = Payment.query.filter_by(
+            external_reference=f'consulta-{consulta.id}',
+            status=PaymentStatus.COMPLETED,
+        ).first()
+        dados_consultas.append(
+            {
+                'cliente': consulta.animal.owner.name if consulta.animal and consulta.animal.owner else 'N/A',
+                'animal': consulta.animal.name if consulta.animal else 'N/A',
+                'total': float(consulta.total_orcamento),
+                'status': 'Pago' if pagamento else 'Pendente',
+            }
+        )
+
+    total_por_cliente = defaultdict(lambda: {'total': 0, 'pagos': 0, 'pendentes': 0})
+    total_por_animal = defaultdict(lambda: {'total': 0, 'pagos': 0, 'pendentes': 0})
+    for d in dados_consultas:
+        tc = total_por_cliente[d['cliente']]
+        tc['total'] += d['total']
+        if d['status'] == 'Pago':
+            tc['pagos'] += d['total']
+        else:
+            tc['pendentes'] += d['total']
+        ta = total_por_animal[d['animal']]
+        ta['total'] += d['total']
+        if d['status'] == 'Pago':
+            ta['pagos'] += d['total']
+        else:
+            ta['pendentes'] += d['total']
+
+    orcamentos = Orcamento.query.all()
+    dados_orcamentos = [
+        {'descricao': o.descricao, 'total': float(o.total)} for o in orcamentos
+    ]
+
+    return render_template(
+        'dashboard_orcamentos.html',
+        consultas=dados_consultas,
+        clientes=total_por_cliente,
+        animais=total_por_animal,
+        orcamentos=dados_orcamentos,
+    )
+
+
 @app.route('/clinica/<int:clinica_id>/dashboard')
 @login_required
 def clinic_dashboard(clinica_id):

--- a/templates/dashboard_orcamentos.html
+++ b/templates/dashboard_orcamentos.html
@@ -1,0 +1,80 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container mt-4">
+  <h2>Dashboard de Orçamentos</h2>
+
+  <h4 class="mt-4">Resumo por Cliente</h4>
+  <table class="table">
+    <thead>
+      <tr><th>Cliente</th><th>Total</th><th>Pagos</th><th>Pendentes</th></tr>
+    </thead>
+    <tbody>
+      {% for nome, info in clientes.items() %}
+      <tr>
+        <td>{{ nome }}</td>
+        <td>{{ '%.2f'|format(info.total) }}</td>
+        <td>{{ '%.2f'|format(info.pagos) }}</td>
+        <td>{{ '%.2f'|format(info.pendentes) }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="4">Nenhum orçamento encontrado.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <h4 class="mt-4">Resumo por Animal</h4>
+  <table class="table">
+    <thead>
+      <tr><th>Animal</th><th>Total</th><th>Pagos</th><th>Pendentes</th></tr>
+    </thead>
+    <tbody>
+      {% for nome, info in animais.items() %}
+      <tr>
+        <td>{{ nome }}</td>
+        <td>{{ '%.2f'|format(info.total) }}</td>
+        <td>{{ '%.2f'|format(info.pagos) }}</td>
+        <td>{{ '%.2f'|format(info.pendentes) }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="4">Nenhum orçamento encontrado.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <h4 class="mt-4">Orçamentos da Clínica</h4>
+  <table class="table">
+    <thead>
+      <tr><th>Descrição</th><th>Total</th></tr>
+    </thead>
+    <tbody>
+      {% for o in orcamentos %}
+      <tr>
+        <td>{{ o.descricao }}</td>
+        <td>{{ '%.2f'|format(o.total) }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="2">Nenhum orçamento encontrado.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <h4 class="mt-4">Orçamentos por Consulta</h4>
+  <table class="table">
+    <thead>
+      <tr><th>Cliente</th><th>Animal</th><th>Total</th><th>Status</th></tr>
+    </thead>
+    <tbody>
+      {% for c in consultas %}
+      <tr>
+        <td>{{ c.cliente }}</td>
+        <td>{{ c.animal }}</td>
+        <td>{{ '%.2f'|format(c.total) }}</td>
+        <td>{{ c.status }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="4">Nenhum orçamento encontrado.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/tests/test_dashboard_orcamentos.py
+++ b/tests/test_dashboard_orcamentos.py
@@ -1,0 +1,45 @@
+import os
+import sys
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, Animal, Consulta, OrcamentoItem
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_dashboard_orcamentos(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        vet = User(name='Vet', email='vet@example.com', worker='veterinario', role='admin')
+        vet.set_password('x')
+        tutor = User(name='Tutor', email='tutor@example.com')
+        tutor.set_password('y')
+        animal = Animal(name='Rex', owner=tutor)
+        db.session.add_all([vet, tutor, animal])
+        db.session.commit()
+        consulta = Consulta(animal_id=animal.id, created_by=vet.id, status='in_progress')
+        db.session.add(consulta)
+        db.session.commit()
+        item = OrcamentoItem(consulta=consulta, descricao='Consulta', valor=50)
+        db.session.add(item)
+        db.session.commit()
+
+    client = app.test_client()
+    with client:
+        client.post('/login', data={'email': 'vet@example.com', 'password': 'x'}, follow_redirects=True)
+        resp = client.get('/dashboard/orcamentos')
+        assert resp.status_code == 200
+        assert b'Tutor' in resp.data
+        assert b'Rex' in resp.data
+        assert b'50.00' in resp.data
+
+    with app.app_context():
+        db.drop_all()


### PR DESCRIPTION
## Summary
- add `/dashboard/orcamentos` view to aggregate budgets by client and animal
- display clinic and consultation budgets in a unified dashboard page
- cover new dashboard with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3aa56d11c832ea39cf76b050d637c