### PR TITLE
Optimize loading for large images

### DIFF
--- a/templates/delivery_detail.html
+++ b/templates/delivery_detail.html
@@ -91,7 +91,7 @@
             <div class="row g-0">
               <div class="col-4">
                 <img src="{{ item.product.image_url or url_for('static', filename='placeholder.png') }}"
-                     class="img-fluid rounded-start" alt="{{ item.product.name }}">
+                     class="img-fluid rounded-start" alt="{{ item.product.name }}" loading="lazy" width="150" height="150">
               </div>
               <div class="col-8">
                 <div class="card-body py-2 px-3">

--- a/templates/plano_saude_overview.html
+++ b/templates/plano_saude_overview.html
@@ -7,7 +7,8 @@
         <img src="{{ url_for('static', filename='plano_saude_banner1.png') }}"
              class="rounded-4 shadow-sm"
              style="height: 220px; width: auto; max-width: 100%; object-fit: cover;"
-             alt="Banner Plano de Saúde Pet">
+             alt="Banner Plano de Saúde Pet"
+             loading="lazy" width="1536" height="1024">
     </div>
 
     <div class="row text-center mb-5 g-4">

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -4,10 +4,10 @@
   <div class="row">
     <div class="col-md-6">
       {% if product.image_url %}
-      <img src="{{ product.image_url }}" class="img-fluid mb-3" alt="{{ product.name }}">
+      <img src="{{ product.image_url }}" class="img-fluid mb-3" alt="{{ product.name }}" loading="lazy" width="600" height="600">
       {% endif %}
       {% for photo in product.extra_photos %}
-        <img src="{{ photo.image_url }}" class="img-thumbnail me-2 mb-2" style="height:100px" alt="Foto extra">
+        <img src="{{ photo.image_url }}" class="img-thumbnail me-2 mb-2" style="width:100px; height:100px; object-fit: cover;" alt="Foto extra" loading="lazy" width="100" height="100">
       {% endfor %}
     </div>
     <div class="col-md-6">

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -26,7 +26,10 @@
           src="{{ tutor.profile_photo or '' }}"
           alt="Foto do Tutor"
           class="img-thumbnail {% if not tutor.profile_photo %}d-none{% endif %}"
-          style="max-height: 150px;"
+          style="width:150px; height:150px; object-fit: cover;"
+          loading="lazy"
+          width="150"
+          height="150"
         >
       </div>
 
@@ -128,7 +131,7 @@
         <tr id="animal-row-{{ a.id }}">
           <td>
             {% if a.image %}
-              <img src="{{ a.image }}" alt="Foto de {{ a.name }}" class="rounded-circle me-2" style="width: 32px; height: 32px; object-fit: cover;">
+              <img src="{{ a.image }}" alt="Foto de {{ a.name }}" class="rounded-circle me-2" style="width: 32px; height: 32px; object-fit: cover;" loading="lazy" width="32" height="32">
             {% endif %}
             <span class="animal-name">{{ a.name }}</span>
           </td>


### PR DESCRIPTION
## Summary
- lazy-load product images and thumbnails in product details page
- add lazy loading and explicit dimensions for tutor profile and animal photos
- lazy-load delivery detail and plan banner images with set dimensions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4e2126bbc832eb14673c8f1e73ed0