### PR TITLE
Exibe botão de agendamento de retorno na consulta

### DIFF
--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -52,7 +52,7 @@
               placeholder="Descreva a conduta adotada">{{ consulta.conduta or '' }}</textarea>
   </div>
 
-  {% if consulta and consulta.status == 'finalizada' and appointment_form %}
+  {% if appointment_form %}
   <div class="mb-3">
     <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#retornoModal">
       Agendar Retorno
@@ -77,7 +77,7 @@
   </div>
 </form>
 
-{% if consulta and consulta.status == 'finalizada' and appointment_form %}
+{% if appointment_form %}
 <div class="modal fade" id="retornoModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">


### PR DESCRIPTION
## Resumo
- Exibe o botão **Agendar Retorno** dentro do formulário da consulta.
- Mostra o modal de agendamento sempre que o formulário de retorno estiver disponível.

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4613dc2e4832e853cb218fc5e9db7