### PR TITLE
Support multiple budget blocks per consultation

### DIFF
--- a/app.py
+++ b/app.py
@@ -6367,10 +6367,28 @@ def imprimir_orcamento(consulta_id):
     clinica = current_user.veterinario.clinica if current_user.veterinario else None
     return render_template(
         'imprimir_orcamento.html',
-        consulta=consulta,
+        itens=consulta.orcamento_items,
+        total=consulta.total_orcamento,
         animal=animal,
         tutor=tutor,
         clinica=clinica
+    )
+
+
+@app.route('/imprimir_bloco_orcamento/<int:bloco_id>')
+@login_required
+def imprimir_bloco_orcamento(bloco_id):
+    bloco = BlocoOrcamento.query.get_or_404(bloco_id)
+    animal = bloco.animal
+    tutor = animal.owner
+    clinica = current_user.veterinario.clinica if current_user.veterinario else None
+    return render_template(
+        'imprimir_orcamento.html',
+        itens=bloco.itens,
+        total=bloco.total,
+        animal=animal,
+        tutor=tutor,
+        clinica=clinica,
     )
 
 @app.route('/consulta/<int:consulta_id>/pagar_orcamento')
@@ -6464,6 +6482,41 @@ def deletar_orcamento_item(item_id):
     db.session.delete(item)
     db.session.commit()
     return jsonify({'total': float(consulta.total_orcamento)}), 200
+
+
+@app.route('/consulta/<int:consulta_id>/bloco_orcamento', methods=['POST'])
+@login_required
+def salvar_bloco_orcamento(consulta_id):
+    consulta = get_consulta_or_404(consulta_id)
+    if current_user.worker != 'veterinario':
+        return jsonify({'success': False, 'message': 'Apenas veterinários podem salvar orçamento.'}), 403
+    if not consulta.orcamento_items:
+        return jsonify({'success': False, 'message': 'Nenhum item no orçamento.'}), 400
+    bloco = BlocoOrcamento(animal_id=consulta.animal_id)
+    db.session.add(bloco)
+    db.session.flush()
+    for item in list(consulta.orcamento_items):
+        item.bloco_id = bloco.id
+        item.consulta_id = None
+        db.session.add(item)
+    db.session.commit()
+    historico_html = render_template('partials/historico_orcamentos.html', animal=consulta.animal)
+    return jsonify({'success': True, 'html': historico_html})
+
+
+@app.route('/bloco_orcamento/<int:bloco_id>/deletar', methods=['POST'])
+@login_required
+def deletar_bloco_orcamento(bloco_id):
+    bloco = BlocoOrcamento.query.get_or_404(bloco_id)
+    if current_user.worker != 'veterinario':
+        return jsonify({'success': False, 'message': 'Apenas veterinários podem excluir.'}), 403
+    animal_id = bloco.animal_id
+    db.session.delete(bloco)
+    db.session.commit()
+    if request.accept_mimetypes.accept_json:
+        historico_html = render_template('partials/historico_orcamentos.html', animal=Animal.query.get(animal_id))
+        return jsonify({'success': True, 'html': historico_html})
+    return redirect(url_for('consulta_direct', animal_id=animal_id))
 
 
 if __name__ == "__main__":

--- a/models.py
+++ b/models.py
@@ -501,6 +501,7 @@ class OrcamentoItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     consulta_id = db.Column(db.Integer, db.ForeignKey('consulta.id'), nullable=True)
     orcamento_id = db.Column(db.Integer, db.ForeignKey('orcamento.id'), nullable=True)
+    bloco_id = db.Column(db.Integer, db.ForeignKey('bloco_orcamento.id'), nullable=True)
     descricao = db.Column(db.String(120), nullable=False)
     valor = db.Column(db.Numeric(10, 2), nullable=False)
     servico_id = db.Column(db.Integer, db.ForeignKey('servico_clinica.id'))
@@ -513,8 +514,27 @@ class OrcamentoItem(db.Model):
         'Orcamento',
         backref=db.backref('items', cascade='all, delete-orphan')
     )
+    bloco = db.relationship(
+        'BlocoOrcamento',
+        backref=db.backref('itens', cascade='all, delete-orphan')
+    )
     servico = db.relationship('ServicoClinica')
 
+
+
+
+class BlocoOrcamento(db.Model):
+    __tablename__ = 'bloco_orcamento'
+
+    id = db.Column(db.Integer, primary_key=True)
+    animal_id = db.Column(db.Integer, db.ForeignKey('animal.id'), nullable=False)
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+
+    animal = db.relationship('Animal', backref=db.backref('blocos_orcamento', cascade='all, delete-orphan', lazy=True))
+
+    @property
+    def total(self):
+        return sum(item.valor for item in self.itens)
 
 
 # models.py

--- a/templates/imprimir_orcamento.html
+++ b/templates/imprimir_orcamento.html
@@ -61,7 +61,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for item in consulta.orcamento_items %}
+      {% for item in itens %}
       <tr>
         <td>{{ item.descricao }}</td>
         <td>{{ '%.2f'|format(item.valor) }}</td>
@@ -69,7 +69,7 @@
       {% endfor %}
       <tr>
         <th>Total</th>
-        <th>{{ '%.2f'|format(consulta.total_orcamento) }}</th>
+        <th>{{ '%.2f'|format(total) }}</th>
       </tr>
     </tbody>
   </table>

--- a/templates/partials/historico_orcamentos.html
+++ b/templates/partials/historico_orcamentos.html
@@ -1,0 +1,32 @@
+{% if animal.blocos_orcamento %}
+<div class="card mb-3">
+  <div class="card-body">
+    <h5 class="card-title">💰 Histórico de Orçamentos</h5>
+    {% for bloco in animal.blocos_orcamento|reverse %}
+    <div class="border rounded p-3 mb-3">
+      <h6 class="text-muted">Orçamento feito em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</h6>
+      <ul class="list-group list-group-flush mb-2">
+        {% for item in bloco.itens %}
+        <li class="list-group-item d-flex justify-content-between">
+          <span>{{ item.descricao }}</span>
+          <span>R$ {{ '%.2f'|format(item.valor) }}</span>
+        </li>
+        {% endfor %}
+        <li class="list-group-item d-flex justify-content-between">
+          <strong>Total</strong>
+          <strong>R$ {{ '%.2f'|format(bloco.total) }}</strong>
+        </li>
+      </ul>
+      <div class="d-flex flex-wrap gap-2">
+        <form method="POST" action="{{ url_for('deletar_bloco_orcamento', bloco_id=bloco.id) }}" class="d-inline delete-history-form" data-sync data-target="historico-orcamentos" data-confirm="Deseja mesmo excluir este orçamento?">
+          <button class="btn btn-danger btn-sm">🗑 Excluir</button>
+        </form>
+        <a href="{{ url_for('imprimir_bloco_orcamento', bloco_id=bloco.id) }}" class="btn btn-outline-secondary btn-sm" target="_blank">🖨 Imprimir</a>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% else %}
+<p class="text-muted">Nenhum orçamento registrado ainda.</p>
+{% endif %}

--- a/templates/partials/orcamento_form.html
+++ b/templates/partials/orcamento_form.html
@@ -63,12 +63,17 @@
   </tfoot>
 </table>
 <div class="text-end mt-3">
+  <button type="button" class="btn btn-success me-2" onclick="finalizarBlocoOrcamento()">💾 Salvar orçamento</button>
   <a href="{{ url_for('imprimir_orcamento', consulta_id=consulta.id) }}" class="btn btn-outline-dark me-2" target="_blank">
     🖨️ Imprimir
   </a>
   <a href="{{ url_for('pagar_orcamento', consulta_id=consulta.id) }}" class="btn btn-primary">
     <i class="fa-solid fa-money-bill-wave me-1"></i> Pagar orçamento
   </a>
+</div>
+
+<div id="historico-orcamentos" class="mt-5">
+  {% include 'partials/historico_orcamentos.html' %}
 </div>
 
 <script>
@@ -128,6 +133,24 @@ async function removerItemOrcamento(id) {
     document.querySelector(`#orcamento-tabela tr[data-id='${id}']`).remove();
     const data = await resp.json();
     document.getElementById('orcamento-total').textContent = data.total.toFixed(2);
+  }
+}
+
+async function finalizarBlocoOrcamento() {
+  const tbody = document.querySelector('#orcamento-tabela tbody');
+  if (!tbody.children.length) return;
+  const resp = await fetch(`/consulta/${consultaId}/bloco_orcamento`, {method: 'POST', headers: {'Accept': 'application/json'}});
+  if (resp.ok) {
+    const data = await resp.json();
+    if (data.success) {
+      tbody.innerHTML = '';
+      document.getElementById('orcamento-total').textContent = '0.00';
+      const historico = document.getElementById('historico-orcamentos');
+      if (data.html) {
+        historico.innerHTML = data.html;
+        if (typeof bindSyncForms === 'function') { bindSyncForms(historico); }
+      }
+    }
   }
 }
 </script>

--- a/tests/test_bloco_orcamento.py
+++ b/tests/test_bloco_orcamento.py
@@ -1,0 +1,47 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, Animal, Consulta, OrcamentoItem, BlocoOrcamento
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_salvar_bloco_orcamento(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        vet = User(name='Vet', email='vet@example.com', worker='veterinario', role='admin')
+        vet.set_password('x')
+        tutor = User(name='Tutor', email='tutor@example.com')
+        tutor.set_password('y')
+        animal = Animal(name='Rex', owner=tutor)
+        db.session.add_all([vet, tutor, animal])
+        db.session.commit()
+        consulta = Consulta(animal=animal, created_by=vet.id, status='in_progress')
+        item1 = OrcamentoItem(consulta=consulta, descricao='Consulta', valor=50)
+        item2 = OrcamentoItem(consulta=consulta, descricao='Exame', valor=30)
+        db.session.add_all([consulta, item1, item2])
+        db.session.commit()
+        consulta_id = consulta.id
+    client = app.test_client()
+    with client:
+        client.post('/login', data={'email': 'vet@example.com', 'password': 'x'}, follow_redirects=True)
+        resp = client.post(f'/consulta/{consulta_id}/bloco_orcamento', headers={'Accept': 'application/json'})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success']
+    with app.app_context():
+        bloco = BlocoOrcamento.query.first()
+        assert bloco is not None
+        assert len(bloco.itens) == 2
+        consulta = Consulta.query.get(consulta_id)
+        assert len(consulta.orcamento_items) == 0
+        db.drop_all()


### PR DESCRIPTION
## Summary
- Allow saving consultation budget items into reusable blocks
- Show budget history with delete/print actions
- Reuse printing template for budget blocks and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3b1b97770832e984311a5e29e7aa5