### PR TITLE
Allow scheduling without health plan subscription

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,6 +36,11 @@ class Config:
     MERCADOPAGO_STATEMENT_DESCRIPTOR = os.environ.get("MERCADOPAGO_STATEMENT_DESCRIPTOR", "PETORLANDIA")
     MERCADOPAGO_BINARY_MODE = bool(int(os.environ.get("MERCADOPAGO_BINARY_MODE", "0")))
 
+    # Habilita validação de plano de saúde para agendamentos
+    REQUIRE_HEALTH_SUBSCRIPTION_FOR_APPOINTMENT = bool(
+        int(os.environ.get("REQUIRE_HEALTH_SUBSCRIPTION_FOR_APPOINTMENT", "0"))
+    )
+
     # Endereço de retirada padrão (usado se não houver PickupLocation no banco)
     DEFAULT_PICKUP_ADDRESS = os.environ.get("DEFAULT_PICKUP_ADDRESS", "Rua Nove, 990")
 

--- a/models.py
+++ b/models.py
@@ -4,7 +4,7 @@ except ImportError:
     from .extensions import db
 
 from flask_login import UserMixin
-from flask import url_for, request
+from flask import url_for, request, current_app
 from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
@@ -762,10 +762,11 @@ class Appointment(db.Model):
 
     @staticmethod
     def _validate_subscription(mapper, connection, target):
-        if not type(target).has_active_subscription(target.animal_id, target.tutor_id):
-            raise ValueError(
-                'Animal does not have an active health subscription for this tutor.'
-            )
+        if current_app.config.get('REQUIRE_HEALTH_SUBSCRIPTION_FOR_APPOINTMENT', False):
+            if not type(target).has_active_subscription(target.animal_id, target.tutor_id):
+                raise ValueError(
+                    'Animal does not have an active health subscription for this tutor.'
+                )
 
     @staticmethod
     def _set_clinica(mapper, connection, target):


### PR DESCRIPTION
## Summary
- add configuration flag to bypass health subscription requirement for appointments
- skip subscription validation when flag disabled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b46679970c832e884d985d3da1c2c6