### PR TITLE
Handle profile updates via AJAX

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -741,6 +741,59 @@
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.js-profile-form').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          const submitBtn = form.querySelector('[type="submit"]');
+          if (submitBtn) submitBtn.disabled = true;
+          try {
+            const resp = await fetchOrQueue(form.action, {
+              method: 'POST',
+              body: new FormData(form),
+              headers: {'Accept': 'application/json'}
+            });
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              ['name','email','phone'].forEach(field => {
+                const display = document.getElementById(field + '-display');
+                const input = document.getElementById(field + '-input');
+                if (display && input) display.textContent = input.value || '---';
+              });
+              const addrSpan = document.getElementById('address-display');
+              if (addrSpan) {
+                const rua = form.querySelector('[name="rua"]').value;
+                const numero = form.querySelector('[name="numero"]').value;
+                const bairro = form.querySelector('[name="bairro"]').value;
+                let txt = rua;
+                if (numero) txt += ', ' + numero;
+                if (bairro) txt += ' - ' + bairro;
+                addrSpan.textContent = txt || '---';
+              }
+              if (typeof toggleAll === 'function') {
+                toggleAll();
+              }
+              const toastEl = document.getElementById('actionToast');
+              toastEl.querySelector('.toast-body').textContent = data.message || 'Sucesso';
+              toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+              toastEl.classList.add('bg-' + (data.category || 'success'));
+              new bootstrap.Toast(toastEl).show();
+            } else if (resp) {
+              const data = await resp.json().catch(() => ({}));
+              const toastEl = document.getElementById('actionToast');
+              toastEl.querySelector('.toast-body').textContent = data.message || 'Erro ao atualizar perfil';
+              toastEl.classList.remove('bg-success', 'bg-info');
+              toastEl.classList.add('bg-danger');
+              new bootstrap.Toast(toastEl).show();
+            }
+          } finally {
+            if (submitBtn) submitBtn.disabled = false;
+          }
+        });
+      });
+    });
+  </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('.js-msg-form').forEach(form => {
         form.addEventListener('submit', async ev => {
           ev.preventDefault();

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -6,7 +6,7 @@
 
   <!-- Cabeçalho do Perfil -->
   <div class="card shadow rounded-4 p-4 mb-5 border-0">
-    <form method="POST" enctype="multipart/form-data">
+    <form method="POST" enctype="multipart/form-data" class="js-profile-form">
       {{ form.hidden_tag() }}
       <div class="row g-4 align-items-center">
 
@@ -73,7 +73,7 @@
           <div class="mb-3">
             <label class="form-label">Endereço</label>
             <div class="d-flex align-items-center text-muted">
-              <span>
+              <span id="address-display">
                 {% if endereco and endereco.rua %}
                   {{ endereco.rua }}{% if endereco.numero %}, {{ endereco.numero }}{% endif %}
                   {% if endereco.bairro %} - {{ endereco.bairro }}{% endif %}


### PR DESCRIPTION
## Summary
- Submit profile form via fetch and update page without reload
- Support JSON responses in profile route for AJAX

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3abe4ff3c832e96575893cc9cbb9d