### PR TITLE
Implement AJAX appointment form updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -5968,6 +5968,11 @@ def appointments():
             )
             form = None
         appointments_grouped = group_appointments_by_day(appointments)
+        if request.headers.get('Accept') == 'text/html':
+            return render_template(
+                'partials/appointments_table.html',
+                appointments_grouped=appointments_grouped,
+            )
         return render_template(
             'appointments.html',
             appointments=appointments,
@@ -6072,30 +6077,67 @@ def edit_appointment(appointment_id):
         abort(403)
 
     if request.method == 'POST':
-        data = request.get_json(silent=True) or {}
-        date_str = data.get('date')
-        time_str = data.get('time')
-        vet_id = data.get('veterinario_id')
-        notes = data.get('notes')
-        if not date_str or not time_str or not vet_id:
-            return jsonify({'success': False, 'message': 'Dados incompletos.'}), 400
+        errors = {}
+        if request.is_json:
+            data = request.get_json() or {}
+            date_str = data.get('date')
+            time_str = data.get('time')
+            vet_id = data.get('veterinario_id')
+            notes = data.get('notes')
+        else:
+            date_str = request.form.get('date')
+            time_str = request.form.get('time')
+            vet_id = request.form.get('veterinario_id')
+            notes = request.form.get('notes')
+        if not date_str:
+            errors.setdefault('date', []).append('Campo obrigatório.')
+        if not time_str:
+            errors.setdefault('time', []).append('Campo obrigatório.')
+        if not vet_id:
+            errors.setdefault('veterinario_id', []).append('Campo obrigatório.')
+        scheduled_at = None
         try:
-            scheduled_at = datetime.combine(
-                datetime.strptime(date_str, '%Y-%m-%d').date(),
-                datetime.strptime(time_str, '%H:%M').time(),
-            )
-            vet_id = int(vet_id)
+            if date_str and time_str:
+                scheduled_at = datetime.combine(
+                    datetime.strptime(date_str, '%Y-%m-%d').date(),
+                    datetime.strptime(time_str, '%H:%M').time(),
+                )
+            if vet_id:
+                vet_id = int(vet_id)
         except (ValueError, TypeError):
-            return jsonify({'success': False, 'message': 'Dados inválidos.'}), 400
-        if not is_slot_available(vet_id, scheduled_at) and not (
+            errors.setdefault('date', []).append('Dados inválidos.')
+        if not errors and not is_slot_available(vet_id, scheduled_at) and not (
             vet_id == appointment.veterinario_id and scheduled_at == appointment.scheduled_at
         ):
-            return jsonify({'success': False, 'message': 'Horário indisponível.'}), 400
+            errors.setdefault('time', []).append('Horário indisponível.')
+        if errors:
+            if request.headers.get('Accept') == 'text/html':
+                return jsonify({'errors': errors}), 400
+            return jsonify({'success': False, 'errors': errors}), 400
         appointment.veterinario_id = vet_id
         appointment.scheduled_at = scheduled_at
         if notes is not None:
             appointment.notes = notes
         db.session.commit()
+        if request.headers.get('Accept') == 'text/html':
+            if current_user.worker in ['colaborador', 'admin', 'veterinario']:
+                clinic_id = appointment.clinica_id or getattr(current_user, 'clinica_id', None)
+                appointments = (
+                    Appointment.query.filter_by(clinica_id=clinic_id)
+                    .order_by(Appointment.scheduled_at)
+                    .all()
+                )
+            else:
+                appointments = (
+                    Appointment.query.filter_by(tutor_id=current_user.id)
+                    .order_by(Appointment.scheduled_at)
+                    .all()
+                )
+            appointments_grouped = group_appointments_by_day(appointments)
+            return render_template(
+                'partials/appointments_table.html',
+                appointments_grouped=appointments_grouped,
+            )
         return jsonify({'success': True})
 
     veterinarios = Veterinario.query.all()

--- a/templates/appointments.html
+++ b/templates/appointments.html
@@ -11,7 +11,7 @@
   <div class="card mb-4">
     <div class="card-body">
       <h5 class="card-title">Agendar Consulta</h5>
-      <form method="POST">
+      <form method="POST" class="js-appointment-form">
         {{ form.hidden_tag() }}
         <div class="mb-3">
           {{ form.animal_id.label(class="form-label") }}
@@ -39,7 +39,9 @@
   </div>
   {% endif %}
 
-  {% include 'partials/appointments_table.html' %}
+  <div id="appointments_table">
+    {% include 'partials/appointments_table.html' %}
+  </div>
 </div>
 {% endblock %}
 {% block scripts %}

--- a/templates/edit_appointment.html
+++ b/templates/edit_appointment.html
@@ -3,18 +3,19 @@
 {% block main %}
 <div class="container mt-4">
   <h2>Editar Consulta</h2>
-  <form id="edit-form">
+  <form method="POST" class="js-appointment-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="mb-3">
       <label for="date" class="form-label">Data</label>
-      <input type="date" id="date" class="form-control" value="{{ appointment.scheduled_at.date() }}">
+      <input type="date" id="date" name="date" class="form-control" value="{{ appointment.scheduled_at.date() }}">
     </div>
     <div class="mb-3">
       <label for="time" class="form-label">Horário</label>
-      <input type="time" id="time" class="form-control" value="{{ appointment.scheduled_at.strftime('%H:%M') }}">
+      <input type="time" id="time" name="time" class="form-control" value="{{ appointment.scheduled_at.strftime('%H:%M') }}">
     </div>
     <div class="mb-3">
       <label for="veterinario" class="form-label">Veterinário</label>
-      <select id="veterinario" class="form-select">
+      <select id="veterinario" name="veterinario_id" class="form-select">
         {% for vet in veterinarios %}
           <option value="{{ vet.id }}" {% if vet.id == appointment.veterinario_id %}selected{% endif %}>
             {{ vet.user.name if vet.user else vet.id }}
@@ -30,29 +31,4 @@
 
 {% block scripts %}
 {{ super() }}
-<script>
-document.getElementById('edit-form').addEventListener('submit', async function(e) {
-  e.preventDefault();
-  const data = {
-    date: document.getElementById('date').value,
-    time: document.getElementById('time').value,
-    veterinario_id: document.getElementById('veterinario').value
-  };
-  const resp = await fetch('', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-CSRFToken': '{{ csrf_token() if csrf_token is defined else "" }}'
-    },
-    body: JSON.stringify(data)
-  });
-  if (resp.ok) {
-    window.location.href = '{{ url_for("appointments") }}';
-  } else {
-    let err = 'Erro ao salvar';
-    try { const data = await resp.json(); if (data.message) err = data.message; } catch (e) {}
-    alert(err);
-  }
-});
-</script>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -767,6 +767,47 @@
       });
     });
   </script>
-{% block scripts %}{% endblock %}
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.js-appointment-form').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          form.querySelectorAll('.is-invalid').forEach(el => el.classList.remove('is-invalid'));
+          form.querySelectorAll('.invalid-feedback').forEach(el => el.remove());
+          const formData = new FormData(form);
+          const resp = await fetch(form.action || window.location.href, {
+            method: form.method || 'POST',
+            body: formData,
+            headers: { 'Accept': 'text/html' }
+          });
+          if (resp && resp.ok) {
+            const html = await resp.text();
+            const container = document.getElementById('appointments_table');
+            if (container) {
+              container.innerHTML = html;
+            }
+          } else if (resp && resp.status === 400) {
+            let data = {};
+            try { data = await resp.json(); } catch (e) {}
+            if (data.errors) {
+              for (const [field, messages] of Object.entries(data.errors)) {
+                const input = form.querySelector(`[name="${field}"]`);
+                if (input) {
+                  input.classList.add('is-invalid');
+                  const div = document.createElement('div');
+                  div.className = 'invalid-feedback';
+                  div.textContent = messages.join(', ');
+                  input.parentNode.appendChild(div);
+                }
+              }
+            }
+          } else if (resp) {
+            form.submit();
+          }
+        });
+      });
+    });
+  </script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- intercept appointment forms and refresh appointments table via fetch
- handle validation errors without reload
- support partial HTML responses for appointment routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3abf68700832ebbadbfa23cfaaacb