### PR TITLE
Align vet and staff management on clinic page

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -71,7 +71,13 @@
               <div class="d-flex justify-content-between align-items-center">
                 <div><strong>{{ s.user.name }}</strong> - {{ s.user.email }}</div>
                 {% if current_user.id == clinica.owner_id %}
-                <button class="btn btn-sm btn-outline-primary" onclick="toggleStaffPerm({{ s.user.id }})">Permissões</button>
+                <div class="btn-group">
+                  <button class="btn btn-sm btn-outline-primary" onclick="toggleStaffPerm({{ s.user.id }})">Permissões</button>
+                  <form method="post" action="{{ url_for('remove_funcionario', clinica_id=clinica.id, user_id=s.user.id) }}" class="d-inline">
+                    {{ staff_permission_forms[s.user.id].csrf_token }}
+                    <button type="submit" class="btn btn-sm btn-outline-danger">Remover</button>
+                  </form>
+                </div>
                 {% endif %}
               </div>
               {% if current_user.id == clinica.owner_id %}
@@ -134,7 +140,10 @@
               <div class="d-flex justify-content-between align-items-center">
                 <div><strong>{{ v.user.name }}</strong> (CRMV: {{ v.crmv }})</div>
                 {% if pode_editar %}
-                <button class="btn btn-sm btn-outline-primary" onclick="toggleVetOptions({{ v.id }})">Editar</button>
+                <div class="btn-group">
+                  <button class="btn btn-sm btn-outline-primary" onclick="toggleVetOptions({{ v.id }})">Editar</button>
+                  <button class="btn btn-sm btn-outline-secondary" onclick="toggleVetPerm({{ v.user.id }})">Permissões</button>
+                </div>
                 {% endif %}
               </div>
               <ul class="ms-3 mt-2">
@@ -145,6 +154,32 @@
                 {% endfor %}
               </ul>
               {% if pode_editar %}
+              <div id="vet-perms-{{ v.user.id }}" style="display:none;" class="mt-2">
+                <form method="post">
+                  {{ vet_permission_forms[v.user.id].hidden_tag() }}
+                  <div class="form-check">
+                    {{ vet_permission_forms[v.user.id].can_manage_clients(class="form-check-input") }}
+                    {{ vet_permission_forms[v.user.id].can_manage_clients.label(class="form-check-label") }}
+                  </div>
+                  <div class="form-check">
+                    {{ vet_permission_forms[v.user.id].can_manage_animals(class="form-check-input") }}
+                    {{ vet_permission_forms[v.user.id].can_manage_animals.label(class="form-check-label") }}
+                  </div>
+                  <div class="form-check">
+                    {{ vet_permission_forms[v.user.id].can_manage_staff(class="form-check-input") }}
+                    {{ vet_permission_forms[v.user.id].can_manage_staff.label(class="form-check-label") }}
+                  </div>
+                  <div class="form-check">
+                    {{ vet_permission_forms[v.user.id].can_manage_schedule(class="form-check-input") }}
+                    {{ vet_permission_forms[v.user.id].can_manage_schedule.label(class="form-check-label") }}
+                  </div>
+                  <div class="form-check">
+                    {{ vet_permission_forms[v.user.id].can_manage_inventory(class="form-check-input") }}
+                    {{ vet_permission_forms[v.user.id].can_manage_inventory.label(class="form-check-label") }}
+                  </div>
+                  {{ vet_permission_forms[v.user.id].submit(class="btn btn-primary btn-sm mt-2") }}
+                </form>
+              </div>
               <div id="vet-options-{{ v.id }}" style="display:none;" class="mt-2">
                 <form method="post" action="{{ url_for('remove_veterinario', clinica_id=clinica.id, veterinario_id=v.id) }}" class="mb-3">
                   {{ vet_schedule_forms[v.id].csrf_token }}
@@ -389,6 +424,12 @@
   }
   function toggleStaffPerm(id) {
     const section = document.getElementById(`staff-perms-${id}`);
+    if (section) {
+      section.style.display = section.style.display === 'none' ? 'block' : 'none';
+    }
+  }
+  function toggleVetPerm(id) {
+    const section = document.getElementById(`vet-perms-${id}`);
     if (section) {
       section.style.display = section.style.display === 'none' ? 'block' : 'none';
     }

--- a/tests/test_remove_staff_access.py
+++ b/tests/test_remove_staff_access.py
@@ -1,0 +1,51 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, Clinica, ClinicStaff
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def login(monkeypatch, user):
+    import flask_login.utils as login_utils
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def test_removed_staff_cannot_access_clinic(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        clinic = Clinica(nome="Clinic")
+        owner = User(name="Owner", email="o@example.com", password_hash="x")
+        staff_user = User(name="Staff", email="s@example.com", password_hash="y", worker="colaborador")
+        db.session.add_all([clinic, owner, staff_user])
+        db.session.commit()
+        clinic.owner_id = owner.id
+        staff = ClinicStaff(clinic_id=clinic.id, user_id=staff_user.id)
+        staff_user.clinica_id = clinic.id
+        db.session.add_all([staff, clinic, staff_user])
+        db.session.commit()
+
+        # Staff can access initially
+        login(monkeypatch, staff_user)
+        resp = client.get('/minha-clinica')
+        assert resp.status_code == 302
+        assert f"/clinica/{clinic.id}" in resp.headers['Location']
+
+        # Owner removes staff
+        login(monkeypatch, owner)
+        client.post(f'/clinica/{clinic.id}/funcionario/{staff_user.id}/remove')
+
+        # Staff no longer has access to clinic detail
+        login(monkeypatch, staff_user)
+        resp = client.get(f'/clinica/{clinic.id}')
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Allow clinic owners to remove non-veterinarian staff
- Manage veterinarian permissions like other staff and keep lists separate
- Add test ensuring removed staff lose clinic access

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3af3f8620832ea1ab4058dd1e44aa