### PR TITLE
Handle missing S3 bucket by saving clinic logos locally

### DIFF
--- a/tests/test_s3_public_acl.py
+++ b/tests/test_s3_public_acl.py
@@ -27,5 +27,5 @@ def test_upload_to_s3_sets_public_read_acl(monkeypatch):
     assert captured['extra']['ACL'] == 'public-read'
     assert captured['extra']['ContentType'] == 'image/jpeg'
     assert captured['bucket'] == 'test-bucket'
-    assert captured['key'].startswith('clinicas/logo.png')
+    assert captured['key'].startswith('clinicas/logo.jpg')
     assert url == f"https://test-bucket.s3.amazonaws.com/{captured['key']}"

--- a/tests/test_upload_to_s3_local_fallback.py
+++ b/tests/test_upload_to_s3_local_fallback.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from io import BytesIO
+from PIL import Image
+from werkzeug.datastructures import FileStorage
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app  # noqa: E402
+
+
+def test_upload_to_s3_falls_back_to_local(tmp_path, monkeypatch):
+    monkeypatch.setattr(app, "BUCKET", None)
+    monkeypatch.setattr(app, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(app, "_s3", lambda: None)
+
+    img_bytes = BytesIO()
+    Image.new("RGB", (1, 1)).save(img_bytes, format="PNG")
+    img_bytes.seek(0)
+    fs = FileStorage(stream=img_bytes, filename="logo.png", content_type="image/png")
+
+    url = app.upload_to_s3(fs, "logo.png", folder="clinicas")
+
+    expected = tmp_path / "static" / "uploads" / "clinicas" / "logo.jpg"
+    assert expected.exists()
+    assert url == "/static/uploads/clinicas/logo.jpg"


### PR DESCRIPTION
## Summary
- fall back to local `static/uploads` when `S3_BUCKET_NAME` is missing so clinic logos still save
- add regression test for local fallback and update S3 ACL test for JPEG conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b452b30fd0832ebbaee42bcb2d1c01