### PR TITLE
Handle long text wrapping in print templates

### DIFF
--- a/static/print.css
+++ b/static/print.css
@@ -101,6 +101,8 @@ footer {
   line-height: 1.5;
   border-radius: 4px;
   background-color: #f9f9f9;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 .info-box strong {
@@ -115,6 +117,8 @@ footer {
   line-height: 1.6;
   margin-bottom: 1.8em;
   border-radius: 4px;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 .prescricao-item, .exame-item {

--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -76,7 +76,7 @@
   <!-- Instruções Gerais -->
   {% if bloco.instrucoes_gerais %}
     <div class="section-title">Orientações e Cuidados</div>
-    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6;">
+    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
       {{ bloco.instrucoes_gerais }}
     </div>
   {% endif %}

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -54,22 +54,22 @@
   </div>
 
   <div class="section-title">Motivo da Consulta</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
     {{ consulta.queixa_principal or '—' }}
   </div>
 
   <div class="section-title">Histórico Clínico</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
     {{ consulta.historico_clinico or '—' }}
   </div>
 
   <div class="section-title">Exame Físico</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
     {{ consulta.exame_fisico or '—' }}
   </div>
 
   <div class="section-title">Conduta Médica</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
     {{ consulta.conduta or '—' }}
   </div>
 

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -90,7 +90,7 @@
 
   {% if bloco.observacoes_gerais %}
     <div class="section-title">Observações</div>
-    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6;">
+    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
       {{ bloco.observacoes_gerais }}
     </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- allow long text to wrap inside print containers
- preserve manual line breaks in consultation, exam, and prescription templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b457eea958832ea59935548ccb4dbf