### PR TITLE
Show print/pay in budget history

### DIFF
--- a/app.py
+++ b/app.py
@@ -6477,6 +6477,52 @@ def imprimir_bloco_orcamento(bloco_id):
         clinica=clinica,
     )
 
+
+@app.route('/pagar_bloco_orcamento/<int:bloco_id>')
+@login_required
+def pagar_bloco_orcamento(bloco_id):
+    bloco = BlocoOrcamento.query.get_or_404(bloco_id)
+    if not bloco.itens:
+        flash('Nenhum item no orçamento.', 'warning')
+        return redirect(url_for('consulta_direct', animal_id=bloco.animal_id))
+
+    items = [
+        {
+            'id': str(it.id),
+            'title': it.descricao,
+            'quantity': 1,
+            'unit_price': float(it.valor),
+        }
+        for it in bloco.itens
+    ]
+
+    preference_data = {
+        'items': items,
+        'external_reference': f'bloco_orcamento-{bloco.id}',
+        'notification_url': url_for('notificacoes_mercado_pago', _external=True),
+        'statement_descriptor': current_app.config.get('MERCADOPAGO_STATEMENT_DESCRIPTOR'),
+        'back_urls': {
+            s: url_for('consulta_direct', animal_id=bloco.animal_id, _external=True)
+            for s in ('success', 'failure', 'pending')
+        },
+        'auto_return': 'approved',
+    }
+
+    try:
+        resp = mp_sdk().preference().create(preference_data)
+    except Exception:
+        current_app.logger.exception('Erro de conexão com Mercado Pago')
+        flash('Falha ao conectar com Mercado Pago.', 'danger')
+        return redirect(url_for('consulta_direct', animal_id=bloco.animal_id))
+
+    if resp.get('status') != 201:
+        current_app.logger.error('MP error (HTTP %s): %s', resp.get('status'), resp)
+        flash('Erro ao iniciar pagamento.', 'danger')
+        return redirect(url_for('consulta_direct', animal_id=bloco.animal_id))
+
+    pref = resp['response']
+    return redirect(pref['init_point'])
+
 @app.route('/consulta/<int:consulta_id>/pagar_orcamento')
 @login_required
 def pagar_orcamento(consulta_id):

--- a/templates/partials/historico_orcamentos.html
+++ b/templates/partials/historico_orcamentos.html
@@ -22,6 +22,7 @@
           <button class="btn btn-danger btn-sm">🗑 Excluir</button>
         </form>
         <a href="{{ url_for('imprimir_bloco_orcamento', bloco_id=bloco.id) }}" class="btn btn-outline-secondary btn-sm" target="_blank">🖨 Imprimir</a>
+        <a href="{{ url_for('pagar_bloco_orcamento', bloco_id=bloco.id) }}" class="btn btn-primary btn-sm">💳 Pagar</a>
       </div>
     </div>
     {% endfor %}

--- a/templates/partials/orcamento_form.html
+++ b/templates/partials/orcamento_form.html
@@ -63,13 +63,7 @@
   </tfoot>
 </table>
 <div class="text-end mt-3">
-  <button type="button" class="btn btn-success me-2" onclick="finalizarBlocoOrcamento()">💾 Salvar orçamento</button>
-  <a href="{{ url_for('imprimir_orcamento', consulta_id=consulta.id) }}" class="btn btn-outline-dark me-2" target="_blank">
-    🖨️ Imprimir
-  </a>
-  <a href="{{ url_for('pagar_orcamento', consulta_id=consulta.id) }}" class="btn btn-primary">
-    <i class="fa-solid fa-money-bill-wave me-1"></i> Pagar orçamento
-  </a>
+  <button type="button" class="btn btn-success" onclick="finalizarBlocoOrcamento()">💾 Salvar orçamento</button>
 </div>
 
 <div id="historico-orcamentos" class="mt-5">

--- a/tests/test_pagar_bloco_orcamento.py
+++ b/tests/test_pagar_bloco_orcamento.py
@@ -1,0 +1,57 @@
+import os, sys
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import app as app_module
+from app import app as flask_app, db
+from models import User, Animal, Consulta, OrcamentoItem, BlocoOrcamento
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_pagar_bloco_orcamento(app, monkeypatch):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        vet = User(name='Vet', email='vet@example.com', worker='veterinario', role='admin')
+        vet.set_password('x')
+        tutor = User(name='Tutor', email='tutor@example.com')
+        tutor.set_password('y')
+        animal = Animal(name='Rex', owner=tutor)
+        db.session.add_all([vet, tutor, animal])
+        db.session.commit()
+        consulta = Consulta(animal=animal, created_by=vet.id, status='in_progress')
+        item = OrcamentoItem(consulta=consulta, descricao='Consulta', valor=50)
+        db.session.add_all([consulta, item])
+        db.session.commit()
+        consulta_id = consulta.id
+
+    client = app.test_client()
+    with client:
+        client.post('/login', data={'email': 'vet@example.com', 'password': 'x'}, follow_redirects=True)
+        resp = client.post(f'/consulta/{consulta_id}/bloco_orcamento', headers={'Accept': 'application/json'})
+        assert resp.status_code == 200
+        with app.app_context():
+            bloco = BlocoOrcamento.query.first()
+            bloco_id = bloco.id
+
+        class FakePrefService:
+            def create(self, data):
+                return {'status': 201, 'response': {'init_point': 'http://mp'}}
+
+        class FakeSDK:
+            def preference(self):
+                return FakePrefService()
+
+        monkeypatch.setattr(app_module, 'mp_sdk', lambda: FakeSDK())
+        resp = client.get(f'/pagar_bloco_orcamento/{bloco_id}')
+        assert resp.status_code == 302
+        assert resp.headers['Location'] == 'http://mp'
+
+    with app.app_context():
+        db.drop_all()


### PR DESCRIPTION
## Summary
- Move print and pay actions from the edit form to the budget history list
- Add route to pay saved budget blocks and link to it from history
- Cover budget block payments with dedicated test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b58c36e8832ea565f63e034e35e1