### PR TITLE
Allow veterinarians to create clinic when none exists

### DIFF
--- a/app.py
+++ b/app.py
@@ -1863,8 +1863,6 @@ def clinicas():
 def minha_clinica():
     clinicas = clinicas_do_usuario().all()
     if not clinicas:
-        if getattr(current_user, 'veterinario', None):
-            abort(404)
         form = ClinicForm()
         if form.validate_on_submit():
             clinica = Clinica(

--- a/tests/test_clinic_vet.py
+++ b/tests/test_clinic_vet.py
@@ -21,6 +21,7 @@ def app():
 
 def test_add_veterinarian_sets_clinic(app):
     with app.app_context():
+        db.drop_all()
         db.create_all()
         clinic = Clinica(id=1, nome='Clinica', owner_id=1)
         user = User(id=2, name='Vet', email='vet@test', password_hash='x')
@@ -37,3 +38,6 @@ def test_add_veterinarian_sets_clinic(app):
         db.session.commit()
 
         assert vet.clinica_id == clinic.id
+
+        db.session.remove()
+        db.drop_all()

--- a/tests/test_remove_vet_access.py
+++ b/tests/test_remove_vet_access.py
@@ -43,7 +43,12 @@ def test_removed_vet_cannot_access_clinic(monkeypatch, app):
         login(monkeypatch, owner)
         client.post(f'/clinica/{clinic.id}/veterinario/{vet.id}/remove')
 
-        # Vet no longer has access
+        # Vet no longer has access to the old clinic
         login(monkeypatch, vet_user)
-        resp = client.get('/minha-clinica')
+        resp = client.get(f'/clinica/{clinic.id}')
         assert resp.status_code == 404
+
+        # But can create a new clinic
+        resp = client.get('/minha-clinica')
+        assert resp.status_code == 200
+        assert b'Criar Cl' in resp.data


### PR DESCRIPTION
## Summary
- Show clinic creation form to veterinarians without an associated clinic
- Add tests ensuring vets without a clinic can create one and removed vets can't access old clinics
- Reset test database state for clinic vet test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b43c0c5230832eb3b5cc5b92b91cc2