### PR TITLE
Enable inline appointment editing

### DIFF
--- a/app.py
+++ b/app.py
@@ -6575,6 +6575,12 @@ def edit_appointment(appointment_id):
         return jsonify({'success': True})
 
     veterinarios = Veterinario.query.all()
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return render_template(
+            'partials/edit_appointment_form.html',
+            appointment=appointment,
+            veterinarios=veterinarios,
+        )
     return render_template('edit_appointment.html', appointment=appointment, veterinarios=veterinarios)
 
 

--- a/static/appointments_table.js
+++ b/static/appointments_table.js
@@ -1,11 +1,55 @@
 function bindAppointmentRowClicks() {
+  const modalEl = document.getElementById('appointmentEditModal');
+  const modalBody = modalEl ? modalEl.querySelector('.modal-body') : null;
+  const bsModal = modalEl ? new bootstrap.Modal(modalEl) : null;
+
   document.querySelectorAll('.appointment-row').forEach(function(row) {
     row.addEventListener('click', function(e) {
       if (e.target.closest('.btn')) {
         return;
       }
       const url = this.dataset.href;
-      if (url) {
+      if (!url) return;
+      if (modalEl && modalBody && bsModal) {
+        fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+          .then(resp => resp.text())
+          .then(html => {
+            modalBody.innerHTML = html;
+            const form = modalBody.querySelector('#edit-appointment-form');
+            if (form) {
+              form.addEventListener('submit', async function(ev) {
+                ev.preventDefault();
+                const payload = {
+                  date: modalBody.querySelector('#edit-date').value,
+                  time: modalBody.querySelector('#edit-time').value,
+                  veterinario_id: modalBody.querySelector('#edit-vet').value
+                };
+                const tokenEl = modalBody.querySelector('#csrf_token');
+                const token = tokenEl ? tokenEl.value : '';
+                const resp = await fetch(url, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': token
+                  },
+                  body: JSON.stringify(payload)
+                });
+                if (resp.ok) {
+                  bsModal.hide();
+                  window.location.reload();
+                } else {
+                  let err = 'Erro ao salvar';
+                  try {
+                    const data = await resp.json();
+                    if (data.message) err = data.message;
+                  } catch (e) {}
+                  alert(err);
+                }
+              });
+            }
+            bsModal.show();
+          });
+      } else {
         window.location = url;
       }
     });

--- a/templates/appointments.html
+++ b/templates/appointments.html
@@ -40,6 +40,18 @@
   {% endif %}
 
 {% include 'partials/appointments_table.html' %}
+
+<div class="modal fade" id="appointmentEditModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Editar Consulta</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
 </div>
 {% endblock %}
 {% block scripts %}

--- a/templates/clinic_detail.html
+++ b/templates/clinic_detail.html
@@ -358,6 +358,18 @@
   </div>
 </div>
 
+<div class="modal fade" id="appointmentEditModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Editar Consulta</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+      </div>
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
 <script>
   function toggleEditInfo() {
     const section = document.getElementById('edit-info');

--- a/templates/partials/edit_appointment_form.html
+++ b/templates/partials/edit_appointment_form.html
@@ -1,0 +1,22 @@
+<form id="edit-appointment-form">
+  <input type="hidden" id="csrf_token" value="{{ csrf_token() if csrf_token is defined else '' }}">
+  <div class="mb-3">
+    <label for="edit-date" class="form-label">Data</label>
+    <input type="date" id="edit-date" class="form-control" value="{{ appointment.scheduled_at.date() }}">
+  </div>
+  <div class="mb-3">
+    <label for="edit-time" class="form-label">Horário</label>
+    <input type="time" id="edit-time" class="form-control" value="{{ appointment.scheduled_at.strftime('%H:%M') }}">
+  </div>
+  <div class="mb-3">
+    <label for="edit-vet" class="form-label">Veterinário</label>
+    <select id="edit-vet" class="form-select">
+      {% for vet in veterinarios %}
+      <option value="{{ vet.id }}" {% if vet.id == appointment.veterinario_id %}selected{% endif %}>
+        {{ vet.user.name if vet.user else vet.id }}
+      </option>
+      {% endfor %}
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Salvar</button>
+</form>


### PR DESCRIPTION
## Summary
- Support AJAX responses for editing appointments and return a form fragment
- Add Bootstrap modal for inline appointment editing on agenda pages
- Introduce JS logic to open and submit edit form within a modal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4828277e8832e8d178ca7a925c8c0