### PR TITLE
Improve print template headers and logo handling

### DIFF
--- a/static/print.css
+++ b/static/print.css
@@ -94,13 +94,15 @@ footer {
 }
 
 .info-box {
-  flex: 1;
-  border: 1px solid #e0e0e0;
-  padding: 12px 15px;
-  font-size: 10.5pt;
-  line-height: 1.5;
-  border-radius: 4px;
-  background-color: #f9f9f9;
+    flex: 1;
+    border: 1px solid #e0e0e0;
+    padding: 12px 15px;
+    font-size: 10.5pt;
+    line-height: 1.5;
+    border-radius: 4px;
+    background-color: #f9f9f9;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
 }
 
 .info-box strong {
@@ -108,13 +110,15 @@ footer {
 }
 
 .prescricao, .exames {
-  border: 1px solid #e0e0e0;
-  padding: 18px;
-  background-color: #f9f9f9;
-  font-size: 11pt;
-  line-height: 1.6;
-  margin-bottom: 1.8em;
-  border-radius: 4px;
+    border: 1px solid #e0e0e0;
+    padding: 18px;
+    background-color: #f9f9f9;
+    font-size: 11pt;
+    line-height: 1.6;
+    margin-bottom: 1.8em;
+    border-radius: 4px;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
 }
 
 .prescricao-item, .exame-item {

--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -18,13 +18,27 @@
 
 <div class="document">
   <!-- Cabeçalho com logo -->
-  {% if clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica and clinica.logotipo %}
+    {% set logo_path = clinica.logotipo %}
+    {% if logo_path.startswith('http') %}
+      {% set logo_src = logo_path %}
+    {% elif logo_path.startswith('static/') %}
+      {% set logo_src = url_for('static', filename=logo_path[7:]) %}
+    {% elif logo_path.startswith('/uploads/clinicas/') %}
+      {% set logo_src = url_for('static', filename=logo_path.lstrip('/')) %}
+    {% elif logo_path.startswith('uploads/clinicas/') %}
+      {% set logo_src = url_for('static', filename=logo_path) %}
+    {% else %}
+      {% set logo_src = url_for('static', filename='uploads/clinicas/' + logo_path) %}
+    {% endif %}
     <div class="header">
       <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      <img src="{{ logo_src }}" alt="" style="visibility: hidden; transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+    </div>
+  {% elif clinica %}
+    <div class="header">
+      <div class="clinica-nome">{{ clinica.nome }}</div>
     </div>
   {% endif %}
 
@@ -74,12 +88,12 @@
   </div>
 
   <!-- Instruções Gerais -->
-  {% if bloco.instrucoes_gerais %}
-    <div class="section-title">Orientações e Cuidados</div>
-    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6;">
-      {{ bloco.instrucoes_gerais }}
-    </div>
-  {% endif %}
+    {% if bloco.instrucoes_gerais %}
+      <div class="section-title">Orientações e Cuidados</div>
+      <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
+        {{ bloco.instrucoes_gerais }}
+      </div>
+    {% endif %}
 
   <!-- Assinatura -->
   <div class="assinaturas">

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -15,16 +15,30 @@
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}">← Voltar</a>
 </div>
 
-<div class="document">
-  {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
-    <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
-      <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
-    </div>
-  {% endif %}
+  <div class="document">
+    {% if clinica and clinica.logotipo %}
+      {% set logo_path = clinica.logotipo %}
+      {% if logo_path.startswith('http') %}
+        {% set logo_src = logo_path %}
+      {% elif logo_path.startswith('static/') %}
+        {% set logo_src = url_for('static', filename=logo_path[7:]) %}
+      {% elif logo_path.startswith('/uploads/clinicas/') %}
+        {% set logo_src = url_for('static', filename=logo_path.lstrip('/')) %}
+      {% elif logo_path.startswith('uploads/clinicas/') %}
+        {% set logo_src = url_for('static', filename=logo_path) %}
+      {% else %}
+        {% set logo_src = url_for('static', filename='uploads/clinicas/' + logo_path) %}
+      {% endif %}
+      <div class="header">
+        <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+        <div class="clinica-nome">{{ clinica.nome }}</div>
+        <img src="{{ logo_src }}" alt="" style="visibility: hidden; transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      </div>
+    {% elif clinica %}
+      <div class="header">
+        <div class="clinica-nome">{{ clinica.nome }}</div>
+      </div>
+    {% endif %}
 
   <h2>Relatório de Atendimento Clínico</h2>
 
@@ -54,22 +68,22 @@
   </div>
 
   <div class="section-title">Motivo da Consulta</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
     {{ consulta.queixa_principal or '—' }}
   </div>
 
   <div class="section-title">Histórico Clínico</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
     {{ consulta.historico_clinico or '—' }}
   </div>
 
   <div class="section-title">Exame Físico</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
     {{ consulta.exame_fisico or '—' }}
   </div>
 
   <div class="section-title">Conduta Médica</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
     {{ consulta.conduta or '—' }}
   </div>
 

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -16,13 +16,27 @@
 </div>
 
 <div class="document">
-  {% if clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica and clinica.logotipo %}
+    {% set logo_path = clinica.logotipo %}
+    {% if logo_path.startswith('http') %}
+      {% set logo_src = logo_path %}
+    {% elif logo_path.startswith('static/') %}
+      {% set logo_src = url_for('static', filename=logo_path[7:]) %}
+    {% elif logo_path.startswith('/uploads/clinicas/') %}
+      {% set logo_src = url_for('static', filename=logo_path.lstrip('/')) %}
+    {% elif logo_path.startswith('uploads/clinicas/') %}
+      {% set logo_src = url_for('static', filename=logo_path) %}
+    {% else %}
+      {% set logo_src = url_for('static', filename='uploads/clinicas/' + logo_path) %}
+    {% endif %}
     <div class="header">
       <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      <img src="{{ logo_src }}" alt="" style="visibility: hidden; transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+    </div>
+  {% elif clinica %}
+    <div class="header">
+      <div class="clinica-nome">{{ clinica.nome }}</div>
     </div>
   {% endif %}
 
@@ -88,12 +102,12 @@
     {% endfor %}
   </div>
 
-  {% if bloco.observacoes_gerais %}
-    <div class="section-title">Observações</div>
-    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6;">
-      {{ bloco.observacoes_gerais }}
-    </div>
-  {% endif %}
+    {% if bloco.observacoes_gerais %}
+      <div class="section-title">Observações</div>
+      <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6; white-space: pre-wrap; word-break: break-word;">
+        {{ bloco.observacoes_gerais }}
+      </div>
+    {% endif %}
 
   <div class="assinatura">
     ___________________________________________<br>


### PR DESCRIPTION
## Summary
- Handle long text in print templates via pre-wrap and word-break styles
- Resolve clinic logo paths flexibly and center headers with a hidden placeholder logo
- Apply text wrapping to freeform sections like consultation notes and observations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b45b294c48832e912252ac89df1f83