### PR TITLE
Fix agenda calendar sources and broaden appointments API

### DIFF
--- a/app.py
+++ b/app.py
@@ -6422,13 +6422,16 @@ def delete_appointment(appointment_id):
 def api_my_appointments():
     """Return the current user's appointments as calendar events."""
     if current_user.worker == 'veterinario' and getattr(current_user, 'veterinario', None):
-        appts = Appointment.query.filter_by(
+        query = Appointment.query.filter_by(
             veterinario_id=current_user.veterinario.id
-        ).order_by(Appointment.scheduled_at).all()
+        )
+    elif current_user.worker == 'colaborador' and current_user.clinica_id:
+        query = Appointment.query.filter_by(clinica_id=current_user.clinica_id)
+    elif current_user.role == 'admin':
+        query = Appointment.query
     else:
-        appts = Appointment.query.filter_by(
-            tutor_id=current_user.id
-        ).order_by(Appointment.scheduled_at).all()
+        query = Appointment.query.filter_by(tutor_id=current_user.id)
+    appts = query.order_by(Appointment.scheduled_at).all()
     return jsonify(appointments_to_events(appts))
 
 

--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -32,12 +32,17 @@ document.addEventListener('DOMContentLoaded', function() {
     return '/api/my_appointments';
   }
 
+  function addEvents() {
+    calendar.removeAllEventSources();
+    calendar.addEventSource(eventUrl());
+  }
+
   const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
-    events: eventUrl(),
   });
 
   window.sharedCalendar = calendar;
+  addEvents();
   calendar.render();
 
   if (toggle) {
@@ -46,8 +51,7 @@ document.addEventListener('DOMContentLoaded', function() {
         toggle.querySelectorAll('button').forEach(b => b.classList.remove('active'));
         this.classList.add('active');
         source = this.dataset.source;
-        calendar.setOption('events', eventUrl());
-        calendar.refetchEvents();
+        addEvents();
       });
     });
   }

--- a/tests/test_appointment_events_api.py
+++ b/tests/test_appointment_events_api.py
@@ -73,3 +73,38 @@ def test_clinic_appointments_returns_events(client, monkeypatch):
     data = resp.get_json()
     assert len(data) == 1
     assert data[0]['id'] == appt_id
+
+
+def test_my_appointments_returns_clinic_events_for_collaborator(client, monkeypatch):
+    with flask_app.app_context():
+        tutor_id, vet_user_id, clinic_id, appt_id, start_iso = create_basic_appointment()
+    fake_colab = type('U', (), {
+        'id': 3,
+        'worker': 'colaborador',
+        'role': 'adotante',
+        'clinica_id': clinic_id,
+        'is_authenticated': True,
+    })()
+    login(monkeypatch, fake_colab)
+    resp = client.get('/api/my_appointments')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['id'] == appt_id
+
+
+def test_my_appointments_returns_all_for_admin(client, monkeypatch):
+    with flask_app.app_context():
+        tutor_id, vet_user_id, clinic_id, appt_id, start_iso = create_basic_appointment()
+    fake_admin = type('U', (), {
+        'id': 99,
+        'worker': None,
+        'role': 'admin',
+        'is_authenticated': True,
+    })()
+    login(monkeypatch, fake_admin)
+    resp = client.get('/api/my_appointments')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['id'] == appt_id


### PR DESCRIPTION
## Summary
- Reload calendar events properly when switching between personal and clinic views
- Expose appointments to collaborators and admins via `/api/my_appointments`
- Extend tests for additional roles

## Testing
- `python -m pytest tests/test_appointment_events_api.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3bdb52b3c832ea8fd90ebe912f713