### PR TITLE
Remove payment option and enable editing in budget history

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 import os, sys, pathlib, importlib, logging, uuid, re
 from io import BytesIO
 from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
 
 
 
@@ -6865,6 +6866,47 @@ def deletar_bloco_orcamento(bloco_id):
         historico_html = render_template('partials/historico_orcamentos.html', animal=Animal.query.get(animal_id))
         return jsonify({'success': True, 'html': historico_html})
     return redirect(url_for('consulta_direct', animal_id=animal_id))
+
+
+@app.route('/bloco_orcamento/<int:bloco_id>/editar', methods=['GET'])
+@login_required
+def editar_bloco_orcamento(bloco_id):
+    bloco = BlocoOrcamento.query.get_or_404(bloco_id)
+    ensure_clinic_access(bloco.clinica_id)
+    if current_user.worker != 'veterinario':
+        return jsonify({'success': False, 'message': 'Apenas veterinários podem editar.'}), 403
+    return render_template('editar_bloco_orcamento.html', bloco=bloco)
+
+
+@app.route('/bloco_orcamento/<int:bloco_id>/atualizar', methods=['POST'])
+@login_required
+def atualizar_bloco_orcamento(bloco_id):
+    bloco = BlocoOrcamento.query.get_or_404(bloco_id)
+    ensure_clinic_access(bloco.clinica_id)
+    if current_user.worker != 'veterinario':
+        return jsonify({'success': False, 'message': 'Apenas veterinários podem editar.'}), 403
+
+    data = request.get_json(silent=True) or {}
+    itens = data.get('itens', [])
+
+    for item in list(bloco.itens):
+        db.session.delete(item)
+
+    for it in itens:
+        descricao = (it.get('descricao') or '').strip()
+        valor = it.get('valor')
+        if not descricao or valor is None:
+            continue
+        try:
+            valor_decimal = Decimal(str(valor))
+        except Exception:
+            continue
+        bloco.itens.append(OrcamentoItem(descricao=descricao, valor=valor_decimal))
+
+    db.session.commit()
+
+    historico_html = render_template('partials/historico_orcamentos.html', animal=bloco.animal)
+    return jsonify(success=True, html=historico_html)
 
 
 if __name__ == "__main__":

--- a/templates/editar_bloco_orcamento.html
+++ b/templates/editar_bloco_orcamento.html
@@ -1,0 +1,73 @@
+{% extends 'layout.html' %}
+{% block main %}
+<div class="container py-4">
+  <h2 class="mb-4">✏️ Editar Orçamento</h2>
+  <div id="itens-container">
+    {% for item in bloco.itens %}
+    <div class="row g-2 mb-2 item-row">
+      <div class="col-md-8">
+        <input type="text" class="form-control descricao" value="{{ item.descricao }}">
+      </div>
+      <div class="col-md-3">
+        <input type="number" step="0.01" class="form-control valor" value="{{ '%.2f'|format(item.valor) }}">
+      </div>
+      <div class="col-md-1">
+        <button type="button" class="btn btn-danger w-100 remover-item">🗑️</button>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  <button type="button" class="btn btn-outline-primary mb-3" onclick="adicionarItem()">➕ Adicionar item</button>
+  <div class="d-flex gap-2">
+    <button class="btn btn-success" onclick="salvar({{ bloco.id }}, {{ bloco.animal_id }})">💾 Salvar alterações</button>
+    <a class="btn btn-secondary" href="javascript:history.back()">↩️ Cancelar</a>
+  </div>
+</div>
+
+<script>
+function adicionarItem() {
+  const container = document.getElementById('itens-container');
+  const row = document.createElement('div');
+  row.className = 'row g-2 mb-2 item-row';
+  row.innerHTML = `
+    <div class="col-md-8">
+      <input type="text" class="form-control descricao" placeholder="Descrição">
+    </div>
+    <div class="col-md-3">
+      <input type="number" step="0.01" class="form-control valor" placeholder="0.00">
+    </div>
+    <div class="col-md-1">
+      <button type="button" class="btn btn-danger w-100 remover-item">🗑️</button>
+    </div>`;
+  container.appendChild(row);
+}
+
+document.addEventListener('click', function(e) {
+  if (e.target.classList.contains('remover-item')) {
+    e.target.closest('.item-row').remove();
+  }
+});
+
+function salvar(blocoId, animalId) {
+  const itens = [];
+  document.querySelectorAll('#itens-container .item-row').forEach(row => {
+    const descricao = row.querySelector('.descricao').value.trim();
+    const valor = parseFloat(row.querySelector('.valor').value);
+    if (descricao && !isNaN(valor)) {
+      itens.push({descricao, valor});
+    }
+  });
+  fetch(`/bloco_orcamento/${blocoId}/atualizar`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+    body: JSON.stringify({ itens })
+  }).then(r => r.json()).then(data => {
+    if (data.success) {
+      window.location.href = `/consulta/${animalId}`;
+    } else {
+      alert(data.message || 'Erro ao salvar.');
+    }
+  });
+}
+</script>
+{% endblock %}

--- a/templates/partials/historico_orcamentos.html
+++ b/templates/partials/historico_orcamentos.html
@@ -24,7 +24,7 @@
           <button class="btn btn-danger btn-sm">🗑 Excluir</button>
         </form>
         <a href="{{ url_for('imprimir_bloco_orcamento', bloco_id=bloco.id) }}" class="btn btn-outline-secondary btn-sm" target="_blank">🖨 Imprimir</a>
-        <a href="{{ url_for('pagar_bloco_orcamento', bloco_id=bloco.id) }}" class="btn btn-primary btn-sm">💳 Pagar</a>
+        <a href="{{ url_for('editar_bloco_orcamento', bloco_id=bloco.id) }}" class="btn btn-outline-primary btn-sm">✏️ Editar</a>
       </div>
     </div>
     {% endfor %}

--- a/tests/test_editar_bloco_orcamento.py
+++ b/tests/test_editar_bloco_orcamento.py
@@ -1,0 +1,49 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, Animal, Clinica, Veterinario, OrcamentoItem, BlocoOrcamento
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_editar_bloco_orcamento(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        clinica = Clinica(nome='Clinica 1')
+        vet_user = User(name='Vet', email='vet@example.com', worker='veterinario', role='admin')
+        vet_user.set_password('x')
+        vet = Veterinario(user=vet_user, crmv='123', clinica=clinica)
+        tutor = User(name='Tutor', email='tutor@example.com')
+        tutor.set_password('y')
+        animal = Animal(name='Rex', owner=tutor, clinica=clinica)
+        bloco = BlocoOrcamento(animal=animal, clinica=clinica)
+        item = OrcamentoItem(bloco=bloco, descricao='Consulta', valor=50)
+        db.session.add_all([clinica, vet_user, vet, tutor, animal, bloco, item])
+        db.session.commit()
+        bloco_id = bloco.id
+    client = app.test_client()
+    with client:
+        client.post('/login', data={'email': 'vet@example.com', 'password': 'x'}, follow_redirects=True)
+        resp = client.post(
+            f'/bloco_orcamento/{bloco_id}/atualizar',
+            json={'itens': [{'descricao': 'Procedimento', 'valor': 100}]},
+            headers={'Accept': 'application/json'}
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success']
+    with app.app_context():
+        bloco = BlocoOrcamento.query.get(bloco_id)
+        assert len(bloco.itens) == 1
+        assert bloco.itens[0].descricao == 'Procedimento'
+        assert float(bloco.itens[0].valor) == 100.0
+        db.drop_all()


### PR DESCRIPTION
## Summary
- remove payment action from budget history view
- add edit button and editing endpoints for saved budgets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47c5e1224832e90b5d7cbce43a6c2