### PR TITLE
Hide colleagues schedules from vet appointments page

### DIFF
--- a/app.py
+++ b/app.py
@@ -6388,22 +6388,6 @@ def appointments():
             .all()
         )
 
-        colleagues = (
-
-            Veterinario.query.filter_by(clinica_id=veterinario.clinica_id)
-            .filter(Veterinario.id != veterinario.id)
-            .all()
-        )
-
-        colleague_appointments = {
-            v.id: (
-                Appointment.query.filter_by(veterinario_id=v.id)
-                .order_by(Appointment.scheduled_at)
-                .all()
-            )
-            for v in colleagues
-        }
-
         return render_template(
             'edit_vet_schedule.html',
             schedule_form=schedule_form,
@@ -6411,10 +6395,6 @@ def appointments():
             veterinario=veterinario,
             horarios=horarios,
             appointments=appointments,
-
-            colleagues=colleagues,
-            colleague_appointments=colleague_appointments,
-
         )
     else:
         if current_user.worker in ['colaborador', 'admin']:

--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -138,24 +138,6 @@
     {% endfor %}
   </ul>
 
-
-  {% if colleagues %}
-  <h3>Agendas dos Colegas</h3>
-  {% for col in colleagues %}
-    <h5>{{ col.user.name }}</h5>
-    <ul class="list-group mb-3">
-      {% for ap in colleague_appointments[col.id] %}
-        <li class="list-group-item">
-          {{ ap.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ ap.animal.name }} ({{ ap.tutor.name }})
-        </li>
-      {% else %}
-        <li class="list-group-item">Nenhuma consulta agendada.</li>
-      {% endfor %}
-    </ul>
-  {% endfor %}
-  {% endif %}
-
-
   <!-- Modal de detalhes da consulta -->
   <div class="modal fade" id="appointmentModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">

--- a/tests/test_colleague_schedule.py
+++ b/tests/test_colleague_schedule.py
@@ -17,7 +17,7 @@ def app():
     yield flask_app
 
 
-def test_colleague_schedules_visible(monkeypatch, app):
+def test_colleague_schedules_hidden(monkeypatch, app):
     client = app.test_client()
     with app.app_context():
         db.create_all()
@@ -31,4 +31,4 @@ def test_colleague_schedules_visible(monkeypatch, app):
         monkeypatch.setattr(login_utils, '_get_user', lambda: main_user)
         resp = client.get('/appointments')
         assert resp.status_code == 200
-        assert b'Col' in resp.data
+        assert b'Agendas dos Colegas' not in resp.data


### PR DESCRIPTION
## Summary
- Remove colleague appointments from veterinarian view at `/appointments`
- Clean up template to show only the current vet's schedule
- Update tests to ensure colleague schedules are hidden

## Testing
- `SQLALCHEMY_DATABASE_URI=sqlite:///:memory: pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48f974368832e903b417192d56629