### PR TITLE
Include non-vet staff with null worker in clinic detail

### DIFF
--- a/app.py
+++ b/app.py
@@ -2027,7 +2027,7 @@ def clinic_detail(clinica_id):
     veterinarios = Veterinario.query.filter_by(clinica_id=clinica_id).all()
     staff_members = ClinicStaff.query.filter(
         ClinicStaff.clinic_id == clinica.id,
-        ClinicStaff.user.has(User.worker != 'veterinario'),
+        ClinicStaff.user.has(or_(User.worker != 'veterinario', User.worker.is_(None))),
     ).all()
 
     staff_permission_forms = {}


### PR DESCRIPTION
## Summary
- Include non-veterinarian staff even when their `worker` field is null in clinic detail staff list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3b751d4ec832ea59239f65e0c0543