### PR TITLE
Remove calendar and scheduling buttons from clinic agenda

### DIFF
--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -250,7 +250,7 @@
     <div class="tab-pane fade" id="agendamentos" role="tabpanel">
       <h3>Agendamentos</h3>
       <div class="mb-3 text-end">
-        <a href="{{ url_for('appointments') }}" class="btn btn-primary">Novo Agendamento</a>
+        <button class="btn btn-primary" disabled>Lista</button>
       </div>
 
       <div id="list-container">

--- a/tests/test_clinic_appointment_links.py
+++ b/tests/test_clinic_appointment_links.py
@@ -33,7 +33,7 @@ def client():
         with flask_app.app_context():
             db.drop_all()
 
-def test_clinic_page_has_new_and_edit_links(client, monkeypatch):
+def test_clinic_page_has_list_button_and_edit_link(client, monkeypatch):
     with flask_app.app_context():
         admin = User(name="Admin", email="admin_links@example.com", password_hash="x", role="admin")
         clinic = Clinica(nome="Clinica", owner=admin)
@@ -63,5 +63,6 @@ def test_clinic_page_has_new_and_edit_links(client, monkeypatch):
     resp = client.get(f'/clinica/{clinic_id}')
     assert resp.status_code == 200
     html = resp.data.decode()
-    assert 'Novo Agendamento' in html
+    assert 'Novo Agendamento' not in html
+    assert 'Lista' in html
     assert f'/appointments/{appt_id}/edit' in html


### PR DESCRIPTION
## Summary
- Replace "Novo Agendamento" link with static "Lista" button in clinic agenda tab
- Adjust clinic appointment link test to expect only the list button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b464a019f8832ea20fd563a5a5f710