### PR TITLE
Ensure Veterinario records sync with User role

### DIFF
--- a/tests/test_appointment_vet.py
+++ b/tests/test_appointment_vet.py
@@ -50,18 +50,21 @@ def test_veterinarian_can_schedule_for_other_users_animal(client, monkeypatch):
         plan = HealthPlan(id=1, name='Basic', price=10.0)
         db.session.add_all([clinic, tutor, vet_user, animal, plan])
         db.session.commit()
+        # ``Veterinario`` is created automatically by the listener
+        vet = vet_user.veterinario
+        vet.crmv = '123'
+        vet.clinica_id = clinic.id
         sub = HealthSubscription(
             animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True
         )
-        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123', clinica_id=clinic.id)
         schedule = VetSchedule(
             id=1,
-            veterinario_id=1,
+            veterinario_id=vet.id,
             dia_semana='Quarta',
             hora_inicio=time(9, 0),
             hora_fim=time(17, 0),
         )
-        db.session.add_all([sub, vet, schedule])
+        db.session.add_all([sub, schedule])
         db.session.commit()
         animal_id = animal.id
         vet_id = vet.id

--- a/tests/test_veterinario_listener.py
+++ b/tests/test_veterinario_listener.py
@@ -1,0 +1,47 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, Veterinario
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_veterinario_created_on_insert(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        user = User(name="Vet", email="v@example.com", password_hash="x", worker="veterinario")
+        db.session.add(user)
+        db.session.commit()
+
+        vet = Veterinario.query.filter_by(user_id=user.id).first()
+        assert vet is not None
+        assert vet.crmv == ""
+
+
+def test_veterinario_create_and_remove_on_update(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        user = User(name="User", email="u@example.com", password_hash="x", worker=None)
+        db.session.add(user)
+        db.session.commit()
+        assert Veterinario.query.count() == 0
+
+        user.worker = "veterinario"
+        db.session.commit()
+        assert Veterinario.query.filter_by(user_id=user.id).first() is not None
+
+        user.worker = "doador"
+        db.session.commit()
+        assert Veterinario.query.filter_by(user_id=user.id).first() is None


### PR DESCRIPTION
## Summary
- Add SQLAlchemy listeners to auto-create or remove `Veterinario` records when a user's `worker` role changes
- Adjust appointment test to rely on automatic `Veterinario` creation
- Add tests covering automatic creation and removal of `Veterinario`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4758aa840832e9180fbe19fee13c5