### PR TITLE
Enable retorno consultations and display badge

### DIFF
--- a/app.py
+++ b/app.py
@@ -1897,6 +1897,25 @@ def agendar_retorno(consulta_id):
     return redirect(url_for('consulta_direct', animal_id=consulta.animal_id))
 
 
+@app.route('/retorno/<int:appointment_id>/start', methods=['POST'])
+@login_required
+def iniciar_retorno(appointment_id):
+    appt = Appointment.query.get_or_404(appointment_id)
+    if current_user.worker != 'veterinario':
+        abort(403)
+    consulta = Consulta(
+        animal_id=appt.animal_id,
+        created_by=current_user.id,
+        clinica_id=appt.clinica_id or current_user_clinic_id(),
+        status='in_progress',
+        retorno_de_id=appt.consulta_id,
+    )
+    db.session.add(consulta)
+    appt.status = 'completed'
+    db.session.commit()
+    return redirect(url_for('consulta_direct', animal_id=consulta.animal_id))
+
+
 @app.route('/consulta/<int:consulta_id>/deletar', methods=['POST'])
 @login_required
 def deletar_consulta(consulta_id):

--- a/migrations/versions/b1db1e768d50_add_retorno_de_id_to_consulta.py
+++ b/migrations/versions/b1db1e768d50_add_retorno_de_id_to_consulta.py
@@ -1,0 +1,20 @@
+"""add retorno_de_id to consulta"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b1db1e768d50'
+down_revision = 'ffcc9c32861f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('consulta', sa.Column('retorno_de_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'consulta', 'consulta', ['retorno_de_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint(None, 'consulta', type_='foreignkey')
+    op.drop_column('consulta', 'retorno_de_id')

--- a/models.py
+++ b/models.py
@@ -461,6 +461,9 @@ class Consulta(db.Model):
     # Status da consulta (em andamento, finalizada, etc)
     status = db.Column(db.String(20), default='in_progress')
 
+    # Consulta de retorno
+    retorno_de_id = db.Column(db.Integer, db.ForeignKey('consulta.id'))
+
     # Relacionamentos (se quiser acessar animal ou vet diretamente)
     animal = db.relationship('Animal', backref=db.backref('consultas', cascade='all, delete-orphan'))
     veterinario = db.relationship(

--- a/templates/partials/historico_consultas.html
+++ b/templates/partials/historico_consultas.html
@@ -23,7 +23,7 @@
     <tbody>
         {% for c in historico_consultas %}
         <tr id="consulta-{{ c.id }}">
-        <td class="text-nowrap">{{ c.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</td>
+        <td class="text-nowrap">{{ c.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}{% if c.retorno_de_id %} <span class="badge bg-info ms-1">Retorno</span>{% endif %}</td>
         <td class="break-word-cell">{{ c.queixa_principal or '—' }}</td>
         <td class="break-word-cell">{{ c.historico_clinico or '—' }}</td>
         <td class="break-word-cell">{{ c.exame_fisico or '—' }}</td>

--- a/tests/test_agendar_retorno.py
+++ b/tests/test_agendar_retorno.py
@@ -5,7 +5,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 import flask_login.utils as login_utils
-from datetime import time
+from datetime import time, datetime
+from flask import render_template
 from app import app as flask_app, db
 from models import (
     User,
@@ -90,3 +91,51 @@ def test_agendar_retorno_cria_appointment(client, monkeypatch):
         assert appt.animal_id == animal_id
         assert appt.tutor_id == tutor_id
         assert appt.veterinario_id == vet_id
+
+
+def test_iniciar_retorno_cria_consulta_e_badge(client, monkeypatch):
+    with flask_app.app_context():
+        clinic = Clinica(id=1, nome='Clinica')
+        tutor = User(id=1, name='Tutor', email='tutor@test')
+        tutor.set_password('x')
+        vet_user = User(id=2, name='Vet', email='vet@test', worker='veterinario')
+        vet_user.set_password('x')
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123', clinica_id=clinic.id)
+        animal = Animal(id=1, name='Rex', user_id=tutor.id, clinica_id=clinic.id)
+        consulta = Consulta(id=1, animal_id=animal.id, created_by=vet_user.id, clinica_id=clinic.id, status='finalizada')
+        appt = Appointment(id=1, animal_id=animal.id, tutor_id=tutor.id, veterinario_id=vet.id, scheduled_at=datetime.utcnow(), consulta_id=consulta.id)
+        db.session.add_all([clinic, tutor, vet_user, vet, animal, consulta, appt])
+        db.session.commit()
+        consulta_id = consulta.id
+        animal_id = animal.id
+        clinic_id = clinic.id
+        vet_user_id = vet_user.id
+        vet_id = vet.id
+        appt_id = appt.id
+
+    fake_vet = type('U', (), {
+        'id': vet_user_id,
+        'worker': 'veterinario',
+        'role': 'adotante',
+        'name': 'Vet',
+        'is_authenticated': True,
+        'veterinario': type('V', (), {
+            'id': vet_id,
+            'user': type('WU', (), {'name': 'Vet'})(),
+            'clinica_id': clinic_id,
+        })()
+    })()
+    login(monkeypatch, fake_vet)
+
+    resp = client.post(f'/retorno/{appt_id}/start')
+    assert resp.status_code == 302
+
+    with flask_app.app_context():
+        nova_consulta = Consulta.query.filter_by(retorno_de_id=consulta_id).one()
+        assert nova_consulta.animal_id == animal_id
+        assert Appointment.query.get(appt_id).status == 'completed'
+        nova_consulta.status = 'finalizada'
+        db.session.commit()
+        animal = Animal.query.get(animal_id)
+        html = render_template('partials/historico_consultas.html', animal=animal, historico_consultas=[consulta, nova_consulta])
+        assert 'Retorno' in html


### PR DESCRIPTION
## Summary
- add `retorno_de_id` field to `Consulta` and migration
- allow starting return consultations via `/retorno/<appointment_id>/start`
- show "Retorno" badge in consultation history
- test return consultation flow and badge display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47d6948e8832ebac2a9e4c8e8ff30