### PR TITLE
Add clinic-specific inventory management page

### DIFF
--- a/app.py
+++ b/app.py
@@ -186,7 +186,7 @@ from forms import (
     ProductUpdateForm, ProductPhotoForm, ChangePasswordForm,
     DeleteAccountForm, ClinicForm, ClinicHoursForm, ClinicAddVeterinarianForm,
     ClinicAddStaffForm, ClinicStaffPermissionForm, VetScheduleForm, VetSpecialtyForm, AppointmentForm, AppointmentDeleteForm,
-    OrcamentoForm
+    InventoryItemForm, OrcamentoForm
 )
 from helpers import (
     calcular_idade,
@@ -2150,6 +2150,62 @@ def clinic_detail(clinica_id):
         next7_str=next7_str,
         now=now_dt,
     )
+
+
+@app.route('/clinica/<int:clinica_id>/estoque', methods=['GET', 'POST'])
+@login_required
+def clinic_stock(clinica_id):
+    clinica = Clinica.query.get_or_404(clinica_id)
+    is_owner = current_user.id == clinica.owner_id if current_user.is_authenticated else False
+    staff = None
+    if current_user.is_authenticated:
+        staff = ClinicStaff.query.filter_by(clinic_id=clinica.id, user_id=current_user.id).first()
+    has_perm = staff.can_manage_inventory if staff else False
+    if not (_is_admin() or is_owner or has_perm):
+        abort(403)
+
+    form = InventoryItemForm()
+    if form.validate_on_submit():
+        item = ClinicInventoryItem(
+            clinica_id=clinica.id,
+            name=form.name.data,
+            quantity=form.quantity.data,
+            unit=form.unit.data,
+        )
+        db.session.add(item)
+        db.session.commit()
+        flash('Item adicionado com sucesso.', 'success')
+        return redirect(url_for('clinic_stock', clinica_id=clinica.id))
+
+    items = (
+        ClinicInventoryItem.query
+        .filter_by(clinica_id=clinica.id)
+        .order_by(ClinicInventoryItem.name)
+        .all()
+    )
+    return render_template('clinic_stock.html', clinica=clinica, items=items, form=form)
+
+
+@app.route('/estoque/item/<int:item_id>/atualizar', methods=['POST'])
+@login_required
+def update_inventory_item(item_id):
+    item = ClinicInventoryItem.query.get_or_404(item_id)
+    clinica = item.clinica
+    is_owner = current_user.id == clinica.owner_id if current_user.is_authenticated else False
+    staff = None
+    if current_user.is_authenticated:
+        staff = ClinicStaff.query.filter_by(clinic_id=clinica.id, user_id=current_user.id).first()
+    has_perm = staff.can_manage_inventory if staff else False
+    if not (_is_admin() or is_owner or has_perm):
+        abort(403)
+    try:
+        qty = int(request.form.get('quantity', item.quantity))
+    except (TypeError, ValueError):
+        qty = item.quantity
+    item.quantity = max(0, qty)
+    db.session.commit()
+    flash('Quantidade atualizada.', 'success')
+    return redirect(url_for('clinic_stock', clinica_id=clinica.id))
 
 
 @app.route('/clinica/<int:clinica_id>/novo_orcamento', methods=['GET', 'POST'])

--- a/forms.py
+++ b/forms.py
@@ -13,7 +13,7 @@ from wtforms import (
     DateTimeField,
     TimeField,
 )
-from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional
+from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional, NumberRange
 from flask_wtf.file import FileField, FileAllowed
 
 
@@ -350,6 +350,13 @@ class ClinicStaffPermissionForm(FlaskForm):
     can_manage_schedule = BooleanField('Agenda')
     can_manage_inventory = BooleanField('Estoque')
     submit = SubmitField('Salvar')
+
+
+class InventoryItemForm(FlaskForm):
+    name = StringField('Nome do item', validators=[DataRequired()])
+    quantity = IntegerField('Quantidade', validators=[DataRequired(), NumberRange(min=0)])
+    unit = StringField('Unidade', validators=[Optional(), Length(max=50)])
+    submit = SubmitField('Adicionar')
 
 
 class VetScheduleForm(FlaskForm):

--- a/models.py
+++ b/models.py
@@ -606,6 +606,17 @@ class ClinicStaff(db.Model):
     clinic = db.relationship('Clinica', backref='staff_members')
     user = db.relationship('User', backref='clinic_roles')
 
+# Itens de estoque específicos por clínica
+class ClinicInventoryItem(db.Model):
+    __tablename__ = 'clinic_inventory_item'
+    id = db.Column(db.Integer, primary_key=True)
+    clinica_id = db.Column(db.Integer, db.ForeignKey('clinica.id'), nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    quantity = db.Column(db.Integer, default=0)
+    unit = db.Column(db.String(50))
+
+    clinica = db.relationship('Clinica', backref='inventory_items')
+
 # Associação many-to-many entre veterinário e especialidade
 veterinario_especialidade = db.Table(
     'veterinario_especialidade',

--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -35,7 +35,7 @@
       </button>
     </li>
     <li class="nav-item" role="presentation">
-      <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('loja') }}">
+      <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('clinic_stock', clinica_id=clinica.id) }}">
         <span class="icon-circle bg-warning text-dark"><i class="fa-solid fa-boxes"></i></span>
         <span class="fw-semibold">Estoque</span>
       </a>

--- a/templates/clinic_stock.html
+++ b/templates/clinic_stock.html
@@ -1,0 +1,45 @@
+{% extends "layout.html" %}
+{% block main %}
+<div class="container mt-4">
+  <h2>Estoque da Clínica {{ clinica.nome }}</h2>
+  <table class="table table-striped mt-3">
+    <thead>
+      <tr>
+        <th>Insumo</th>
+        <th style="width:180px;">Quantidade</th>
+        <th>Unidade</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in items %}
+      <tr>
+        <td>{{ item.name }}</td>
+        <td>
+          <form method="post" action="{{ url_for('update_inventory_item', item_id=item.id) }}" class="d-flex">
+            {% if csrf_token %}{{ csrf_token() }}{% endif %}
+            <input type="number" name="quantity" value="{{ item.quantity }}" min="0" class="form-control form-control-sm me-2">
+            <button class="btn btn-sm btn-primary">Salvar</button>
+          </form>
+        </td>
+        <td>{{ item.unit or '-' }}</td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="3" class="text-center">Nenhum item no estoque.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <hr>
+  <h4>Adicionar Item</h4>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <div class="row g-2">
+      <div class="col-md-5">{{ form.name(class="form-control", placeholder="Nome") }}</div>
+      <div class="col-md-3">{{ form.quantity(class="form-control", placeholder="Quantidade") }}</div>
+      <div class="col-md-2">{{ form.unit(class="form-control", placeholder="Unidade") }}</div>
+      <div class="col-md-2">{{ form.submit(class="btn btn-success w-100") }}</div>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/tests/test_clinic_inventory.py
+++ b/tests/test_clinic_inventory.py
@@ -1,0 +1,42 @@
+import pytest
+import app as app_module
+from app import app as flask_app, db
+from models import User, Clinica, ClinicInventoryItem
+import flask_login.utils as login_utils
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    yield flask_app
+
+
+def test_clinic_inventory_page(app, monkeypatch):
+    client = app.test_client()
+    with app.app_context():
+        user = User(id=999, email="u@example.com", name="User", password_hash="x")
+        clinic = Clinica(nome="Clinic", owner_id=user.id)
+        db.session.add_all([user, clinic])
+        db.session.commit()
+        clinic_id = clinic.id
+        user_id = user.id
+    monkeypatch.setattr(login_utils, '_get_user', lambda: User.query.get(user_id))
+    monkeypatch.setattr(app_module, '_is_admin', lambda: False)
+
+    response = client.get(f'/clinica/{clinic_id}/estoque')
+    assert response.status_code == 200
+
+    response = client.post(
+        f'/clinica/{clinic_id}/estoque',
+        data={'name': 'Seringa', 'quantity': 10, 'unit': 'caixa'},
+        follow_redirects=True,
+    )
+    assert b'Seringa' in response.data
+    with app.app_context():
+        item = ClinicInventoryItem.query.filter_by(clinica_id=clinic_id, name='Seringa').first()
+        assert item is not None
+        assert item.quantity == 10


### PR DESCRIPTION
## Summary
- track per-clinic supplies with new `ClinicInventoryItem` model
- manage items through new inventory routes and template
- link clinic dashboard to new inventory page and cover with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3b052fc74832e82db4f838e110dde