### PR TITLE
Simplify print headers and improve logo path handling

### DIFF
--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -18,13 +18,15 @@
 
 <div class="document">
   <!-- Cabeçalho com logo -->
-  {% if clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica and clinica.logotipo %}
+    {% set logo_src = (
+      clinica.logotipo if clinica.logotipo.startswith('http')
+      else url_for('static', filename=clinica.logotipo) if clinica.logotipo.startswith('uploads/clinicas/')
+      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo)
+    ) %}
     <div class="header">
       <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -17,12 +17,14 @@
 
 <div class="document">
   {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+    {% set logo_src = (
+      clinica.logotipo if clinica.logotipo.startswith('http')
+      else url_for('static', filename=clinica.logotipo) if clinica.logotipo.startswith('uploads/clinicas/')
+      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo)
+    ) %}
     <div class="header">
       <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -16,13 +16,15 @@
 </div>
 
 <div class="document">
-  {% if clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica and clinica.logotipo %}
+    {% set logo_src = (
+      clinica.logotipo if clinica.logotipo.startswith('http')
+      else url_for('static', filename=clinica.logotipo) if clinica.logotipo.startswith('uploads/clinicas/')
+      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo)
+    ) %}
     <div class="header">
       <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 

--- a/templates/imprimir_orcamento.html
+++ b/templates/imprimir_orcamento.html
@@ -17,12 +17,14 @@
 
 <div class="document">
   {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+    {% set logo_src = (
+      clinica.logotipo if clinica.logotipo.startswith('http')
+      else url_for('static', filename=clinica.logotipo) if clinica.logotipo.startswith('uploads/clinicas/')
+      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo)
+    ) %}
     <div class="header">
       <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 

--- a/templates/imprimir_orcamento_padrao.html
+++ b/templates/imprimir_orcamento_padrao.html
@@ -13,11 +13,14 @@
 </div>
 <div class="document">
   {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http') else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+    {% set logo_src = (
+      clinica.logotipo if clinica.logotipo.startswith('http')
+      else url_for('static', filename=clinica.logotipo) if clinica.logotipo.startswith('uploads/clinicas/')
+      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo)
+    ) %}
     <div class="header">
       <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
   <h2>Orçamento</h2>

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -16,12 +16,14 @@
 
 <div class="document">
   {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+    {% set logo_src = (
+      clinica.logotipo if clinica.logotipo.startswith('http')
+      else url_for('static', filename=clinica.logotipo) if clinica.logotipo.startswith('uploads/clinicas/')
+      else url_for('static', filename='uploads/clinicas/' + clinica.logotipo)
+    ) %}
     <div class="header">
       <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
     </div>
   {% endif %}
 


### PR DESCRIPTION
## Summary
- streamline print template headers to use one logo image and clinic name
- resolve logo path for absolute URLs, pre-prefixed uploads paths, or plain filenames

## Testing
- `pytest -q`
- `python - <<'PY'
from jinja2 import Environment, FileSystemLoader
from types import SimpleNamespace

def url_for(endpoint, **kwargs):
    if endpoint == 'static':
        return '/static/' + kwargs['filename']
    else:
        return '/' + endpoint

env = Environment(loader=FileSystemLoader('templates'))
template = env.get_template('imprimir_consulta.html')

class Clinica(SimpleNamespace):
    pass

scenarios = [
    Clinica(nome='C1', logotipo='http://example.com/logo.png'),
    Clinica(nome='C2', logotipo='uploads/clinicas/logo2.png'),
    Clinica(nome='C3', logotipo='logo3.png'),
]

for c in scenarios:
    html = template.render(clinica=c, animal=SimpleNamespace(name='A'), tutor=SimpleNamespace(name='T'),
                           current_user=SimpleNamespace(name='U', veterinario=None), consulta=SimpleNamespace(),
                           url_for=url_for)
    import re
    match = re.search(r'<img src="([^"]+)"', html)
    print(c.logotipo, '->', match.group(1) if match else 'no match')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b4580d4f64832e88259d46d5440737