### PR TITLE
Fix clinic admin logo upload

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -251,8 +251,8 @@ class ClinicaAdmin(MyModelView):
     }
 
     def on_model_change(self, form, model, is_created):
-        if form.logotipo_upload.data:
-            file = form.logotipo_upload.data
+        file = form.logotipo_upload.data
+        if file and getattr(file, "filename", ""):
             filename = f"{uuid.uuid4().hex}_{secure_filename(file.filename)}"
             from app import upload_to_s3
             image_url = upload_to_s3(file, filename, folder="clinicas")

--- a/tests/test_clinica_admin_logo.py
+++ b/tests/test_clinica_admin_logo.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+from werkzeug.datastructures import FileStorage
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from admin import ClinicaAdmin  # noqa: E402
+from models import Clinica, db  # noqa: E402
+import app as app_module  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app_module.app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    yield app_module.app
+
+
+def make_file(filename: str = "logo.png") -> FileStorage:
+    img = Image.new("RGB", (1, 1))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return FileStorage(stream=buf, filename=filename, content_type="image/png")
+
+
+def test_admin_saves_clinic_logo(monkeypatch, app):
+    monkeypatch.setattr(app_module, "upload_to_s3", lambda *a, **k: "http://img")
+    view = ClinicaAdmin(Clinica, db.session)
+    form = SimpleNamespace(logotipo_upload=SimpleNamespace(data=make_file()))
+    clinic = Clinica(nome="Test")
+    view.on_model_change(form, clinic, True)
+    assert clinic.logotipo == "http://img"
+
+
+def test_admin_skips_empty_logo(monkeypatch, app):
+    monkeypatch.setattr(app_module, "upload_to_s3", lambda *a, **k: "http://img")
+    view = ClinicaAdmin(Clinica, db.session)
+    form = SimpleNamespace(logotipo_upload=SimpleNamespace(data=make_file("")))
+    clinic = Clinica(nome="Test", logotipo="existing")
+    view.on_model_change(form, clinic, False)
+    assert clinic.logotipo == "existing"


### PR DESCRIPTION
## Summary
- ensure clinic admin only uploads logo when a real file is provided
- add tests covering clinic logo upload behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4502eb4b4832e9852b22bc3991ed9