### PR TITLE
Add dynamic loja data endpoint and AJAX pagination

### DIFF
--- a/app.py
+++ b/app.py
@@ -4818,23 +4818,11 @@ def _setup_checkout_form(form, preserve_selected=True):
 
 
 
-from flask import session, render_template, request
+from flask import session, render_template, request, jsonify
 from flask_login import login_required
 
 
-@app.route("/loja")
-@login_required
-def loja():
-    pagamento_pendente = None
-    payment_id = session.get("last_pending_payment")
-    if payment_id:
-        payment = Payment.query.get(payment_id)
-        if payment and payment.status.name == "PENDING":
-            pagamento_pendente = payment
-
-    search_term = request.args.get("q", "").strip()
-    filtro = request.args.get("filter", "all")
-
+def _build_loja_query(search_term: str, filtro: str):
     query = Product.query
     if search_term:
         like = f"%{search_term}%"
@@ -4851,7 +4839,27 @@ def loja():
     else:
         query = query.order_by(Product.name)
 
-    produtos = query.all()
+    return query
+
+
+@app.route("/loja")
+@login_required
+def loja():
+    pagamento_pendente = None
+    payment_id = session.get("last_pending_payment")
+    if payment_id:
+        payment = Payment.query.get(payment_id)
+        if payment and payment.status.name == "PENDING":
+            pagamento_pendente = payment
+
+    search_term = request.args.get("q", "").strip()
+    filtro = request.args.get("filter", "all")
+    page = request.args.get("page", 1, type=int)
+    per_page = 12
+
+    query = _build_loja_query(search_term, filtro)
+    pagination = query.paginate(page=page, per_page=per_page, error_out=False)
+    produtos = pagination.items
     form = AddToCartForm()
 
     # Verifica se há pedidos anteriores
@@ -4860,12 +4868,56 @@ def loja():
     return render_template(
         "loja.html",
         products=produtos,
+        pagination=pagination,
         pagamento_pendente=pagamento_pendente,
         form=form,
         has_orders=has_orders,
         selected_filter=filtro,
         search_term=search_term,
     )
+
+
+@app.route("/loja/data")
+@login_required
+def loja_data():
+    search_term = request.args.get("q", "").strip()
+    filtro = request.args.get("filter", "all")
+    page = request.args.get("page", 1, type=int)
+    per_page = 12
+
+    query = _build_loja_query(search_term, filtro)
+    pagination = query.paginate(page=page, per_page=per_page, error_out=False)
+    produtos = pagination.items
+    form = AddToCartForm()
+
+    if request.args.get("format") == "json":
+        products_data = [
+            {
+                "id": p.id,
+                "name": p.name,
+                "description": p.description,
+                "price": p.price,
+                "image_url": p.image_url,
+            }
+            for p in produtos
+        ]
+        return jsonify(
+            products=products_data,
+            page=pagination.page,
+            total_pages=pagination.pages,
+            has_next=pagination.has_next,
+            has_prev=pagination.has_prev,
+        )
+
+    html = render_template(
+        "partials/_product_grid.html",
+        products=produtos,
+        pagination=pagination,
+        form=form,
+        selected_filter=filtro,
+        search_term=search_term,
+    )
+    return html
 
 
 @app.route('/produto/<int:product_id>', methods=['GET', 'POST'])

--- a/static/loja_dynamic.js
+++ b/static/loja_dynamic.js
@@ -1,0 +1,111 @@
+// Dynamic interactions for loja page
+function initQuantitySelectors(root=document){
+  root.querySelectorAll('.quantity-selector').forEach(box => {
+    const input = box.querySelector('.quantity-input');
+    box.querySelector('.minus')?.addEventListener('click', () => {
+      const v = parseInt(input.value || '1', 10);
+      input.value = Math.max(1, v - 1);
+    });
+    box.querySelector('.plus')?.addEventListener('click', () => {
+      const v = parseInt(input.value || '1', 10);
+      input.value = v + 1;
+    });
+  });
+}
+
+function initAddToCartButtons(root=document){
+  root.querySelectorAll('.js-add-to-cart').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const original = btn.innerHTML;
+      btn.disabled = true;
+      btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Adicionando...';
+      setTimeout(() => {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="fa-solid fa-cart-plus me-2"></i>Adicionar ao carrinho';
+      }, 1200);
+    }, { once:false });
+  });
+}
+
+function initChipScroll(){
+  const sc = document.getElementById('chipsScroll');
+  if(!sc) return;
+  sc.addEventListener('wheel', e => {
+    if(Math.abs(e.deltaY) > Math.abs(e.deltaX)){
+      sc.scrollLeft += e.deltaY;
+      e.preventDefault();
+    }
+  }, {passive:false});
+}
+
+function initDynamicProducts(){
+  const container = document.getElementById('products-container');
+  const form = document.getElementById('search-form');
+  if(!container || !form) return;
+
+  const fetchProducts = (params, push=true) => {
+    fetch('/loja/data?' + params.toString(), {headers:{'X-Requested-With':'XMLHttpRequest'}})
+      .then(r => r.text())
+      .then(html => {
+        container.innerHTML = html;
+        initQuantitySelectors(container);
+        initAddToCartButtons(container);
+        if(push){
+          history.pushState(null, '', '/loja?' + params.toString());
+        }
+      });
+  };
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const params = new URLSearchParams(new FormData(form));
+    params.set('page', 1);
+    fetchProducts(params);
+  });
+
+  form.querySelector('select[name="filter"]').addEventListener('change', () => {
+    const params = new URLSearchParams(new FormData(form));
+    params.set('page', 1);
+    fetchProducts(params);
+  });
+
+  document.querySelectorAll('.chip[data-category]').forEach(chip => {
+    chip.addEventListener('click', e => {
+      e.preventDefault();
+      const params = new URLSearchParams(new FormData(form));
+      params.set('category', chip.dataset.category);
+      params.set('page', 1);
+      fetchProducts(params);
+    });
+  });
+  document.querySelectorAll('.js-clear-category').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      const params = new URLSearchParams(new FormData(form));
+      params.delete('category');
+      params.set('page', 1);
+      fetchProducts(params);
+    });
+  });
+
+  container.addEventListener('click', e => {
+    const link = e.target.closest('.pagination a.page-link');
+    if(link){
+      e.preventDefault();
+      const url = new URL(link.href);
+      fetchProducts(url.searchParams);
+    }
+  });
+
+  window.addEventListener('popstate', () => {
+    const params = new URLSearchParams(window.location.search);
+    fetchProducts(params, false);
+  });
+
+  // initialize on first load
+  initQuantitySelectors();
+  initAddToCartButtons();
+  initChipScroll();
+}
+
+document.addEventListener('DOMContentLoaded', initDynamicProducts);

--- a/templates/loja.html
+++ b/templates/loja.html
@@ -63,7 +63,7 @@
 {% endif %}
 
 <!-- Busca + Filtros -->
-<form method="get" class="row g-2 align-items-stretch mb-3">
+<form method="get" id="search-form" class="row g-2 align-items-stretch mb-3">
   <!-- preserva categoria ao buscar -->
   {% if request.args.get('category') %}
     <input type="hidden" name="category" value="{{ request.args.get('category') }}">
@@ -100,98 +100,9 @@
 </form>
 
 <!-- Grid de Produtos -->
-{% if products %}
-<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
-  {% for product in products %}
-  <div class="col">
-    <article class="card product-card h-100 d-flex flex-column overflow-hidden">
-      <!-- Imagem -->
-      <a href="{{ url_for('produto_detail', product_id=product.id) }}"
-         class="ratio ratio-4x3 product-image-wrap d-block position-relative" aria-label="Abrir {{ product.name }}">
-        {% if product.image_url %}
-          {% if 'http' in product.image_url %}
-            <img src="{{ product.image_url }}" class="product-image" alt="{{ product.name }}" loading="lazy">
-          {% else %}
-            <img src="{{ url_for('static', filename=product.image_url) }}" class="product-image" alt="{{ product.name }}" loading="lazy">
-          {% endif %}
-        {% else %}
-          <div class="product-image-placeholder">
-            <i class="fa-regular fa-image"></i>
-          </div>
-        {% endif %}
-      </a>
-
-      <!-- Info -->
-      <div class="card-body d-flex flex-column">
-        <h3 class="h6 fw-semibold product-name mb-1" title="{{ product.name }}">{{ product.name }}</h3>
-        {% if product.description %}
-          <p class="text-muted small product-description mb-2" data-bs-toggle="tooltip"
-             data-bs-placement="top" title="{{ product.description }}">
-            {{ product.description|truncate(110) }}
-          </p>
-        {% endif %}
-
-        <div class="mt-auto">
-          <div class="d-flex align-items-center justify-content-between mb-1">
-            <span class="h5 m-0 text-success fw-bold">R$ {{ '%.2f'|format(product.price)|replace('.', ',') }}</span>
-          </div>
-          <div class="text-muted small mb-2">
-            <i class="fa-solid fa-truck-fast ms-1 me-1"></i>entrega rápida
-          </div>
-
-          <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}"
-                method="post" class="js-cart-form">
-            {{ form.hidden_tag() }}
-            <div class="d-flex align-items-stretch gap-2">
-              <!-- Seletor de quantidade -->
-              <div class="quantity-selector" aria-label="Selecionar quantidade">
-                <button type="button" class="quantity-btn minus" aria-label="Diminuir">–</button>
-                {{ form.quantity(class="form-control quantity-input", min="1", value="1", **{'aria-label': 'Quantidade'}) }}
-                <button type="button" class="quantity-btn plus" aria-label="Aumentar">+</button>
-              </div>
-
-              <!-- Botão adicionar -->
-              <button type="submit" class="btn btn-primary add-to-cart-btn flex-grow-1 js-add-to-cart"
-                      aria-label="Adicionar {{ product.name }} ao carrinho">
-                <i class="fa-solid fa-cart-plus me-2"></i>
-                Adicionar ao carrinho
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </article>
-  </div>
-  {% endfor %}
+<div id="products-container">
+  {% include 'partials/_product_grid.html' %}
 </div>
-
-<!-- Paginação (exemplo estático; troque pela sua paginação real) -->
-{% if pagination is defined %}
-<nav aria-label="Paginação" class="mt-4">
-  <ul class="pagination justify-content-center">
-    <li class="page-item {% if not pagination.prev %}disabled{% endif %}">
-      <a class="page-link" href="{{ pagination.prev or '#' }}">Anterior</a>
-    </li>
-    {% for p in pagination.pages %}
-      <li class="page-item {% if p.active %}active{% endif %}">
-        <a class="page-link" href="{{ p.url }}">{{ p.number }}</a>
-      </li>
-    {% endfor %}
-    <li class="page-item {% if not pagination.next %}disabled{% endif %}">
-      <a class="page-link" href="{{ pagination.next or '#' }}">Próximo</a>
-    </li>
-  </ul>
-</nav>
-{% endif %}
-
-{% else %}
-<!-- Empty state -->
-<section class="text-center py-5 my-5">
-  <div class="mb-3"><i class="fa-regular fa-face-frown-open display-4 text-muted"></i></div>
-  <h2 class="h5 text-muted">Nenhum produto disponível</h2>
-  <p class="text-muted">Volte em breve para novas ofertas!</p>
-</section>
-{% endif %}
 
 <!-- Floating Cart (mobile) -->
 <div class="d-lg-none fixed-bottom p-3">
@@ -323,71 +234,7 @@
   }
 </style>
 
-<!-- JS específico da loja -->
-<script>
-  // Chips de categoria -> aplicam/limpam query param
-  (function(){
-    const setParam = (key,val)=>{
-      const url = new URL(window.location.href);
-      if (val) url.searchParams.set(key,val); else url.searchParams.delete(key);
-      url.searchParams.delete('page'); // reset de paginação ao filtrar
-      window.location.href = url.toString();
-    };
+  <!-- JS específico da loja -->
+  <script src="{{ url_for('static', filename='loja_dynamic.js') }}"></script>
 
-    document.querySelectorAll('.chip[data-category]').forEach(chip=>{
-      chip.addEventListener('click', ()=>{
-        setParam('category', chip.dataset.category);
-      });
-    });
-
-    document.querySelectorAll('.js-clear-category').forEach(btn=>{
-      btn.addEventListener('click', ()=> setParam('category',''));
-    });
-  })();
-
-  // Seletor de quantidade
-  (function(){
-    document.querySelectorAll('.quantity-selector').forEach(box=>{
-      const input = box.querySelector('.quantity-input');
-      box.querySelector('.minus')?.addEventListener('click', ()=>{
-        const v = parseInt(input.value||'1',10);
-        input.value = Math.max(1, v-1);
-      });
-      box.querySelector('.plus')?.addEventListener('click', ()=>{
-        const v = parseInt(input.value||'1',10);
-        input.value = v+1;
-      });
-    });
-  })();
-
-  // Feedback visual no botão "Adicionar"
-  (function(){
-    document.querySelectorAll('.js-add-to-cart').forEach(btn=>{
-      btn.addEventListener('click', ()=>{
-        const original = btn.innerHTML;
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Adicionando...';
-        // A submissão real é tratada pelo listener global .js-cart-form do layout via fetch/AJAX.
-        // Após um breve tempo, voltamos o estado (o toast global confirmará).
-        setTimeout(()=>{
-          btn.disabled = false;
-          btn.innerHTML = '<i class="fa-solid fa-cart-plus me-2"></i>Adicionar ao carrinho';
-        }, 1200);
-      }, { once:false });
-    });
-  })();
-
-  // Scroll suave horizontal (mouse wheel) nas chips
-  (function(){
-    const sc = document.getElementById('chipsScroll');
-    if (!sc) return;
-    sc.addEventListener('wheel', (e)=>{
-      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
-        sc.scrollLeft += e.deltaY;
-        e.preventDefault();
-      }
-    }, { passive:false });
-  })();
-</script>
-
-{% endblock %}
+  {% endblock %}

--- a/templates/partials/_product_grid.html
+++ b/templates/partials/_product_grid.html
@@ -1,0 +1,89 @@
+{% if products %}
+<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
+  {% for product in products %}
+  <div class="col">
+    <article class="card product-card h-100 d-flex flex-column overflow-hidden">
+      <!-- Imagem -->
+      <a href="{{ url_for('produto_detail', product_id=product.id) }}"
+         class="ratio ratio-4x3 product-image-wrap d-block position-relative" aria-label="Abrir {{ product.name }}">
+        {% if product.image_url %}
+          {% if 'http' in product.image_url %}
+            <img src="{{ product.image_url }}" class="product-image" alt="{{ product.name }}" loading="lazy">
+          {% else %}
+            <img src="{{ url_for('static', filename=product.image_url) }}" class="product-image" alt="{{ product.name }}" loading="lazy">
+          {% endif %}
+        {% else %}
+          <div class="product-image-placeholder">
+            <i class="fa-regular fa-image"></i>
+          </div>
+        {% endif %}
+      </a>
+
+      <!-- Info -->
+      <div class="card-body d-flex flex-column">
+        <h3 class="h6 fw-semibold product-name mb-1" title="{{ product.name }}">{{ product.name }}</h3>
+        {% if product.description %}
+          <p class="text-muted small product-description mb-2" data-bs-toggle="tooltip"
+             data-bs-placement="top" title="{{ product.description }}">
+            {{ product.description|truncate(110) }}
+          </p>
+        {% endif %}
+
+        <div class="mt-auto">
+          <div class="d-flex align-items-center justify-content-between mb-1">
+            <span class="h5 m-0 text-success fw-bold">R$ {{ '%.2f'|format(product.price)|replace('.', ',') }}</span>
+          </div>
+          <div class="text-muted small mb-2">
+            <i class="fa-solid fa-truck-fast ms-1 me-1"></i>entrega rápida
+          </div>
+
+          <form action="{{ url_for('adicionar_carrinho', product_id=product.id) }}"
+                method="post" class="js-cart-form">
+            {{ form.hidden_tag() }}
+            <div class="d-flex align-items-stretch gap-2">
+              <!-- Seletor de quantidade -->
+              <div class="quantity-selector" aria-label="Selecionar quantidade">
+                <button type="button" class="quantity-btn minus" aria-label="Diminuir">–</button>
+                {{ form.quantity(class="form-control quantity-input", min="1", value="1", **{'aria-label': 'Quantidade'}) }}
+                <button type="button" class="quantity-btn plus" aria-label="Aumentar">+</button>
+              </div>
+
+              <!-- Botão adicionar -->
+              <button type="submit" class="btn btn-primary add-to-cart-btn flex-grow-1 js-add-to-cart"
+                      aria-label="Adicionar {{ product.name }} ao carrinho">
+                <i class="fa-solid fa-cart-plus me-2"></i>
+                Adicionar ao carrinho
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </article>
+  </div>
+  {% endfor %}
+</div>
+
+{% if pagination.pages > 1 %}
+<nav aria-label="Paginação" class="mt-4">
+  <ul class="pagination justify-content-center">
+    <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('loja', page=pagination.prev_num, q=search_term, filter=selected_filter) if pagination.has_prev else '#' }}">Anterior</a>
+    </li>
+    {% for p in range(1, pagination.pages + 1) %}
+      <li class="page-item {% if p == pagination.page %}active{% endif %}">
+        <a class="page-link" href="{{ url_for('loja', page=p, q=search_term, filter=selected_filter) }}">{{ p }}</a>
+      </li>
+    {% endfor %}
+    <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('loja', page=pagination.next_num, q=search_term, filter=selected_filter) if pagination.has_next else '#' }}">Próximo</a>
+    </li>
+  </ul>
+</nav>
+{% endif %}
+{% else %}
+<section class="text-center py-5 my-5">
+  <div class="mb-3"><i class="fa-regular fa-face-frown-open display-4 text-muted"></i></div>
+  <h2 class="h5 text-muted">Nenhum produto disponível</h2>
+  <p class="text-muted">Volte em breve para novas ofertas!</p>
+</section>
+{% endif %}


### PR DESCRIPTION
## Summary
- add `/loja/data` API returning product grid HTML or JSON
- paginate product listing and load products dynamically via fetch
- use JavaScript to update product grid and browser history without full reload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3ac1d41f4832e8e1d83939c2703b6