### PR TITLE
Show clinic stock inline on clinic page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1929,6 +1929,21 @@ def clinic_detail(clinica_id):
             .filter(Clinica.id == clinica_id)
             .first_or_404()
         )
+    is_owner = current_user.id == clinica.owner_id if current_user.is_authenticated else False
+    staff = None
+    if current_user.is_authenticated:
+        staff = ClinicStaff.query.filter_by(clinic_id=clinica.id, user_id=current_user.id).first()
+    has_inventory_perm = staff.can_manage_inventory if staff else False
+    show_inventory = _is_admin() or is_owner or has_inventory_perm
+    inventory_form = InventoryItemForm() if show_inventory else None
+    inventory_items = []
+    if show_inventory:
+        inventory_items = (
+            ClinicInventoryItem.query
+            .filter_by(clinica_id=clinica.id)
+            .order_by(ClinicInventoryItem.name)
+            .all()
+        )
     hours_form = ClinicHoursForm()
     clinic_form = ClinicForm(obj=clinica)
     vets_form = ClinicAddVeterinarianForm()
@@ -2179,6 +2194,9 @@ def clinic_detail(clinica_id):
         today_str=today_str,
         next7_str=next7_str,
         now=now_dt,
+        inventory_items=inventory_items,
+        inventory_form=inventory_form,
+        show_inventory=show_inventory,
     )
 
 
@@ -2194,26 +2212,31 @@ def clinic_stock(clinica_id):
     if not (_is_admin() or is_owner or has_perm):
         abort(403)
 
-    form = InventoryItemForm()
-    if form.validate_on_submit():
+    inventory_form = InventoryItemForm()
+    if inventory_form.validate_on_submit():
         item = ClinicInventoryItem(
             clinica_id=clinica.id,
-            name=form.name.data,
-            quantity=form.quantity.data,
-            unit=form.unit.data,
+            name=inventory_form.name.data,
+            quantity=inventory_form.quantity.data,
+            unit=inventory_form.unit.data,
         )
         db.session.add(item)
         db.session.commit()
         flash('Item adicionado com sucesso.', 'success')
-        return redirect(url_for('clinic_stock', clinica_id=clinica.id))
+        return redirect(url_for('clinic_detail', clinica_id=clinica.id) + '#estoque')
 
-    items = (
+    inventory_items = (
         ClinicInventoryItem.query
         .filter_by(clinica_id=clinica.id)
         .order_by(ClinicInventoryItem.name)
         .all()
     )
-    return render_template('clinic_stock.html', clinica=clinica, items=items, form=form)
+    return render_template(
+        'clinic_stock.html',
+        clinica=clinica,
+        inventory_items=inventory_items,
+        inventory_form=inventory_form,
+    )
 
 
 @app.route('/estoque/item/<int:item_id>/atualizar', methods=['POST'])
@@ -2235,7 +2258,7 @@ def update_inventory_item(item_id):
     item.quantity = max(0, qty)
     db.session.commit()
     flash('Quantidade atualizada.', 'success')
-    return redirect(url_for('clinic_stock', clinica_id=clinica.id))
+    return redirect(url_for('clinic_detail', clinica_id=clinica.id) + '#estoque')
 
 
 @app.route('/clinica/<int:clinica_id>/novo_orcamento', methods=['GET', 'POST'])

--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -34,12 +34,14 @@
         <span class="fw-semibold">Tutores</span>
       </button>
     </li>
+    {% if show_inventory %}
     <li class="nav-item" role="presentation">
-      <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('clinic_stock', clinica_id=clinica.id) }}">
+      <button class="nav-link d-flex align-items-center gap-2" id="estoque-tab" data-bs-toggle="tab" data-bs-target="#estoque" type="button" role="tab">
         <span class="icon-circle bg-warning text-dark"><i class="fa-solid fa-boxes"></i></span>
         <span class="fw-semibold">Estoque</span>
-      </a>
+      </button>
     </li>
+    {% endif %}
     <li class="nav-item" role="presentation">
       <button class="nav-link d-flex align-items-center gap-2" id="orcamento-tab" data-bs-toggle="tab" data-bs-target="#orcamento" type="button" role="tab">
         <span class="icon-circle bg-dark text-white"><i class="fa-solid fa-file-invoice-dollar"></i></span>
@@ -292,6 +294,11 @@
     <div class="tab-pane fade" id="tutores" role="tabpanel">
       {% include 'partials/tutores_adicionados.html' %}
     </div>
+    {% if show_inventory %}
+    <div class="tab-pane fade" id="estoque" role="tabpanel">
+      {% include 'partials/clinic_stock.html' %}
+    </div>
+    {% endif %}
     <div class="tab-pane fade" id="orcamento" role="tabpanel">
       <div class="d-flex justify-content-between align-items-center mb-3 mt-3">
         <h3 class="mb-0">Orçamentos</h3>

--- a/templates/clinic_stock.html
+++ b/templates/clinic_stock.html
@@ -1,45 +1,6 @@
 {% extends "layout.html" %}
 {% block main %}
 <div class="container mt-4">
-  <h2>Estoque da Clínica {{ clinica.nome }}</h2>
-  <table class="table table-striped mt-3">
-    <thead>
-      <tr>
-        <th>Insumo</th>
-        <th style="width:180px;">Quantidade</th>
-        <th>Unidade</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for item in items %}
-      <tr>
-        <td>{{ item.name }}</td>
-        <td>
-          <form method="post" action="{{ url_for('update_inventory_item', item_id=item.id) }}" class="d-flex">
-            {% if csrf_token %}{{ csrf_token() }}{% endif %}
-            <input type="number" name="quantity" value="{{ item.quantity }}" min="0" class="form-control form-control-sm me-2">
-            <button class="btn btn-sm btn-primary">Salvar</button>
-          </form>
-        </td>
-        <td>{{ item.unit or '-' }}</td>
-      </tr>
-      {% else %}
-      <tr>
-        <td colspan="3" class="text-center">Nenhum item no estoque.</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  <hr>
-  <h4>Adicionar Item</h4>
-  <form method="post">
-    {{ form.hidden_tag() }}
-    <div class="row g-2">
-      <div class="col-md-5">{{ form.name(class="form-control", placeholder="Nome") }}</div>
-      <div class="col-md-3">{{ form.quantity(class="form-control", placeholder="Quantidade") }}</div>
-      <div class="col-md-2">{{ form.unit(class="form-control", placeholder="Unidade") }}</div>
-      <div class="col-md-2">{{ form.submit(class="btn btn-success w-100") }}</div>
-    </div>
-  </form>
+  {% include 'partials/clinic_stock.html' %}
 </div>
 {% endblock %}

--- a/templates/partials/clinic_stock.html
+++ b/templates/partials/clinic_stock.html
@@ -1,0 +1,40 @@
+<h3>Estoque da Clínica {{ clinica.nome }}</h3>
+<table class="table table-striped mt-3">
+  <thead>
+    <tr>
+      <th>Insumo</th>
+      <th style="width:180px;">Quantidade</th>
+      <th>Unidade</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in inventory_items %}
+    <tr>
+      <td>{{ item.name }}</td>
+      <td>
+        <form method="post" action="{{ url_for('update_inventory_item', item_id=item.id) }}" class="d-flex">
+          {% if csrf_token %}{{ csrf_token() }}{% endif %}
+          <input type="number" name="quantity" value="{{ item.quantity }}" min="0" class="form-control form-control-sm me-2">
+          <button class="btn btn-sm btn-primary">Salvar</button>
+        </form>
+      </td>
+      <td>{{ item.unit or '-' }}</td>
+    </tr>
+    {% else %}
+    <tr>
+      <td colspan="3" class="text-center">Nenhum item no estoque.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<hr>
+<h4>Adicionar Item</h4>
+<form method="post" action="{{ url_for('clinic_stock', clinica_id=clinica.id) }}">
+  {{ inventory_form.hidden_tag() }}
+  <div class="row g-2">
+    <div class="col-md-5">{{ inventory_form.name(class="form-control", placeholder="Nome") }}</div>
+    <div class="col-md-3">{{ inventory_form.quantity(class="form-control", placeholder="Quantidade") }}</div>
+    <div class="col-md-2">{{ inventory_form.unit(class="form-control", placeholder="Unidade") }}</div>
+    <div class="col-md-2">{{ inventory_form.submit(class="btn btn-success w-100") }}</div>
+  </div>
+</form>

--- a/tests/test_clinic_inventory.py
+++ b/tests/test_clinic_inventory.py
@@ -27,8 +27,9 @@ def test_clinic_inventory_page(app, monkeypatch):
     monkeypatch.setattr(login_utils, '_get_user', lambda: User.query.get(user_id))
     monkeypatch.setattr(app_module, '_is_admin', lambda: False)
 
-    response = client.get(f'/clinica/{clinic_id}/estoque')
+    response = client.get(f'/clinica/{clinic_id}')
     assert response.status_code == 200
+    assert b'Estoque' in response.data
 
     response = client.post(
         f'/clinica/{clinic_id}/estoque',


### PR DESCRIPTION
## Summary
- Render clinic inventory as a tab within the clinic detail page
- Add partial template for inventory and pass data through backend
- Redirect stock updates back to clinic detail

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3b7dc9300832eb88679d1359c6baa