### PR TITLE
refactor: centralize logo rendering

### DIFF
--- a/templates/admin/master.html
+++ b/templates/admin/master.html
@@ -1,3 +1,4 @@
+{% from 'components/logo.html' import clinic_logo %}
 <!DOCTYPE html>
 <html lang="pt-br">
 <head>
@@ -423,8 +424,7 @@
   <div class="sidebar">
     <div class="logo">
       <a href="{{ url_for('index') }}">
-        <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo PetOrlândia">
-        <span class="logo-text">PetOrlândia</span>
+        {{ clinic_logo(clinica, text='PetOrlândia', text_class='logo-text', alt_text='Logo PetOrlândia') }}
         <span class="logo-icon"><i class="fas fa-paw"></i></span>
       </a>
     </div>

--- a/templates/components/logo.html
+++ b/templates/components/logo.html
@@ -1,5 +1,18 @@
-{% macro clinic_logo(clinica) %}
+{#
+  Macro responsável por renderizar o logotipo da clínica ou o logotipo padrão do
+  site. Também pode opcionalmente exibir um texto ao lado da imagem, utilizado
+  nas áreas pública e administrativa do sistema.
+#}
+{% macro clinic_logo(clinica=None, text=None, alt_text=None, text_class='') %}
   {% if clinica and clinica.logotipo %}
-    <img src="{{ clinica.logo_url }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+    <img
+      src="{{ clinica.logo_url }}"
+      alt="{{ alt_text or text or 'Logotipo da clínica' }}"
+      style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+  {% else %}
+    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="{{ alt_text or text or 'Logo' }}">
+  {% endif %}
+  {% if text %}
+    <span{% if text_class %} class="{{ text_class }}"{% endif %}>{{ text }}</span>
   {% endif %}
 {% endmacro %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,3 +1,4 @@
+{% from 'components/logo.html' import clinic_logo %}
 <!DOCTYPE html>
 <html lang="pt-br">
 <head>
@@ -406,13 +407,11 @@
         <div class="container-fluid">
             {% if current_user.is_authenticated and current_user.role == "admin" %}
                 <a href="{{ url_for('painel_admin.index') }}" class="navbar-brand">
-                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo">
-                    <span>PetOrlândia</span>
+                    {{ clinic_logo(clinica, text='PetOrlândia') }}
                 </a>
             {% else %}
                 <a href="{{ url_for('index') }}" class="navbar-brand">
-                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo">
-                    <span>PetOrlândia</span>
+                    {{ clinic_logo(clinica, text='PetOrlândia') }}
                 </a>
             {% endif %}
 


### PR DESCRIPTION
## Summary
- enhance clinic logo macro to support default logos and optional text
- use logo macro in layout and admin master templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4e22459e0832eb4bc843e55aa45b4