### PR TITLE
Centralize clinic logo rendering

### DIFF
--- a/models.py
+++ b/models.py
@@ -4,6 +4,7 @@ except ImportError:
     from .extensions import db
 
 from flask_login import UserMixin
+from flask import url_for, request
 from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
@@ -599,6 +600,26 @@ class Clinica(db.Model):
         cascade='all, delete-orphan',
         lazy=True,
     )
+
+
+    @property
+    def logo_url(self):
+        """Return an absolute URL for the clinic logo.
+
+        Handles three cases:
+        * ``http``/``https`` URLs stored directly in ``logotipo``.
+        * Paths starting with ``/`` which are joined with ``request.url_root``.
+        * Bare filenames stored in the uploads folder.
+        """
+        if not self.logotipo:
+            return ""
+        if self.logotipo.startswith("http"):
+            return self.logotipo
+        if self.logotipo.startswith("/"):
+            return request.url_root.rstrip("/") + self.logotipo
+        return url_for(
+            "static", filename=f"uploads/clinicas/{self.logotipo}", _external=True
+        )
 
 
     def __str__(self):

--- a/templates/components/logo.html
+++ b/templates/components/logo.html
@@ -1,0 +1,5 @@
+{% macro clinic_logo(clinica) %}
+  {% if clinica and clinica.logotipo %}
+    <img src="{{ clinica.logo_url }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+  {% endif %}
+{% endmacro %}

--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -16,15 +16,14 @@
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}">← Voltar</a>
 </div>
 
+{% from 'components/logo.html' import clinic_logo %}
 <div class="document">
   <!-- Cabeçalho com logo -->
-  {% if clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
     </div>
   {% endif %}
 

--- a/templates/imprimir_consulta.html
+++ b/templates/imprimir_consulta.html
@@ -15,14 +15,13 @@
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}">← Voltar</a>
 </div>
 
+{% from 'components/logo.html' import clinic_logo %}
 <div class="document">
-  {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
     </div>
   {% endif %}
 

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -15,14 +15,13 @@
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}">← Voltar</a>
 </div>
 
+{% from 'components/logo.html' import clinic_logo %}
 <div class="document">
-  {% if clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
     </div>
   {% endif %}
 

--- a/templates/imprimir_orcamento.html
+++ b/templates/imprimir_orcamento.html
@@ -15,14 +15,13 @@
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}">← Voltar</a>
 </div>
 
+{% from 'components/logo.html' import clinic_logo %}
 <div class="document">
-  {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
     </div>
   {% endif %}
 

--- a/templates/imprimir_orcamento_padrao.html
+++ b/templates/imprimir_orcamento_padrao.html
@@ -11,13 +11,13 @@
   <button onclick="window.print()">🖨️ Imprimir</button>
   <a href="{{ url_for('clinic_detail', clinica_id=orcamento.clinica_id) }}#orcamento">← Voltar</a>
 </div>
+{% from 'components/logo.html' import clinic_logo %}
 <div class="document">
-  {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http') else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
     </div>
   {% endif %}
   <h2>Orçamento</h2>

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -14,14 +14,13 @@
   <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}">← Voltar</a>
 </div>
 
+{% from 'components/logo.html' import clinic_logo %}
 <div class="document">
-  {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
     </div>
   {% endif %}
 

--- a/templates/partials/clinic_info.html
+++ b/templates/partials/clinic_info.html
@@ -1,16 +1,12 @@
 <!-- partials/clinic_info.html -->
+{% from 'components/logo.html' import clinic_logo %}
 <div class="card shadow-lg border-0 rounded-3 mb-4">
   <div class="card-body text-center">
     <h2 class="fw-bold mb-3">{{ clinica.nome }}</h2>
 
     {% if clinica.logotipo %}
       <div class="mb-3">
-        <img src="{{ clinica.logotipo }}" alt="Imagem da Clínica"
-             class="img-fluid rounded shadow-sm"
-             style="max-height: 180px; object-fit: cover;
-                    transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px)
-                               rotate({{ clinica.photo_rotation or 0 }}deg)
-                               scale({{ clinica.photo_zoom or 1 }});">
+        {{ clinic_logo(clinica) }}
       </div>
     {% endif %}
 

--- a/templates/termo_eutanasia.html
+++ b/templates/termo_eutanasia.html
@@ -15,14 +15,13 @@
   <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}">← Voltar</a>
 </div>
 
+{% from 'components/logo.html' import clinic_logo %}
 <div class="document">
-  {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
     </div>
   {% endif %}
 

--- a/templates/termo_internacao.html
+++ b/templates/termo_internacao.html
@@ -15,14 +15,13 @@
   <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}">← Voltar</a>
 </div>
 
+{% from 'components/logo.html' import clinic_logo %}
 <div class="document">
-  {% if clinica and clinica.logotipo %}
-    {% set logo_src = clinica.logotipo if clinica.logotipo.startswith('http')
-                     else url_for('static', filename='uploads/clinicas/' + clinica.logotipo) %}
+  {% if clinica %}
     <div class="header">
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
       <div class="clinica-nome">{{ clinica.nome }}</div>
-      <img src="{{ logo_src }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+      {{ clinic_logo(clinica) }}
     </div>
   {% endif %}
 


### PR DESCRIPTION
## Summary
- Add `Clinica.logo_url` property to build absolute logo paths
- Create reusable `clinic_logo` macro for consistent logo rendering
- Refactor print and clinic info templates to use new helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b461845e18832e97bcaf7c3888ba19