### PR TITLE
Enable offline-aware AJAX submission for tutor and animal forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -2382,6 +2382,58 @@ def tutores():
         flash('Apenas veterinários ou colaboradores podem acessar esta página.', 'danger')
         return redirect(url_for('index'))
 
+    def fetch_tutores(scope, page):
+        clinic_id = current_user_clinic_id()
+        if scope == 'mine':
+            query = User.query.filter(User.created_at != None)
+            if clinic_id:
+                query = query.filter(User.clinica_id == clinic_id)
+            consultas_exist = (
+                db.session.query(Consulta.id)
+                .join(Animal, Consulta.animal_id == Animal.id)
+                .filter(
+                    Consulta.created_by == current_user.id,
+                    Animal.user_id == User.id,
+                )
+            )
+            pagination = (
+                query.filter(
+                    or_(
+                        User.added_by_id == current_user.id,
+                        consultas_exist.exists(),
+                    )
+                )
+                .order_by(User.created_at.desc())
+                .paginate(page=page, per_page=9)
+            )
+            return pagination.items, pagination
+        elif clinic_id:
+            last_appt = (
+                db.session.query(
+                    Appointment.tutor_id,
+                    func.max(Appointment.scheduled_at).label('last_at')
+                )
+                .filter(Appointment.clinica_id == clinic_id)
+                .group_by(Appointment.tutor_id)
+                .subquery()
+            )
+
+            pagination = (
+                User.query
+                .outerjoin(last_appt, User.id == last_appt.c.tutor_id)
+                .filter(
+                    or_(
+                        User.clinica_id == clinic_id,
+                        last_appt.c.last_at != None
+                    )
+                )
+                .order_by(func.coalesce(last_appt.c.last_at, User.created_at).desc())
+                .paginate(page=page, per_page=9)
+            )
+            return pagination.items, pagination
+        else:
+            return [], None
+
     # Criação de novo tutor
     if request.method == 'POST':
         name = request.form.get('tutor_name') or request.form.get('name')
@@ -2453,63 +2505,25 @@ def tutores():
         db.session.add(novo)
         db.session.commit()
 
+        if request.accept_mimetypes.accept_json:
+            scope = request.args.get('scope', 'all')
+            page = request.args.get('page', 1, type=int)
+            tutores_adicionados, pagination = fetch_tutores(scope, page)
+            html = render_template(
+                'partials/tutores_adicionados.html',
+                tutores_adicionados=tutores_adicionados,
+                pagination=pagination,
+                scope=scope
+            )
+            return jsonify(message='Tutor criado com sucesso!', category='success', html=html)
+
         flash('Tutor criado com sucesso!', 'success')
         return redirect(url_for('ficha_tutor', tutor_id=novo.id))
 
     # — GET com paginação —
     page = request.args.get('page', 1, type=int)
     scope = request.args.get('scope', 'all')
-    clinic_id = current_user_clinic_id()
-    if scope == 'mine':
-        query = User.query.filter(User.created_at != None)
-        if clinic_id:
-            query = query.filter(User.clinica_id == clinic_id)
-        consultas_exist = (
-            db.session.query(Consulta.id)
-            .join(Animal, Consulta.animal_id == Animal.id)
-            .filter(
-                Consulta.created_by == current_user.id,
-                Animal.user_id == User.id,
-            )
-        )
-        pagination = (
-            query.filter(
-                or_(
-                    User.added_by_id == current_user.id,
-                    consultas_exist.exists(),
-                )
-            )
-            .order_by(User.created_at.desc())
-            .paginate(page=page, per_page=9)
-        )
-        tutores_adicionados = pagination.items
-    elif clinic_id:
-        last_appt = (
-            db.session.query(
-                Appointment.tutor_id,
-                func.max(Appointment.scheduled_at).label('last_at')
-            )
-            .filter(Appointment.clinica_id == clinic_id)
-            .group_by(Appointment.tutor_id)
-            .subquery()
-        )
-
-        pagination = (
-            User.query
-            .outerjoin(last_appt, User.id == last_appt.c.tutor_id)
-            .filter(
-                or_(
-                    User.clinica_id == clinic_id,
-                    last_appt.c.last_at != None
-                )
-            )
-            .order_by(func.coalesce(last_appt.c.last_at, User.created_at).desc())
-            .paginate(page=page, per_page=9)
-        )
-        tutores_adicionados = pagination.items
-    else:
-        pagination = None
-        tutores_adicionados = []
+    tutores_adicionados, pagination = fetch_tutores(scope, page)
 
     return render_template(
         'tutores.html',
@@ -3876,6 +3890,63 @@ def novo_animal():
         flash('Apenas veterinários ou colaboradores podem cadastrar animais.', 'danger')
         return redirect(url_for('index'))
 
+    def fetch_animais(scope, page):
+        clinic_id = current_user_clinic_id()
+        if scope == 'mine':
+            query = Animal.query.filter(Animal.removido_em == None)
+            if clinic_id:
+                query = query.filter(Animal.clinica_id == clinic_id)
+            consultas_exist = (
+                db.session.query(Consulta.id)
+                .filter(
+                    Consulta.animal_id == Animal.id,
+                    Consulta.created_by == current_user.id,
+                )
+            )
+            pagination = (
+                query.filter(
+                    or_(
+                        Animal.added_by_id == current_user.id,
+                        consultas_exist.exists(),
+                    )
+                )
+                .order_by(Animal.date_added.desc())
+                .paginate(page=page, per_page=9)
+            )
+        elif clinic_id:
+            last_appt = (
+                db.session.query(
+                    Appointment.animal_id,
+                    func.max(Appointment.scheduled_at).label('last_at')
+                )
+                .filter(Appointment.clinica_id == clinic_id)
+                .group_by(Appointment.animal_id)
+                .subquery()
+            )
+
+            pagination = (
+                Animal.query
+                .outerjoin(last_appt, Animal.id == last_appt.c.animal_id)
+                .filter(Animal.removido_em == None)
+                .filter(
+                    or_(
+                        Animal.clinica_id == clinic_id,
+                        last_appt.c.last_at != None
+                    )
+                )
+                .order_by(func.coalesce(last_appt.c.last_at, Animal.date_added).desc())
+                .paginate(page=page, per_page=9)
+            )
+        else:
+            pagination = (
+                Animal.query
+                .filter_by(added_by_id=current_user.id)
+                .filter(Animal.removido_em == None)
+                .order_by(Animal.date_added.desc())
+                .paginate(page=page, per_page=9)
+            )
+        return pagination.items, pagination
+
     if request.method == 'POST':
         tutor_id = request.form.get('tutor_id', type=int)
         tutor = User.query.get_or_404(tutor_id)
@@ -3950,68 +4021,25 @@ def novo_animal():
         db.session.add(consulta)
         db.session.commit()
 
+        if request.accept_mimetypes.accept_json:
+            scope = request.args.get('scope', 'all')
+            page = request.args.get('page', 1, type=int)
+            animais_adicionados, pagination = fetch_animais(scope, page)
+            html = render_template(
+                'partials/animais_adicionados.html',
+                animais_adicionados=animais_adicionados,
+                pagination=pagination,
+                scope=scope
+            )
+            return jsonify(message='Animal cadastrado com sucesso!', category='success', html=html)
+
         flash('Animal cadastrado com sucesso!', 'success')
         return redirect(url_for('consulta_direct', animal_id=animal.id))
 
     # GET: lista de animais adicionados para exibição
     page = request.args.get('page', 1, type=int)
     scope = request.args.get('scope', 'all')
-    clinic_id = current_user_clinic_id()
-    if scope == 'mine':
-        query = Animal.query.filter(Animal.removido_em == None)
-        if clinic_id:
-            query = query.filter(Animal.clinica_id == clinic_id)
-        consultas_exist = (
-            db.session.query(Consulta.id)
-            .filter(
-                Consulta.animal_id == Animal.id,
-                Consulta.created_by == current_user.id,
-            )
-        )
-        pagination = (
-            query.filter(
-                or_(
-                    Animal.added_by_id == current_user.id,
-                    consultas_exist.exists(),
-                )
-            )
-            .order_by(Animal.date_added.desc())
-            .paginate(page=page, per_page=9)
-        )
-    elif clinic_id:
-        last_appt = (
-            db.session.query(
-                Appointment.animal_id,
-                func.max(Appointment.scheduled_at).label('last_at')
-            )
-            .filter(Appointment.clinica_id == clinic_id)
-            .group_by(Appointment.animal_id)
-            .subquery()
-        )
-
-        pagination = (
-            Animal.query
-            .outerjoin(last_appt, Animal.id == last_appt.c.animal_id)
-            .filter(Animal.removido_em == None)
-            .filter(
-                or_(
-                    Animal.clinica_id == clinic_id,
-                    last_appt.c.last_at != None
-                )
-            )
-            .order_by(func.coalesce(last_appt.c.last_at, Animal.date_added).desc())
-            .paginate(page=page, per_page=9)
-        )
-    else:
-        pagination = (
-            Animal.query
-            .filter_by(added_by_id=current_user.id)
-            .filter(Animal.removido_em == None)
-            .order_by(Animal.date_added.desc())
-            .paginate(page=page, per_page=9)
-        )
-
-    animais_adicionados = pagination.items
+    animais_adicionados, pagination = fetch_animais(scope, page)
 
     # Lista de espécies e raças para os <select> do formulário
     species_list = list_species()

--- a/static/offline.js
+++ b/static/offline.js
@@ -72,6 +72,15 @@
   window.addEventListener('online', sendQueued);
   document.addEventListener('DOMContentLoaded', sendQueued);
 
+  function showToast(message, category='success'){
+    const toastEl = document.getElementById('actionToast');
+    if(!toastEl) return;
+    toastEl.querySelector('.toast-body').textContent = message;
+    toastEl.classList.remove('bg-danger','bg-info','bg-success');
+    toastEl.classList.add('bg-' + category);
+    bootstrap.Toast.getOrCreateInstance(toastEl).show();
+  }
+
   document.addEventListener('submit', async ev => {
     if (ev.defaultPrevented) return;
     const form = ev.target;
@@ -104,6 +113,41 @@
       document.dispatchEvent(evt);
       if (!evt.defaultPrevented) {
         location.reload();
+      }
+    }
+  });
+
+  document.addEventListener('form-sync-success', ev => {
+    const detail = ev.detail || {};
+    const form = detail.form;
+    const data = detail.data || {};
+    if(!form) return;
+
+    if(form.classList.contains('js-tutor-form')){
+      ev.preventDefault();
+      if(data.html){
+        const cont=document.getElementById('tutores-adicionados');
+        if(cont) cont.innerHTML=data.html;
+      }
+      showToast(data.message || 'Tutor criado com sucesso', data.category || 'success');
+      form.reset();
+      const btn=form.querySelector('button[type="submit"]');
+      if(btn && btn.dataset.original){
+        btn.disabled=false;
+        btn.innerHTML=btn.dataset.original;
+      }
+    } else if(form.classList.contains('js-animal-form')){
+      ev.preventDefault();
+      if(data.html){
+        const cont=document.getElementById('animais-adicionados');
+        if(cont) cont.innerHTML=data.html;
+      }
+      showToast(data.message || 'Animal cadastrado com sucesso', data.category || 'success');
+      form.reset();
+      const btn=form.querySelector('button[type="submit"]');
+      if(btn && btn.dataset.original){
+        btn.disabled=false;
+        btn.innerHTML=btn.dataset.original;
       }
     }
   });

--- a/templates/novo_animal.html
+++ b/templates/novo_animal.html
@@ -7,6 +7,8 @@
       {% include 'partials/animal_register_form.html' %}
     </div>
   </div>
+  <div id="animais-adicionados">
   {% include 'partials/animais_adicionados.html' %}
+  </div>
 
 {% endblock %}

--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -1,5 +1,5 @@
 <!-- templates/partials/animal_register_form.html -->
-<form method="POST" action="{{ url_for('novo_animal') }}" onsubmit="return handleSubmit(this);" data-sync="true">
+<form method="POST" action="{{ url_for('novo_animal') }}" onsubmit="return handleSubmit(this);" data-sync="true" class="js-animal-form">
     <h5 class="mb-3">🐾 Cadastro do Animal</h5>
 
     {% if not tutor %}
@@ -133,6 +133,7 @@
       }
       const submitBtn = form.querySelector('button[type="submit"]');
       if (submitBtn) {
+        submitBtn.dataset.original = submitBtn.innerHTML;
         submitBtn.disabled = true;
         submitBtn.textContent = 'Salvando...';
       }

--- a/templates/tutores.html
+++ b/templates/tutores.html
@@ -20,7 +20,7 @@
     <div class="card-body">
       <h5 class="card-title mb-3">➕ Cadastrar Novo Tutor</h5>
 
-      <form id="novo-tutor-form" method="POST">
+      <form id="novo-tutor-form" method="POST" action="{{ url_for('tutores') }}" class="js-tutor-form" data-sync="true">
         <div class="row">
           <div class="mb-3 col-md-6">
             <label class="form-label">Nome</label>
@@ -62,14 +62,16 @@
             {% include "partials/endereco_form.html" %}
           </div>
 
-        <button class="btn btn-primary btn-lg">💾 Salvar e abrir ficha</button>
+        <button class="btn btn-primary btn-lg" data-original="💾 Salvar e abrir ficha">💾 Salvar e abrir ficha</button>
       </form>
     </div>
   </div>
 
 </div>
 
+<div id="tutores-adicionados">
 {% include 'partials/tutores_adicionados.html' %}
+</div>
 
 
 


### PR DESCRIPTION
## Summary
- Add `js-tutor-form` and `js-animal-form` classes, wrap results containers for dynamic updates
- Extend `offline.js` to intercept these forms, queue offline requests, show toasts, and refresh snippets
- Update `tutores` and `novo_animal` routes to return HTML snippets when `Accept: application/json`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3ac077d58832e8b95e92f4c255f54