### PR TITLE
Handle missing clinic during bloco_orcamento migration

### DIFF
--- a/migrations/versions/c592f5b733c6_add_clinica_id_to_bloco_orcamento.py
+++ b/migrations/versions/c592f5b733c6_add_clinica_id_to_bloco_orcamento.py
@@ -22,6 +22,13 @@ def upgrade():
             'UPDATE bloco_orcamento bo SET clinica_id = a.clinica_id FROM animal a WHERE bo.animal_id = a.id'
         )
     )
+    # Ensure existing rows have a clinic even when the animal has none
+    op.execute(
+        sa.text(
+            'UPDATE bloco_orcamento bo SET clinica_id = (SELECT id FROM clinica ORDER BY id LIMIT 1) '
+            'WHERE bo.clinica_id IS NULL'
+        )
+    )
     op.alter_column('bloco_orcamento', 'clinica_id', nullable=False)
 
 def downgrade():


### PR DESCRIPTION
## Summary
- Set `clinica_id` for existing `bloco_orcamento` records even when their animals lack a clinic
- Prevent NOT NULL alteration from failing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b44840ec70832ebaf68177e23963bc