### PR TITLE
Handle auth forms via JSON fetch

### DIFF
--- a/app.py
+++ b/app.py
@@ -329,9 +329,15 @@ def reset_password_request():
                 """
             )
             mail.send(msg)
+            if request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+                return jsonify({'success': True, 'redirect': url_for('login_view')})
             flash('Um e-mail foi enviado com instruções para redefinir sua senha.', 'info')
             return redirect(url_for('login_view'))
+        if request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+            return jsonify({'success': False, 'errors': {'email': ['E-mail não encontrado.']}}), 400
         flash('E-mail não encontrado.', 'danger')
+    elif request.method == 'POST' and request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+        return jsonify({'success': False, 'errors': form.errors}), 400
     return render_template('reset_password_request.html', form=form)
 
 
@@ -394,8 +400,10 @@ def register():
         # Verifica se o e-mail já está em uso
         existing_user = User.query.filter_by(email=form.email.data).first()
         if existing_user:
+            if request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+                return jsonify({'success': False, 'errors': {'email': ['Email já está em uso.']}}), 400
             flash('Email já está em uso.', 'danger')
-            return render_template('register.html', form=form)
+            return render_template('register.html', form=form, endereco=None)
 
         # Cria o endereço
         endereco = Endereco(
@@ -431,8 +439,13 @@ def register():
         db.session.add(user)
         db.session.commit()
 
+        if request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+            return jsonify({'success': True, 'redirect': url_for('index')})
         flash('Usuário registrado com sucesso!', 'success')
         return redirect(url_for('index'))
+
+    if request.method == 'POST' and request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+        return jsonify({'success': False, 'errors': form.errors}), 400
 
     return render_template('register.html', form=form, endereco=None)
 
@@ -537,10 +550,16 @@ def login_view():
             login_user(user, remember=form.remember.data)
             if form.remember.data:
                 session.permanent = True
+            if request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+                return jsonify({'success': True, 'redirect': url_for('index')})
             flash('Login realizado com sucesso!', 'success')
             return redirect(url_for('index'))
         else:
+            if request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+                return jsonify({'success': False, 'errors': {'email': ['Email ou senha inválidos.']}}), 400
             flash('Email ou senha inválidos.', 'danger')
+    elif request.method == 'POST' and request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+        return jsonify({'success': False, 'errors': form.errors}), 400
     return render_template('login.html', form=form)
 
 
@@ -620,12 +639,18 @@ def change_password():
     form = ChangePasswordForm()
     if form.validate_on_submit():
         if not current_user.check_password(form.current_password.data):
+            if request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+                return jsonify({'success': False, 'errors': {'current_password': ['Senha atual incorreta.']}}), 400
             flash('Senha atual incorreta.', 'danger')
         else:
             current_user.set_password(form.new_password.data)
             db.session.commit()
+            if request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+                return jsonify({'success': True, 'redirect': url_for('profile')})
             flash('Senha atualizada com sucesso!', 'success')
             return redirect(url_for('profile'))
+    elif request.method == 'POST' and request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
+        return jsonify({'success': False, 'errors': form.errors}), 400
     return render_template('change_password.html', form=form)
 
 

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -4,7 +4,7 @@
 <div class="container d-flex justify-content-center align-items-center mt-5">
     <div class="card shadow-lg p-4 rounded-4" style="width: 100%; max-width: 450px;">
         <h3 class="mb-4 text-center">🔑 Alterar Senha</h3>
-        <form method="POST">
+        <form method="POST" class="js-auth-form">
             {{ form.hidden_tag() }}
             <div class="mb-3">
                 {{ form.current_password.label(class="form-label") }}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -741,6 +741,42 @@
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.js-auth-form').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          form.querySelectorAll('.text-danger').forEach(el => el.remove());
+          const resp = await fetch(form.action, {
+            method: form.method || 'POST',
+            body: new FormData(form),
+            headers: { 'Accept': 'application/json' }
+          });
+          if (resp && resp.ok) {
+            const data = await resp.json().catch(() => null);
+            if (data && data.redirect) {
+              window.location = data.redirect;
+              return;
+            }
+            window.location.reload();
+          } else if (resp) {
+            const data = await resp.json().catch(() => null);
+            if (data && data.errors) {
+              for (const [field, messages] of Object.entries(data.errors)) {
+                const input = form.querySelector(`[name="${field}"]`);
+                if (input) {
+                  const div = document.createElement('div');
+                  div.className = 'text-danger';
+                  div.textContent = messages.join(', ');
+                  input.insertAdjacentElement('afterend', div);
+                }
+              }
+            }
+          }
+        });
+      });
+    });
+  </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('.js-msg-form').forEach(form => {
         form.addEventListener('submit', async ev => {
           ev.preventDefault();

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,7 +4,7 @@
 <div class="container d-flex justify-content-center align-items-center mt-5">
     <div class="card shadow-lg p-4 rounded-4" style="width: 100%; max-width: 450px;">
         <h3 class="mb-4 text-center">🔐 Entrar na PetOrlândia</h3>
-        <form method="POST">
+        <form method="POST" class="js-auth-form">
             {{ form.hidden_tag() }}
 
             <div class="mb-3">

--- a/templates/register.html
+++ b/templates/register.html
@@ -5,7 +5,7 @@
 <div class="container d-flex justify-content-center align-items-center mt-5">
     <div class="card shadow-lg p-4 rounded-4" style="width: 100%; max-width: 700px;">
         <h3 class="mb-4 text-center">🧑 Criar Conta na PetOrlândia</h3>
-        <form method="POST" enctype="multipart/form-data">
+        <form method="POST" enctype="multipart/form-data" class="js-auth-form">
             {{ form.hidden_tag() }}
 
             <!-- Nome -->

--- a/templates/reset_password_request.html
+++ b/templates/reset_password_request.html
@@ -4,7 +4,7 @@
 <div class="container d-flex justify-content-center align-items-center mt-5">
     <div class="card shadow-lg p-4 rounded-4" style="width: 100%; max-width: 450px;">
         <h3 class="mb-4 text-center">📧 Redefinir Senha</h3>
-        <form method="POST">
+        <form method="POST" class="js-auth-form">
             {{ form.hidden_tag() }}
 
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- add `.js-auth-form` class to auth templates
- intercept auth forms to submit via fetch with JSON
- adjust login, register, and password flows to return JSON responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3abd3ce10832e9b4ca69b612c90d6