### PR TITLE
Fix owner select on clinic edit page

### DIFF
--- a/templates/admin/master.html
+++ b/templates/admin/master.html
@@ -16,6 +16,9 @@
   <!-- Font Awesome 6 -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
+    <!-- Select2 (Flask-Admin dependency) -->
+    <link rel="stylesheet" href="{{ url_for('painel_admin.static', filename='vendor/select2/select2.min.css') }}">
+
   <style>
     :root {
       --primary-color: #4e73df;
@@ -461,8 +464,16 @@
     {% endblock %}
   </div>
 
+  <!-- jQuery (required for Flask-Admin widgets) -->
+    <script src="{{ url_for('painel_admin.static', filename='vendor/jquery.min.js') }}"></script>
+
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+  <!-- Select2 and Flask-Admin form helpers -->
+    <script src="{{ url_for('painel_admin.static', filename='vendor/select2/select2.min.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='admin/js/helpers.js') }}"></script>
+    <script src="{{ url_for('painel_admin.static', filename='admin/js/form.js') }}"></script>
 
   <!-- Custom JS -->
   <script>


### PR DESCRIPTION
## Summary
- load Select2 assets in admin master template so AJAX fields render properly
- point static asset links to the `painel_admin` blueprint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4850dfc28832ebbe039c960042fe1