### PR TITLE
Add consultation follow-up scheduling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1735,6 +1735,23 @@ def consulta_direct(animal_id):
     form = AnimalForm(obj=animal)
     tutor_form = EditProfileForm(obj=tutor)
 
+    appointment_form = None
+    if consulta:
+        appointment_form = AppointmentForm()
+        appointment_form.animal_id.choices = [(animal.id, animal.name)]
+        appointment_form.animal_id.data = animal.id
+        vet_obj = None
+        if consulta.veterinario and getattr(consulta.veterinario, "veterinario", None):
+            vet_obj = consulta.veterinario.veterinario
+        if vet_obj:
+            appointment_form.veterinario_id.choices = [(
+                vet_obj.id,
+                consulta.veterinario.name,
+            )]
+            appointment_form.veterinario_id.data = vet_obj.id
+
+    show_retorno_modal = request.args.get('agendar_retorno')
+
     # Idade e unidade (anos/meses)
     idade = ''
     idade_unidade = ''
@@ -1782,6 +1799,8 @@ def consulta_direct(animal_id):
         animal_idade=idade,
         animal_idade_unidade=idade_unidade,
         servicos=servicos,
+        appointment_form=appointment_form,
+        show_retorno_modal=show_retorno_modal,
     )
 
 
@@ -1796,7 +1815,38 @@ def finalizar_consulta(consulta_id):
 
     consulta.status = 'finalizada'
     db.session.commit()
-    flash('Consulta finalizada e registrada no histórico!', 'success')
+    flash('Consulta finalizada e registrada no histórico! Agende o retorno.', 'success')
+    return redirect(
+        url_for('consulta_direct', animal_id=consulta.animal_id, agendar_retorno=1)
+    )
+
+
+@app.route('/agendar_retorno/<int:consulta_id>', methods=['POST'])
+@login_required
+def agendar_retorno(consulta_id):
+    consulta = get_consulta_or_404(consulta_id)
+    if current_user.worker != 'veterinario':
+        abort(403)
+    form = AppointmentForm()
+    form.animal_id.choices = [(consulta.animal.id, consulta.animal.name)]
+    form.veterinario_id.choices = [
+        (consulta.veterinario.veterinario.id, consulta.veterinario.name)
+    ]
+    if form.validate_on_submit():
+        scheduled_at = datetime.combine(form.date.data, form.time.data)
+        appt = Appointment(
+            consulta_id=consulta.id,
+            animal_id=consulta.animal_id,
+            tutor_id=consulta.animal.owner.id,
+            veterinario_id=consulta.veterinario.veterinario.id,
+            scheduled_at=scheduled_at,
+            notes=form.reason.data,
+        )
+        db.session.add(appt)
+        db.session.commit()
+        flash('Retorno agendado com sucesso.', 'success')
+    else:
+        flash('Erro ao agendar retorno.', 'danger')
     return redirect(url_for('consulta_direct', animal_id=consulta.animal_id))
 
 

--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -208,6 +208,57 @@
   </div>
 {% endif %}
 
+{% if consulta and consulta.status == 'finalizada' and appointment_form %}
+  <div class="mt-3">
+    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#retornoModal">Agendar Retorno</button>
+  </div>
+
+  <div class="modal fade" id="retornoModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="POST" action="{{ url_for('agendar_retorno', consulta_id=consulta.id) }}">
+          <div class="modal-header">
+            <h5 class="modal-title">Agendar Retorno</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            {{ appointment_form.hidden_tag() }}
+            <input type="hidden" name="animal_id" value="{{ animal.id }}">
+            <input type="hidden" name="veterinario_id" value="{{ consulta.veterinario.veterinario.id }}">
+            <p><strong>Animal:</strong> {{ animal.name }}</p>
+            <p><strong>Veterinário:</strong> {{ consulta.veterinario.name }}</p>
+            <div class="mb-3">
+              {{ appointment_form.date.label(class='form-label') }}
+              {{ appointment_form.date(class='form-control', type='date') }}
+            </div>
+            <div class="mb-3">
+              {{ appointment_form.time.label(class='form-label') }}
+              {{ appointment_form.time(class='form-control', type='time') }}
+            </div>
+            <div class="mb-3">
+              {{ appointment_form.reason.label(class='form-label') }}
+              {{ appointment_form.reason(class='form-control', rows=3) }}
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            {{ appointment_form.submit(class='btn btn-primary') }}
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  {% if show_retorno_modal %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      var retornoModal = new bootstrap.Modal(document.getElementById('retornoModal'));
+      retornoModal.show();
+    });
+  </script>
+  {% endif %}
+{% endif %}
+
 <style>
   .icon-circle {
     width: 2rem;

--- a/tests/test_agendar_retorno.py
+++ b/tests/test_agendar_retorno.py
@@ -1,0 +1,92 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import flask_login.utils as login_utils
+from datetime import time
+from app import app as flask_app, db
+from models import (
+    User,
+    Animal,
+    Veterinario,
+    Appointment,
+    HealthPlan,
+    HealthSubscription,
+    Clinica,
+    Consulta,
+)
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def login(monkeypatch, user):
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def test_agendar_retorno_cria_appointment(client, monkeypatch):
+    with flask_app.app_context():
+        clinic = Clinica(id=1, nome='Clinica')
+        tutor = User(id=1, name='Tutor', email='tutor@test')
+        tutor.set_password('x')
+        vet_user = User(id=2, name='Vet', email='vet@test', worker='veterinario')
+        vet_user.set_password('x')
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123', clinica_id=clinic.id)
+        animal = Animal(id=1, name='Rex', user_id=tutor.id, clinica_id=clinic.id)
+        consulta = Consulta(id=1, animal_id=animal.id, created_by=vet_user.id, clinica_id=clinic.id, status='finalizada')
+        plan = HealthPlan(id=1, name='Basic', price=10.0)
+        db.session.add_all([clinic, tutor, vet_user, vet, animal, consulta, plan])
+        db.session.commit()
+        sub = HealthSubscription(animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True)
+        db.session.add(sub)
+        db.session.commit()
+        consulta_id = consulta.id
+        animal_id = animal.id
+        tutor_id = tutor.id
+        vet_id = vet.id
+        clinic_id = clinic.id
+        vet_user_id = vet_user.id
+    fake_vet = type('U', (), {
+        'id': vet_user_id,
+        'worker': 'veterinario',
+        'role': 'adotante',
+        'name': 'Vet',
+        'is_authenticated': True,
+        'veterinario': type('V', (), {
+            'id': vet_id,
+            'user': type('WU', (), {'name': 'Vet'})(),
+            'clinica_id': clinic_id,
+        })()
+    })()
+    login(monkeypatch, fake_vet)
+    resp = client.post(
+        f'/agendar_retorno/{consulta_id}',
+        data={
+            'animal_id': animal_id,
+            'veterinario_id': vet_id,
+            'date': '2024-05-01',
+            'time': '10:00',
+            'reason': 'Reavaliação',
+        }
+    )
+    assert resp.status_code == 302
+    with flask_app.app_context():
+        appt = Appointment.query.one()
+        assert appt.consulta_id == consulta_id
+        assert appt.animal_id == animal_id
+        assert appt.tutor_id == tutor_id
+        assert appt.veterinario_id == vet_id


### PR DESCRIPTION
## Summary
- allow veterinarians to schedule follow-up appointments linked to a consultation
- show scheduling modal on consultation page after finalization
- test that agendar_retorno creates Appointment associated with consultation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45a3060c8832e830b7559ae24de30