### PR TITLE
Embed return scheduling in consultation page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1796,8 +1796,6 @@ def consulta_direct(animal_id):
             )]
             appointment_form.veterinario_id.data = vet_obj.id
 
-    show_retorno_modal = request.args.get('agendar_retorno')
-
     # Idade e unidade (anos/meses)
     idade = ''
     idade_unidade = ''
@@ -1846,7 +1844,6 @@ def consulta_direct(animal_id):
         animal_idade_unidade=idade_unidade,
         servicos=servicos,
         appointment_form=appointment_form,
-        show_retorno_modal=show_retorno_modal,
     )
 
 
@@ -1862,9 +1859,7 @@ def finalizar_consulta(consulta_id):
     consulta.status = 'finalizada'
     db.session.commit()
     flash('Consulta finalizada e registrada no histórico! Agende o retorno.', 'success')
-    return redirect(
-        url_for('consulta_direct', animal_id=consulta.animal_id, agendar_retorno=1)
-    )
+    return redirect(url_for('consulta_direct', animal_id=consulta.animal_id))
 
 
 @app.route('/agendar_retorno/<int:consulta_id>', methods=['POST'])

--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -52,14 +52,6 @@
               placeholder="Descreva a conduta adotada">{{ consulta.conduta or '' }}</textarea>
   </div>
 
-  {% if appointment_form %}
-  <div class="mb-3">
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#retornoModal">
-      Agendar Retorno
-    </button>
-  </div>
-  {% endif %}
-
   <div class="d-flex justify-content-between mt-4">
     <button type="submit" class="btn btn-primary">
       {% if edit_mode %}
@@ -78,56 +70,28 @@
 </form>
 
 {% if appointment_form %}
-<div class="modal fade" id="retornoModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <form method="POST" action="{{ url_for('agendar_retorno', consulta_id=consulta.id) }}">
-        <div class="modal-header">
-          <h5 class="modal-title">Agendar Retorno</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body">
-          {{ appointment_form.hidden_tag() }}
-          <input type="hidden" name="animal_id" value="{{ animal.id }}">
-          <input type="hidden" name="veterinario_id" value="{{ consulta.veterinario.veterinario.id }}">
-          <p><strong>Animal:</strong> {{ animal.name }}</p>
-          <p><strong>Veterinário:</strong> {{ consulta.veterinario.name }}</p>
-          <div class="mb-3">
-            {{ appointment_form.date.label(class='form-label') }}
-            {{ appointment_form.date(class='form-control', type='date') }}
-          </div>
-          <div class="mb-3">
-            {{ appointment_form.time.label(class='form-label') }}
-            {{ appointment_form.time(class='form-control', type='time') }}
-          </div>
-          <div class="mb-3">
-            {{ appointment_form.reason.label(class='form-label') }}
-            {{ appointment_form.reason(class='form-control', rows=3) }}
-          </div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-          {{ appointment_form.submit(class='btn btn-primary') }}
-        </div>
-      </form>
-    </div>
+<hr class="my-4">
+<h5>Agendar Retorno</h5>
+<form method="POST" action="{{ url_for('agendar_retorno', consulta_id=consulta.id) }}" class="row g-3">
+  {{ appointment_form.hidden_tag() }}
+  <input type="hidden" name="animal_id" value="{{ animal.id }}">
+  <input type="hidden" name="veterinario_id" value="{{ consulta.veterinario.veterinario.id }}">
+  <div class="col-md-6">
+    {{ appointment_form.date.label(class='form-label') }}
+    {{ appointment_form.date(class='form-control', type='date') }}
   </div>
-</div>
-
-{% if show_retorno_modal %}
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    // Garante que a aba de consulta esteja ativa antes de exibir o modal
-    var tabTrigger = document.querySelector('[data-bs-target="#consulta-info"]');
-    if (tabTrigger) {
-      new bootstrap.Tab(tabTrigger).show();
-    }
-
-    var retornoModal = new bootstrap.Modal(document.getElementById('retornoModal'), {keyboard: false, backdrop: 'static'});
-    retornoModal.show();
-  });
-</script>
-{% endif %}
+  <div class="col-md-6">
+    {{ appointment_form.time.label(class='form-label') }}
+    {{ appointment_form.time(class='form-control', type='time') }}
+  </div>
+  <div class="col-12">
+    {{ appointment_form.reason.label(class='form-label') }}
+    {{ appointment_form.reason(class='form-control', rows=3) }}
+  </div>
+  <div class="col-12">
+    {{ appointment_form.submit(class='btn btn-primary') }}
+  </div>
+</form>
 {% endif %}
 
 <script>


### PR DESCRIPTION
## Summary
- Replace return scheduling modal with an inline form in consultation view
- Remove modal auto-popup logic and redirect parameter after finalizing consultation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b46eee3618832e8a0ec1bbac5f7342