### PR TITLE
Add generic term generation view with print and WhatsApp sharing

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,7 @@ from flask import (
 )
 from twilio.rest import Client
 from itsdangerous import URLSafeTimedSerializer
+from jinja2 import TemplateNotFound
 import json
 from sqlalchemy import func, or_, exists
 
@@ -1322,6 +1323,26 @@ def termo_transferencia(animal_id, user_id):
     return render_template('termo_transferencia.html', animal=animal, novo_dono=novo_dono)
 
 
+
+
+@app.route('/termo/<int:animal_id>/<tipo>')
+@login_required
+def gerar_termo(animal_id, tipo):
+    """Gera um termo específico para um animal."""
+    animal = get_animal_or_404(animal_id)
+    tutor = animal.owner
+    veterinario = current_user.veterinario
+    template_name = f'termos/{tipo}.html'
+    try:
+        return render_template(
+            template_name,
+            animal=animal,
+            tutor=tutor,
+            veterinario=veterinario,
+            tipo=tipo,
+        )
+    except TemplateNotFound:
+        abort(404)
 
 
 @app.route("/plano-saude")

--- a/templates/termos/modelo.html
+++ b/templates/termos/modelo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Termo {{ tipo|capitalize }} - {{ animal.name }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}">
+</head>
+<body>
+<div class="no-print">
+  <button onclick="window.print()">🖨️ Imprimir</button>
+  <button onclick="enviarWhatsApp()" id="btn-whatsapp">📱 WhatsApp</button>
+  <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}">← Voltar</a>
+</div>
+
+<div class="document">
+  <h2>Termo {{ tipo|capitalize }}</h2>
+  <p><strong>Animal:</strong> {{ animal.name }}</p>
+  <p><strong>Tutor:</strong> {{ tutor.name if tutor else '—' }}</p>
+  <p><strong>Veterinário:</strong> {{ veterinario.user.name if veterinario else current_user.name }}</p>
+  <p>Conteúdo do termo aqui...</p>
+</div>
+
+<script>
+  const numeroWhatsApp = "{{ tutor.phone | digits_only if tutor and tutor.phone else '' }}";
+  const btnWhats = document.getElementById('btn-whatsapp');
+  if (!numeroWhatsApp && btnWhats) { btnWhats.style.display = 'none'; }
+
+  function enviarWhatsApp() {
+    if (!numeroWhatsApp) {
+      alert('Número de telefone do tutor não informado.');
+      return;
+    }
+    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de {{ tipo }} de {{ animal.name }}:\n\n${window.location.href}`);
+    const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
+    try {
+      const wpp = window.open(url, '_blank');
+      if (!wpp) {
+        alert('Não foi possível abrir o WhatsApp. Verifique o bloqueador de pop-ups.');
+      }
+    } catch (err) {
+      console.error('Erro ao abrir WhatsApp:', err);
+      alert('Ocorreu um erro ao abrir o WhatsApp. Tente novamente.');
+    }
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `gerar_termo` view to render term templates for animals
- create example term template with print and WhatsApp share buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b459ee1038832ea1ce945399a36647