### PR TITLE
Enable async clinic staff management

### DIFF
--- a/app.py
+++ b/app.py
@@ -2205,15 +2205,21 @@ def clinic_dashboard(clinica_id):
 def clinic_staff(clinica_id):
     clinic = Clinica.query.get_or_404(clinica_id)
     if current_user.id != clinic.owner_id:
+        if request.accept_mimetypes.accept_json:
+            return jsonify(success=False, message='Sem permissão'), 403
         abort(403)
     if request.method == 'POST':
         email = request.form.get('email')
         user = User.query.filter_by(email=email).first()
         if not user:
+            if request.accept_mimetypes.accept_json:
+                return jsonify(success=False, message='Usuário não encontrado'), 404
             flash('Usuário não encontrado', 'danger')
         else:
             staff = ClinicStaff.query.filter_by(clinic_id=clinic.id, user_id=user.id).first()
             if staff:
+                if request.accept_mimetypes.accept_json:
+                    return jsonify(success=False, message='Funcionário já está na clínica'), 400
                 flash('Funcionário já está na clínica', 'warning')
             else:
                 staff = ClinicStaff(clinic_id=clinic.id, user_id=user.id)
@@ -2221,9 +2227,16 @@ def clinic_staff(clinica_id):
                 user.clinica_id = clinic.id
                 db.session.add(user)
                 db.session.commit()
+                if request.accept_mimetypes.accept_json:
+                    staff_members = ClinicStaff.query.filter_by(clinic_id=clinic.id).all()
+                    html = render_template('partials/clinic_staff_rows.html', clinic=clinic, staff_members=staff_members)
+                    return jsonify(success=True, html=html, message='Funcionário adicionado', category='success')
                 flash('Funcionário adicionado. Defina as permissões.', 'success')
                 return redirect(url_for('clinic_staff_permissions', clinica_id=clinic.id, user_id=user.id))
     staff_members = ClinicStaff.query.filter_by(clinic_id=clinic.id).all()
+    if request.accept_mimetypes.accept_json:
+        html = render_template('partials/clinic_staff_rows.html', clinic=clinic, staff_members=staff_members)
+        return jsonify(success=True, html=html)
     return render_template('clinic_staff_list.html', clinic=clinic, staff_members=staff_members)
 
 
@@ -2232,7 +2245,14 @@ def clinic_staff(clinica_id):
 def clinic_staff_permissions(clinica_id, user_id):
     clinic = Clinica.query.get_or_404(clinica_id)
     if current_user.id != clinic.owner_id:
+        if request.accept_mimetypes.accept_json:
+            return jsonify(success=False, message='Sem permissão'), 403
         abort(403)
+    user = User.query.get(user_id)
+    if not user:
+        if request.accept_mimetypes.accept_json:
+            return jsonify(success=False, message='Usuário não encontrado'), 404
+        abort(404)
     staff = ClinicStaff.query.filter_by(clinic_id=clinic.id, user_id=user_id).first()
     if not staff:
         staff = ClinicStaff(clinic_id=clinic.id, user_id=user_id)
@@ -2241,13 +2261,17 @@ def clinic_staff_permissions(clinica_id, user_id):
         form.populate_obj(staff)
         staff.user_id = user_id
         db.session.add(staff)
-        user = User.query.get(user_id)
-        if user:
-            user.clinica_id = clinic.id
-            db.session.add(user)
+        user.clinica_id = clinic.id
+        db.session.add(user)
         db.session.commit()
+        if request.accept_mimetypes.accept_json:
+            html = render_template('partials/clinic_staff_permissions_form.html', form=form, clinic=clinic)
+            return jsonify(success=True, html=html, message='Permissões atualizadas', category='success')
         flash('Permissões atualizadas', 'success')
         return redirect(url_for('clinic_dashboard', clinica_id=clinic.id))
+    if request.accept_mimetypes.accept_json:
+        html = render_template('partials/clinic_staff_permissions_form.html', form=form, clinic=clinic)
+        return jsonify(success=True, html=html)
     return render_template('clinic_staff_permissions.html', form=form, clinic=clinic)
 
 

--- a/templates/clinic_staff_list.html
+++ b/templates/clinic_staff_list.html
@@ -3,7 +3,7 @@
 {% block main %}
 <div class="container mt-4">
   <h2>Funcionários de {{ clinic.nome }}</h2>
-  <form method="post" class="mb-4">
+  <form method="post" class="mb-4 js-staff-form" data-target="#staffList">
     <div class="input-group">
       <input type="email" name="email" class="form-control" placeholder="Email do usuário" required>
       <button class="btn btn-primary" type="submit">Adicionar</button>
@@ -17,18 +17,8 @@
         <th>Ações</th>
       </tr>
     </thead>
-    <tbody>
-      {% for s in staff_members %}
-      <tr>
-        <td>{{ s.user.name }}</td>
-        <td>{{ s.user.email }}</td>
-        <td>
-          <a href="{{ url_for('clinic_staff_permissions', clinica_id=clinic.id, user_id=s.user.id) }}" class="btn btn-sm btn-outline-primary">Permissões</a>
-        </td>
-      </tr>
-      {% else %}
-      <tr><td colspan="3">Nenhum funcionário.</td></tr>
-      {% endfor %}
+    <tbody id="staffList">
+      {% include 'partials/clinic_staff_rows.html' %}
     </tbody>
   </table>
 </div>

--- a/templates/clinic_staff_permissions.html
+++ b/templates/clinic_staff_permissions.html
@@ -3,29 +3,8 @@
 {% block main %}
 <div class="container mt-4" style="max-width: 500px;">
   <h2>Permissões do Funcionário</h2>
-  <form method="post">
-    {{ form.hidden_tag() }}
-    <div class="form-check">
-      {{ form.can_manage_clients(class="form-check-input") }}
-      {{ form.can_manage_clients.label(class="form-check-label") }}
-    </div>
-    <div class="form-check">
-      {{ form.can_manage_animals(class="form-check-input") }}
-      {{ form.can_manage_animals.label(class="form-check-label") }}
-    </div>
-    <div class="form-check">
-      {{ form.can_manage_staff(class="form-check-input") }}
-      {{ form.can_manage_staff.label(class="form-check-label") }}
-    </div>
-    <div class="form-check">
-      {{ form.can_manage_schedule(class="form-check-input") }}
-      {{ form.can_manage_schedule.label(class="form-check-label") }}
-    </div>
-    <div class="form-check">
-      {{ form.can_manage_inventory(class="form-check-input") }}
-      {{ form.can_manage_inventory.label(class="form-check-label") }}
-    </div>
-    {{ form.submit(class="btn btn-primary mt-3") }}
+  <form method="post" class="js-staff-form" id="staffPermissionForm" data-target="#staffPermissionForm">
+    {% include 'partials/clinic_staff_permissions_form.html' %}
   </form>
 </div>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -767,6 +767,53 @@
       });
     });
   </script>
-{% block scripts %}{% endblock %}
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.js-staff-form').forEach(form => {
+        form.addEventListener('submit', async ev => {
+          ev.preventDefault();
+          const resp = await fetchOrQueue(form.action, {
+            method: 'POST',
+            headers: {'Accept': 'application/json'},
+            body: new FormData(form)
+          });
+          if (resp && resp.ok) {
+            const data = await resp.json();
+            if (data.redirect) {
+              window.location.href = data.redirect;
+              return;
+            }
+            if (data.html) {
+              const target = form.dataset.target;
+              if (target) {
+                const el = document.querySelector(target);
+                if (el) {
+                  el.innerHTML = data.html;
+                }
+              }
+            }
+            if (data.message) {
+              const toastEl = document.getElementById('actionToast');
+              toastEl.querySelector('.toast-body').textContent = data.message;
+              toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
+              toastEl.classList.add('bg-' + (data.category || 'success'));
+              new bootstrap.Toast(toastEl).show();
+            }
+          } else if (resp) {
+            let data = {};
+            try { data = await resp.json(); } catch(e) {}
+            const toastEl = document.getElementById('actionToast');
+            toastEl.querySelector('.toast-body').textContent = data.message || 'Erro ao processar ação';
+            toastEl.classList.remove('bg-success', 'bg-info');
+            toastEl.classList.add('bg-danger');
+            new bootstrap.Toast(toastEl).show();
+          } else {
+            form.submit();
+          }
+        });
+      });
+    });
+  </script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/partials/clinic_staff_permissions_form.html
+++ b/templates/partials/clinic_staff_permissions_form.html
@@ -1,0 +1,22 @@
+{{ form.hidden_tag() }}
+<div class="form-check">
+  {{ form.can_manage_clients(class="form-check-input") }}
+  {{ form.can_manage_clients.label(class="form-check-label") }}
+</div>
+<div class="form-check">
+  {{ form.can_manage_animals(class="form-check-input") }}
+  {{ form.can_manage_animals.label(class="form-check-label") }}
+</div>
+<div class="form-check">
+  {{ form.can_manage_staff(class="form-check-input") }}
+  {{ form.can_manage_staff.label(class="form-check-label") }}
+</div>
+<div class="form-check">
+  {{ form.can_manage_schedule(class="form-check-input") }}
+  {{ form.can_manage_schedule.label(class="form-check-label") }}
+</div>
+<div class="form-check">
+  {{ form.can_manage_inventory(class="form-check-input") }}
+  {{ form.can_manage_inventory.label(class="form-check-label") }}
+</div>
+{{ form.submit(class="btn btn-primary mt-3") }}

--- a/templates/partials/clinic_staff_rows.html
+++ b/templates/partials/clinic_staff_rows.html
@@ -1,0 +1,11 @@
+{% for s in staff_members %}
+<tr>
+  <td>{{ s.user.name }}</td>
+  <td>{{ s.user.email }}</td>
+  <td>
+    <a href="{{ url_for('clinic_staff_permissions', clinica_id=clinic.id, user_id=s.user.id) }}" class="btn btn-sm btn-outline-primary">Permissões</a>
+  </td>
+</tr>
+{% else %}
+<tr><td colspan="3">Nenhum funcionário.</td></tr>
+{% endfor %}


### PR DESCRIPTION
## Summary
- Add `js-staff-form` forms for clinic staff list and permissions
- Submit staff-related forms via AJAX and refresh DOM with returned HTML
- Return JSON responses and proper HTTP codes from clinic staff routes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3ac1e682c832e8ffe2d13faea3df2