### PR TITLE
Restore budget access for non-veterinary staff

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -314,13 +314,17 @@
             <td>{{ o.descricao }}</td>
             <td>
               {% if o.consulta %}
-              <a href="{{ url_for('consulta_direct', animal_id=o.consulta.animal_id, c=o.consulta.id) }}#orcamento" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
-              <a href="mailto:{{ o.consulta.animal.owner.email }}?subject=Orçamento&body={{ url_for('imprimir_orcamento', consulta_id=o.consulta.id, _external=True)|urlencode }}" class="btn btn-sm btn-outline-primary">E-mail</a>
-              <a href="https://api.whatsapp.com/send?phone={{ o.consulta.animal.owner.phone }}&text={{ ('Olá ' ~ o.consulta.animal.owner.name ~ '! Segue o orçamento para ' ~ o.consulta.animal.name ~ ': ' ~ url_for('imprimir_orcamento', consulta_id=o.consulta.id, _external=True))|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
+                {% if current_user.worker in ['veterinario', 'colaborador'] %}
+                <a href="{{ url_for('consulta_direct', animal_id=o.consulta.animal_id, c=o.consulta.id) }}#orcamento" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
+                {% else %}
+                <a href="{{ url_for('editar_orcamento', orcamento_id=o.id) }}" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
+                {% endif %}
+                <a href="mailto:{{ o.consulta.animal.owner.email }}?subject=Orçamento&body={{ url_for('imprimir_orcamento', consulta_id=o.consulta.id, _external=True)|urlencode }}" class="btn btn-sm btn-outline-primary">E-mail</a>
+                <a href="https://api.whatsapp.com/send?phone={{ o.consulta.animal.owner.phone }}&text={{ ('Olá ' ~ o.consulta.animal.owner.name ~ '! Segue o orçamento para ' ~ o.consulta.animal.name ~ ': ' ~ url_for('imprimir_orcamento', consulta_id=o.consulta.id, _external=True))|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
               {% else %}
-              <a href="{{ url_for('editar_orcamento', orcamento_id=o.id) }}" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
-              <a href="mailto:?subject=Orçamento&body={{ url_for('editar_orcamento', orcamento_id=o.id, _external=True) }}" class="btn btn-sm btn-outline-primary">E-mail</a>
-              <a href="https://api.whatsapp.com/send?text={{ url_for('editar_orcamento', orcamento_id=o.id, _external=True)|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
+                <a href="{{ url_for('editar_orcamento', orcamento_id=o.id) }}" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
+                <a href="mailto:?subject=Orçamento&body={{ url_for('editar_orcamento', orcamento_id=o.id, _external=True) }}" class="btn btn-sm btn-outline-primary">E-mail</a>
+                <a href="https://api.whatsapp.com/send?text={{ url_for('editar_orcamento', orcamento_id=o.id, _external=True)|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
               {% endif %}
             </td>
           </tr>

--- a/templates/orcamentos.html
+++ b/templates/orcamentos.html
@@ -15,13 +15,17 @@
         <td>{{ o.descricao }}</td>
         <td>
           {% if o.consulta %}
-          <a href="{{ url_for('consulta_direct', animal_id=o.consulta.animal_id, c=o.consulta.id) }}#orcamento" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
-          <a href="mailto:{{ o.consulta.animal.owner.email }}?subject=Orçamento&body={{ url_for('imprimir_orcamento', consulta_id=o.consulta.id, _external=True)|urlencode }}" class="btn btn-sm btn-outline-primary">E-mail</a>
-          <a href="https://api.whatsapp.com/send?phone={{ o.consulta.animal.owner.phone }}&text={{ ('Olá ' ~ o.consulta.animal.owner.name ~ '! Segue o orçamento para ' ~ o.consulta.animal.name ~ ': ' ~ url_for('imprimir_orcamento', consulta_id=o.consulta.id, _external=True))|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
+            {% if current_user.worker in ['veterinario', 'colaborador'] %}
+            <a href="{{ url_for('consulta_direct', animal_id=o.consulta.animal_id, c=o.consulta.id) }}#orcamento" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
+            {% else %}
+            <a href="{{ url_for('editar_orcamento', orcamento_id=o.id) }}" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
+            {% endif %}
+            <a href="mailto:{{ o.consulta.animal.owner.email }}?subject=Orçamento&body={{ url_for('imprimir_orcamento', consulta_id=o.consulta.id, _external=True)|urlencode }}" class="btn btn-sm btn-outline-primary">E-mail</a>
+            <a href="https://api.whatsapp.com/send?phone={{ o.consulta.animal.owner.phone }}&text={{ ('Olá ' ~ o.consulta.animal.owner.name ~ '! Segue o orçamento para ' ~ o.consulta.animal.name ~ ': ' ~ url_for('imprimir_orcamento', consulta_id=o.consulta.id, _external=True))|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
           {% else %}
-          <a href="{{ url_for('editar_orcamento', orcamento_id=o.id) }}" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
-          <a href="mailto:?subject=Orçamento&body={{ url_for('editar_orcamento', orcamento_id=o.id, _external=True) }}" class="btn btn-sm btn-outline-primary">E-mail</a>
-          <a href="https://api.whatsapp.com/send?text={{ url_for('editar_orcamento', orcamento_id=o.id, _external=True)|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
+            <a href="{{ url_for('editar_orcamento', orcamento_id=o.id) }}" class="btn btn-sm btn-outline-secondary">Ver/Editar</a>
+            <a href="mailto:?subject=Orçamento&body={{ url_for('editar_orcamento', orcamento_id=o.id, _external=True) }}" class="btn btn-sm btn-outline-primary">E-mail</a>
+            <a href="https://api.whatsapp.com/send?text={{ url_for('editar_orcamento', orcamento_id=o.id, _external=True)|urlencode }}" target="_blank" class="btn btn-sm btn-outline-success">WhatsApp</a>
           {% endif %}
         </td>
       </tr>


### PR DESCRIPTION
## Summary
- Gate consultation-linked budget links by worker role
- Fall back to standard budget editor for non-worker roles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b43d05d8f4832e9a9c7c189c1bc3c1