### PR TITLE
Atualiza cards da clínica com edição inline

### DIFF
--- a/templates/partials/clinic_info.html
+++ b/templates/partials/clinic_info.html
@@ -25,31 +25,34 @@
         <p><i class="fas fa-envelope text-primary me-2"></i><strong>Email:</strong> {{ clinica.email }}</p>
       {% endif %}
     </div>
-  </div>
-</div>
 
-<!-- Calendário -->
-<div class="card shadow-sm border-0 rounded-3 mb-4">
-  <div class="card-header bg-light d-flex justify-content-between align-items-center">
-    <h5 class="mb-0"><i class="far fa-calendar-alt me-2"></i>Calendário da Clínica</h5>
-    <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse" data-bs-target="#clinicCalendar">Mostrar</button>
-  </div>
-  <div id="clinicCalendar" class="collapse">
-    <div class="card-body">
-      {% with clinic_id=clinica.id, calendar_id='clinic-calendar', toggle_id='clinic-agenda-toggle', include_assets=True %}
-        {% include 'partials/schedule_toggle.html' %}
-      {% endwith %}
-    </div>
+    {% if pode_editar %}
+      <button class="btn btn-sm btn-outline-primary mt-3" onclick="toggleEditInfo()">Editar</button>
+      <div id="edit-info" class="mt-3" style="display:none;">
+        <form method="post" enctype="multipart/form-data" class="row g-3">
+          {{ clinic_form.hidden_tag() }}
+          <div class="col-md-6">{{ clinic_form.nome.label }} {{ clinic_form.nome(class="form-control") }}</div>
+          <div class="col-md-6">{{ clinic_form.cnpj.label }} {{ clinic_form.cnpj(class="form-control") }}</div>
+          <div class="col-md-12">{{ clinic_form.endereco.label }} {{ clinic_form.endereco(class="form-control") }}</div>
+          <div class="col-md-6">{{ clinic_form.telefone.label }} {{ clinic_form.telefone(class="form-control") }}</div>
+          <div class="col-md-6">{{ clinic_form.email.label }} {{ clinic_form.email(class="form-control") }}</div>
+          <div class="col-md-12">
+            {{ clinic_form.logotipo.label }}
+            {{ photo_cropper(clinic_form.logotipo, clinic_form.photo_rotation, clinic_form.photo_zoom, clinic_form.photo_offset_x, clinic_form.photo_offset_y, clinica.logotipo, 150, 'clinic_logo', 'user') }}
+          </div>
+          <div class="col-12">
+            {{ clinic_form.submit(class="btn btn-primary") }}
+          </div>
+        </form>
+      </div>
+    {% endif %}
   </div>
 </div>
 
 <!-- Horários -->
 <div class="card shadow-sm border-0 rounded-3 mb-4">
-  <div class="card-header bg-light d-flex justify-content-between align-items-center">
+  <div class="card-header bg-light">
     <h5 class="mb-0"><i class="far fa-clock me-2"></i>Horários de Atendimento</h5>
-    {% if pode_editar %}
-      <button class="btn btn-sm btn-outline-primary" onclick="toggleEditHours()">Editar</button>
-    {% endif %}
   </div>
   <div class="card-body">
     <div class="table-responsive">
@@ -92,7 +95,8 @@
     </div>
 
     {% if pode_editar %}
-      <div id="edit-hours" class="mt-4" style="display:none;">
+      <button class="btn btn-sm btn-outline-primary mt-3" onclick="toggleEditHours()">Editar</button>
+      <div id="edit-hours" class="mt-3" style="display:none;">
         <form method="post" class="row g-3">
           {{ form.hidden_tag() }}
           <div class="col-md-12">
@@ -121,29 +125,3 @@
     {% endif %}
   </div>
 </div>
-
-<!-- Editar Clínica -->
-{% if pode_editar %}
-<div class="card shadow-sm border-0 rounded-3 mb-4">
-  <div class="card-header bg-light">
-    <h5 class="mb-0"><i class="fas fa-edit me-2"></i>Editar Informações da Clínica</h5>
-  </div>
-  <div class="card-body" id="edit-info" style="display:none;">
-    <form method="post" enctype="multipart/form-data" class="row g-3">
-      {{ clinic_form.hidden_tag() }}
-      <div class="col-md-6">{{ clinic_form.nome.label }} {{ clinic_form.nome(class="form-control") }}</div>
-      <div class="col-md-6">{{ clinic_form.cnpj.label }} {{ clinic_form.cnpj(class="form-control") }}</div>
-      <div class="col-md-12">{{ clinic_form.endereco.label }} {{ clinic_form.endereco(class="form-control") }}</div>
-      <div class="col-md-6">{{ clinic_form.telefone.label }} {{ clinic_form.telefone(class="form-control") }}</div>
-      <div class="col-md-6">{{ clinic_form.email.label }} {{ clinic_form.email(class="form-control") }}</div>
-      <div class="col-md-12">
-        {{ clinic_form.logotipo.label }}
-        {{ photo_cropper(clinic_form.logotipo, clinic_form.photo_rotation, clinic_form.photo_zoom, clinic_form.photo_offset_x, clinic_form.photo_offset_y, clinica.logotipo, 150, 'clinic_logo', 'user') }}
-      </div>
-      <div class="col-12">
-        {{ clinic_form.submit(class="btn btn-primary") }}
-      </div>
-    </form>
-  </div>
-</div>
-{% endif %}


### PR DESCRIPTION
## Summary
- Mostra informações da clínica em um único card com botão de edição e formulário embutido
- Remove calendário da aba da clínica
- Move botão de edição de horários para o final do card de horários

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3bd4db554832e985e54863907265f