### PR TITLE
Display calendar and hours on clinic tab

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -222,7 +222,7 @@
       </div>
 
       <div id="calendar-container">
-        {% with clinic_id = clinica.id %}
+        {% with clinic_id=clinica.id, calendar_id='agendamentos-calendar', toggle_id='agendamentos-agenda-toggle', include_assets=False %}
           {% include 'partials/schedule_toggle.html' %}
         {% endwith %}
       </div>
@@ -249,64 +249,6 @@
           {% include 'partials/appointments_table.html' %}
         </div>
       </div>
-
-      <h3 class="mt-4">Horários de Atendimento</h3>
-      <table class="table">
-        <thead>
-          <tr><th>Dia</th><th>Abre</th><th>Fecha</th>{% if pode_editar %}<th>Ações</th>{% endif %}</tr>
-        </thead>
-        <tbody>
-          {% for h in horarios %}
-            <tr>
-              <td>{{ h.dia_semana }}</td>
-              <td>{{ h.hora_abertura.strftime('%H:%M') }}</td>
-              <td>{{ h.hora_fechamento.strftime('%H:%M') }}</td>
-              {% if pode_editar %}
-              <td>
-                <form method="post" action="{{ url_for('delete_clinic_hour', clinica_id=clinica.id, horario_id=h.id) }}" class="d-inline">
-                  {{ form.csrf_token }}
-                  <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Excluir este horário?');">Excluir</button>
-                </form>
-              </td>
-              {% endif %}
-            </tr>
-          {% else %}
-            <tr><td colspan="{% if pode_editar %}4{% else %}3{% endif %}">Nenhum horário cadastrado.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
-
-      {% if pode_editar %}
-        <button class="btn btn-secondary mt-3" onclick="toggleEditHours()">Editar Horários</button>
-        <div id="edit-hours" class="mt-4" style="display: none;">
-          <form method="post" class="mb-4">
-            {{ form.hidden_tag() }}
-          <div class="mb-3">
-            {{ form.clinica_id.label }}
-            {{ form.clinica_id(class="form-select") }}
-          </div>
-          <div class="mb-3">
-            {{ form.dias_semana.label }}
-            {{ form.dias_semana(class="form-select", multiple=True, size=7) }}
-            <div class="mt-2">
-              <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('all')">Todos</button>
-              <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekday')">Dias Úteis</button>
-              <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekend')">Fins de Semana</button>
-              <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('clear')">Limpar</button>
-            </div>
-          </div>
-          <div class="mb-3">
-            {{ form.hora_abertura.label }}
-            {{ form.hora_abertura(class="form-control") }}
-          </div>
-          <div class="mb-3">
-            {{ form.hora_fechamento.label }}
-            {{ form.hora_fechamento(class="form-control") }}
-          </div>
-          {{ form.submit(class="btn btn-primary") }}
-        </form>
-      </div>
-      {% endif %}
 
     </div>
     <div class="tab-pane fade" id="animais" role="tabpanel">

--- a/templates/partials/clinic_info.html
+++ b/templates/partials/clinic_info.html
@@ -7,37 +7,98 @@
 {% if clinica.telefone %}<p><strong>Telefone:</strong> {{ clinica.telefone }}</p>{% endif %}
 {% if clinica.email %}<p><strong>Email:</strong> {{ clinica.email }}</p>{% endif %}
 
+<h3 class="mt-4">Calendário da Clínica</h3>
+{% with clinic_id=clinica.id, calendar_id='clinic-calendar', toggle_id='clinic-agenda-toggle', include_assets=True %}
+  {% include 'partials/schedule_toggle.html' %}
+{% endwith %}
+
+<h3 class="mt-4">Horários de Atendimento</h3>
+<table class="table">
+  <thead>
+    <tr><th>Dia</th><th>Abre</th><th>Fecha</th>{% if pode_editar %}<th>Ações</th>{% endif %}</tr>
+  </thead>
+  <tbody>
+    {% for h in horarios %}
+      <tr>
+        <td>{{ h.dia_semana }}</td>
+        <td>{{ h.hora_abertura.strftime('%H:%M') }}</td>
+        <td>{{ h.hora_fechamento.strftime('%H:%M') }}</td>
+        {% if pode_editar %}
+        <td>
+          <form method="post" action="{{ url_for('delete_clinic_hour', clinica_id=clinica.id, horario_id=h.id) }}" class="d-inline">
+            {{ form.csrf_token }}
+            <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Excluir este horário?');">Excluir</button>
+          </form>
+        </td>
+        {% endif %}
+      </tr>
+    {% else %}
+      <tr><td colspan="{% if pode_editar %}4{% else %}3{% endif %}">Nenhum horário cadastrado.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
 {% if pode_editar %}
-<button class="btn btn-secondary mt-3" onclick="toggleEditInfo()">Editar Informações</button>
-<div id="edit-info" class="mt-4" style="display: none;">
-  <form method="post" class="mb-4" enctype="multipart/form-data">
-    {{ clinic_form.hidden_tag() }}
-    <div class="mb-3">
-      {{ clinic_form.nome.label }}
-      {{ clinic_form.nome(class="form-control") }}
-    </div>
-    <div class="mb-3">
-      {{ clinic_form.cnpj.label }}
-      {{ clinic_form.cnpj(class="form-control") }}
-    </div>
-    <div class="mb-3">
-      {{ clinic_form.endereco.label }}
-      {{ clinic_form.endereco(class="form-control") }}
-    </div>
-    <div class="mb-3">
-      {{ clinic_form.telefone.label }}
-      {{ clinic_form.telefone(class="form-control") }}
-    </div>
-    <div class="mb-3">
-      {{ clinic_form.email.label }}
-      {{ clinic_form.email(class="form-control") }}
-    </div>
-    <div class="mb-3">
-      {{ clinic_form.logotipo.label }}
-      {{ photo_cropper(clinic_form.logotipo, clinic_form.photo_rotation, clinic_form.photo_zoom, clinic_form.photo_offset_x, clinic_form.photo_offset_y, clinica.logotipo, 150, 'clinic_logo', 'user') }}
-    </div>
-    {{ clinic_form.submit(class="btn btn-primary") }}
-  </form>
-</div>
+  <button class="btn btn-secondary mt-3" onclick="toggleEditHours()">Editar Horários</button>
+  <div id="edit-hours" class="mt-4" style="display: none;">
+    <form method="post" class="mb-4">
+      {{ form.hidden_tag() }}
+      <div class="mb-3">
+        {{ form.clinica_id.label }}
+        {{ form.clinica_id(class="form-select") }}
+      </div>
+      <div class="mb-3">
+        {{ form.dias_semana.label }}
+        {{ form.dias_semana(class="form-select", multiple=True, size=7) }}
+        <div class="mt-2">
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('all')">Todos</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekday')">Dias Úteis</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekend')">Fins de Semana</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('clear')">Limpar</button>
+        </div>
+      </div>
+      <div class="mb-3">
+        {{ form.hora_abertura.label }}
+        {{ form.hora_abertura(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ form.hora_fechamento.label }}
+        {{ form.hora_fechamento(class="form-control") }}
+      </div>
+      {{ form.submit(class="btn btn-primary") }}
+    </form>
+  </div>
+
+  <button class="btn btn-secondary mt-3" onclick="toggleEditInfo()">Editar Informações da Clínica</button>
+  <div id="edit-info" class="mt-4" style="display: none;">
+    <form method="post" class="mb-4" enctype="multipart/form-data">
+      {{ clinic_form.hidden_tag() }}
+      <div class="mb-3">
+        {{ clinic_form.nome.label }}
+        {{ clinic_form.nome(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ clinic_form.cnpj.label }}
+        {{ clinic_form.cnpj(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ clinic_form.endereco.label }}
+        {{ clinic_form.endereco(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ clinic_form.telefone.label }}
+        {{ clinic_form.telefone(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ clinic_form.email.label }}
+        {{ clinic_form.email(class="form-control") }}
+      </div>
+      <div class="mb-3">
+        {{ clinic_form.logotipo.label }}
+        {{ photo_cropper(clinic_form.logotipo, clinic_form.photo_rotation, clinic_form.photo_zoom, clinic_form.photo_offset_x, clinic_form.photo_offset_y, clinica.logotipo, 150, 'clinic_logo', 'user') }}
+      </div>
+      {{ clinic_form.submit(class="btn btn-primary") }}
+    </form>
+  </div>
 {% endif %}
 

--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -1,6 +1,9 @@
+{% set calendar_id = calendar_id|default('shared-calendar') %}
+{% set toggle_id = toggle_id|default('agenda-toggle') %}
+
 <div class="card mb-4">
   <div class="card-header d-flex justify-content-center">
-    <div class="btn-group" id="agenda-toggle">
+    <div class="btn-group" id="{{ toggle_id }}">
       <button class="btn btn-outline-primary active" data-source="user">Minha Agenda</button>
       {% if clinic_id %}
       <button class="btn btn-outline-primary" data-source="clinic">Agenda da Clínica</button>
@@ -8,16 +11,18 @@
     </div>
   </div>
   <div class="card-body p-0">
-    <div id="shared-calendar"></div>
+    <div id="{{ calendar_id }}"></div>
   </div>
 </div>
 
+{% if include_assets|default(True) %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css">
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
+{% endif %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-  const calendarEl = document.getElementById('shared-calendar');
-  const toggle = document.getElementById('agenda-toggle');
+  const calendarEl = document.getElementById('{{ calendar_id }}');
+  const toggle = document.getElementById('{{ toggle_id }}');
   let source = 'user';
 
   function eventUrl() {
@@ -94,3 +99,4 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 </script>
+


### PR DESCRIPTION
## Summary
- show clinic calendar and operating hours directly in the Clinic tab
- make schedule calendar component reusable with custom IDs and optional asset loading
- load calendar in Appointments tab using the new component

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3aff45520832ea9c8d8cbff892e20