### PR TITLE
Fix retorno modal flicker

### DIFF
--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -116,7 +116,13 @@
 
 {% if show_retorno_modal %}
 <script>
-  document.addEventListener('DOMContentLoaded', function(){
+  document.addEventListener('DOMContentLoaded', function() {
+    // Garante que a aba de consulta esteja ativa antes de exibir o modal
+    var tabTrigger = document.querySelector('[data-bs-target="#consulta-info"]');
+    if (tabTrigger) {
+      new bootstrap.Tab(tabTrigger).show();
+    }
+
     var retornoModal = new bootstrap.Modal(document.getElementById('retornoModal'));
     retornoModal.show();
   });


### PR DESCRIPTION
## Summary
- Ensure consulta tab is active before auto-showing return modal to avoid flashing overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b46332d9f8832e977d66f03f09b019