### PR TITLE
Move agendar retorno abaixo de conduta

### DIFF
--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -208,57 +208,6 @@
   </div>
 {% endif %}
 
-{% if consulta and consulta.status == 'finalizada' and appointment_form %}
-  <div class="mt-3">
-    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#retornoModal">Agendar Retorno</button>
-  </div>
-
-  <div class="modal fade" id="retornoModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <form method="POST" action="{{ url_for('agendar_retorno', consulta_id=consulta.id) }}">
-          <div class="modal-header">
-            <h5 class="modal-title">Agendar Retorno</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-          </div>
-          <div class="modal-body">
-            {{ appointment_form.hidden_tag() }}
-            <input type="hidden" name="animal_id" value="{{ animal.id }}">
-            <input type="hidden" name="veterinario_id" value="{{ consulta.veterinario.veterinario.id }}">
-            <p><strong>Animal:</strong> {{ animal.name }}</p>
-            <p><strong>Veterinário:</strong> {{ consulta.veterinario.name }}</p>
-            <div class="mb-3">
-              {{ appointment_form.date.label(class='form-label') }}
-              {{ appointment_form.date(class='form-control', type='date') }}
-            </div>
-            <div class="mb-3">
-              {{ appointment_form.time.label(class='form-label') }}
-              {{ appointment_form.time(class='form-control', type='time') }}
-            </div>
-            <div class="mb-3">
-              {{ appointment_form.reason.label(class='form-label') }}
-              {{ appointment_form.reason(class='form-control', rows=3) }}
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-            {{ appointment_form.submit(class='btn btn-primary') }}
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-
-  {% if show_retorno_modal %}
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      var retornoModal = new bootstrap.Modal(document.getElementById('retornoModal'));
-      retornoModal.show();
-    });
-  </script>
-  {% endif %}
-{% endif %}
-
 <style>
   .icon-circle {
     width: 2rem;

--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -47,10 +47,18 @@
     <label for="conduta" class="form-label fw-bold">
       <i class="bi bi-prescription2"></i> Conduta
     </label>
-    <textarea id="conduta" name="conduta" 
+    <textarea id="conduta" name="conduta"
               class="form-control auto-expand" rows="3"
               placeholder="Descreva a conduta adotada">{{ consulta.conduta or '' }}</textarea>
   </div>
+
+  {% if consulta and consulta.status == 'finalizada' and appointment_form %}
+  <div class="mb-3">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#retornoModal">
+      Agendar Retorno
+    </button>
+  </div>
+  {% endif %}
 
   <div class="d-flex justify-content-between mt-4">
     <button type="submit" class="btn btn-primary">
@@ -68,6 +76,53 @@
     {% endif %}
   </div>
 </form>
+
+{% if consulta and consulta.status == 'finalizada' and appointment_form %}
+<div class="modal fade" id="retornoModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="POST" action="{{ url_for('agendar_retorno', consulta_id=consulta.id) }}">
+        <div class="modal-header">
+          <h5 class="modal-title">Agendar Retorno</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          {{ appointment_form.hidden_tag() }}
+          <input type="hidden" name="animal_id" value="{{ animal.id }}">
+          <input type="hidden" name="veterinario_id" value="{{ consulta.veterinario.veterinario.id }}">
+          <p><strong>Animal:</strong> {{ animal.name }}</p>
+          <p><strong>Veterinário:</strong> {{ consulta.veterinario.name }}</p>
+          <div class="mb-3">
+            {{ appointment_form.date.label(class='form-label') }}
+            {{ appointment_form.date(class='form-control', type='date') }}
+          </div>
+          <div class="mb-3">
+            {{ appointment_form.time.label(class='form-label') }}
+            {{ appointment_form.time(class='form-control', type='time') }}
+          </div>
+          <div class="mb-3">
+            {{ appointment_form.reason.label(class='form-label') }}
+            {{ appointment_form.reason(class='form-control', rows=3) }}
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          {{ appointment_form.submit(class='btn btn-primary') }}
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+{% if show_retorno_modal %}
+<script>
+  document.addEventListener('DOMContentLoaded', function(){
+    var retornoModal = new bootstrap.Modal(document.getElementById('retornoModal'));
+    retornoModal.show();
+  });
+</script>
+{% endif %}
+{% endif %}
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- Exibe botão de agendar retorno logo abaixo do campo de conduta
- Remove bloco antigo de agendar retorno do template principal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45dd9a2dc832ea41f5135d5a98e90