### PR TITLE
Enable searching clinic owner by name

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -238,6 +238,12 @@ class ClinicaAdmin(MyModelView):
         'logotipo_upload': FileField('Logotipo')
     }
 
+    form_ajax_refs = {
+        'owner': {
+            'fields': ('name', 'email')
+        }
+    }
+
     form_columns = [
         'nome', 'cnpj', 'endereco', 'telefone', 'email', 'logotipo_upload', 'owner'
     ]


### PR DESCRIPTION
## Summary
- add AJAX user name search for clinic owner field in admin panel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b454eec6a0832e8d099caf41b4a637