### PR TITLE
Add signed term upload and standardized document naming

### DIFF
--- a/templates/termo_interesse.html
+++ b/templates/termo_interesse.html
@@ -49,4 +49,10 @@
     </div>
     <button class="btn btn-success" type="submit">Confirmar Interesse</button>
 </form>
+
+<form action="{{ url_for('upload_document', animal_id=animal.id) }}" method="post" enctype="multipart/form-data" class="mt-3">
+    <input type="hidden" name="descricao" value="termo_interesse">
+    <input type="file" id="termo_interesse_assinado" name="documento" class="d-none" onchange="this.form.submit()">
+    <button type="button" class="btn btn-secondary" onclick="document.getElementById('termo_interesse_assinado').click()">Enviar termo assinado</button>
+</form>
 {% endblock %}

--- a/templates/termo_transferencia.html
+++ b/templates/termo_transferencia.html
@@ -44,4 +44,10 @@
     <button class="btn btn-success" type="submit">Transferir Tutoria</button>
     <a href="{{ url_for('conversa', animal_id=animal.id, user_id=novo_dono.id) }}" class="btn btn-secondary ms-2">Cancelar</a>
 </form>
+
+<form action="{{ url_for('upload_document', animal_id=animal.id) }}" method="post" enctype="multipart/form-data" class="mt-3">
+    <input type="hidden" name="descricao" value="termo_transferencia">
+    <input type="file" id="termo_transferencia_assinado" name="documento" class="d-none" onchange="this.form.submit()">
+    <button type="button" class="btn btn-secondary" onclick="document.getElementById('termo_transferencia_assinado').click()">Enviar termo assinado</button>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add "Enviar termo assinado" button to term pages for direct upload
- Standardize document naming in `upload_document` based on term type

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b459ef3060832e9acdab3355449dfc