### PR TITLE
refactor: centralize image styles

### DIFF
--- a/static/images.css
+++ b/static/images.css
@@ -1,0 +1,17 @@
+.logo-img {
+    max-width: 275px;
+    height: auto;
+    border-radius: 1rem;
+    object-fit: cover;
+}
+
+.avatar {
+    object-fit: cover;
+    border-radius: 50%;
+    display: block;
+}
+
+.card-img {
+    object-fit: cover;
+    display: block;
+}

--- a/templates/animals.html
+++ b/templates/animals.html
@@ -82,7 +82,7 @@
         <div class="card h-100 shadow-sm border-0 rounded-4 position-relative {% if animal.modo == 'perdido' %}border border-danger{% endif %}">
 
           {% if animal.image %}
-          <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 200px; object-fit: cover;" loading="lazy" alt="Imagem de {{ animal.name }}">
+          <img src="{{ animal.image }}" class="card-img card-img-top rounded-top-4" height="200" loading="lazy" alt="Imagem de {{ animal.name }}">
           {% endif %}
           <div class="card-body">
             <h5 class="card-title d-flex justify-content-between align-items-start">

--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -73,7 +73,7 @@
 
   {% else %}
   <div class="text-center text-muted mt-5">
-    <img src="https://cdn-icons-png.flaticon.com/512/2038/2038854.png" alt="Carrinho vazio" style="width: 120px; opacity: 0.5;">
+    <img src="https://cdn-icons-png.flaticon.com/512/2038/2038854.png" alt="Carrinho vazio" width="120" class="opacity-50">
     <p class="mt-4 fs-5">Seu carrinho está vazio 😿</p>
     <a href="{{ url_for('loja') }}" class="btn btn-outline-primary mt-3">
       <i class="bi bi-arrow-left-circle"></i> Voltar à loja

--- a/templates/components/logo.html
+++ b/templates/components/logo.html
@@ -1,5 +1,5 @@
 {% macro clinic_logo(clinica) %}
   {% if clinica and clinica.logotipo %}
-    <img src="{{ clinica.logo_url }}" alt="Logotipo da clínica" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }}); object-fit: cover;">
+    <img src="{{ clinica.logo_url }}" alt="Logotipo da clínica" class="logo-img rounded-0" style="transform: translate({{ clinica.photo_offset_x or 0 }}px, {{ clinica.photo_offset_y or 0 }}px) rotate({{ clinica.photo_rotation or 0 }}deg) scale({{ clinica.photo_zoom or 1 }});">
   {% endif %}
 {% endmacro %}

--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -23,7 +23,7 @@
     <div class="row g-3 align-items-center">
       {% if animal.image %}
       <div class="col-md-3 text-center">
-        <img src="{{ animal.image }}" class="img-fluid rounded shadow-sm" style="max-height: 200px;" loading="lazy" alt="Foto de {{ animal.name }}">
+        <img src="{{ animal.image }}" class="img-fluid rounded shadow-sm card-img" height="200" loading="lazy" alt="Foto de {{ animal.name }}">
       </div>
       {% endif %}
       <div class="col-md">

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,8 +60,7 @@
             <div class="text-center">
                 <img src="{{ url_for('static', filename='logo_pet.png') }}"
                      alt="Logo PetOrlândia"
-                     class="mb-4"
-                     style="max-width: 275px; height: auto; border-radius: 1rem;">
+                     class="mb-4 logo-img">
             </div>
 
             <p class="lead">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -23,6 +23,8 @@
     <!-- Font Awesome 6 -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
+    <link href="{{ url_for('static', filename='images.css') }}" rel="stylesheet">
+
     <style>
         :root {
             --primary-color: #4e73df;
@@ -406,12 +408,12 @@
         <div class="container-fluid">
             {% if current_user.is_authenticated and current_user.role == "admin" %}
                 <a href="{{ url_for('painel_admin.index') }}" class="navbar-brand">
-                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo">
+                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo" class="logo-img">
                     <span>PetOrlândia</span>
                 </a>
             {% else %}
                 <a href="{{ url_for('index') }}" class="navbar-brand">
-                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo">
+                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo" class="logo-img">
                     <span>PetOrlândia</span>
                 </a>
             {% endif %}

--- a/templates/mensagens.html
+++ b/templates/mensagens.html
@@ -12,7 +12,7 @@
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center">
                         {% if msg.sender.profile_photo %}
-                            <img src="{{ msg.sender.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width: 50px; height: 50px; object-fit: cover;">
+                            <img src="{{ msg.sender.profile_photo }}" alt="Foto" class="avatar me-3" width="50" height="50">
                         {% else %}
                             <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width: 50px; height: 50px; color: white;">
                                 {{ msg.sender.name[0] }}

--- a/templates/mensagens_admin.html
+++ b/templates/mensagens_admin.html
@@ -9,7 +9,7 @@
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <div class="d-flex align-items-center">
                 {% if other_user.profile_photo %}
-                    <img src="{{ other_user.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
+                    <img src="{{ other_user.profile_photo }}" alt="Foto" class="avatar me-3" width="50" height="50">
                 {% else %}
                     <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width:50px;height:50px;color:white;">
                         {{ other_user.name[0] }}
@@ -43,7 +43,7 @@
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <div class="d-flex align-items-center">
                 {% if other_user.profile_photo %}
-                    <img src="{{ other_user.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
+                    <img src="{{ other_user.profile_photo }}" alt="Foto" class="avatar me-3" width="50" height="50">
                 {% else %}
                     <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width:50px;height:50px;color:white;">
                         {{ other_user.name[0] }}

--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -33,7 +33,7 @@
         <div class="col-md-6 d-flex" data-name="{{ animal.name|lower }}" data-date="{{ animal.date_added.isoformat() if animal.date_added else '' }}" data-age="{{ animal.age_years or 0 }}">
           <div class="card shadow-sm rounded-4 h-100 flex-fill">
             {% if animal.image %}
-              <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 180px; object-fit: cover;" loading="lazy" alt="Foto de {{ animal.name }}">
+              <img src="{{ animal.image }}" class="card-img card-img-top rounded-top-4" height="180" loading="lazy" alt="Foto de {{ animal.name }}">
             {% else %}
               <div class="d-flex align-items-center justify-content-center bg-light rounded-top-4" style="height: 180px;">
                 <span class="text-muted" style="font-size: 2rem;">🐾</span>

--- a/templates/plano_saude_overview.html
+++ b/templates/plano_saude_overview.html
@@ -53,7 +53,7 @@
                 <div class="col">
                     <div class="card h-100 shadow-sm border-0 rounded-4">
                         {% if animal.image %}
-                            <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="max-height: 200px; object-fit: cover;" loading="lazy" alt="Foto de {{ animal.name }}">
+                            <img src="{{ animal.image }}" class="card-img card-img-top rounded-top-4" height="200" loading="lazy" alt="Foto de {{ animal.name }}">
                         {% endif %}
                         <div class="card-body">
                             <h5 class="card-title">{{ animal.name }}</h5>

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -7,7 +7,7 @@
       <img src="{{ product.image_url }}" class="img-fluid mb-3" alt="{{ product.name }}">
       {% endif %}
       {% for photo in product.extra_photos %}
-        <img src="{{ photo.image_url }}" class="img-thumbnail me-2 mb-2" style="height:100px" alt="Foto extra">
+        <img src="{{ photo.image_url }}" class="img-thumbnail me-2 mb-2" height="100" alt="Foto extra">
       {% endfor %}
     </div>
     <div class="col-md-6">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -15,7 +15,7 @@
 
           {% if current_user.profile_photo %}
             <div id="photo-container" class="img-thumbnail shadow-sm mb-2 position-relative overflow-hidden" style="width: 240px; height: 240px; border-radius: 1rem;">
-              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" style="width:100%; height:100%; object-fit: cover; transform: translate({{ current_user.photo_offset_x or 0 }}px, {{ current_user.photo_offset_y or 0 }}px) rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});" alt="Foto de {{ current_user.name }}">
+              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" class="avatar w-100 h-100" style="transform: translate({{ current_user.photo_offset_x or 0 }}px, {{ current_user.photo_offset_y or 0 }}px) rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});" alt="Foto de {{ current_user.name }}">
             </div>
           {% else %}
             <div class="bg-light border d-flex align-items-center justify-content-center mb-2" style="width: 240px; height: 240px; border-radius: 1rem; font-size: 1.2rem; color: #555;">
@@ -136,7 +136,7 @@
       <div class="col-md-4">
         <div class="card shadow-sm rounded-4 h-100">
           {% if animal.image %}
-          <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 180px; object-fit: cover;" loading="lazy" alt="Foto de {{ animal.name }}">
+          <img src="{{ animal.image }}" class="card-img card-img-top rounded-top-4" height="180" loading="lazy" alt="Foto de {{ animal.name }}">
           {% endif %}
           <div class="card-body">
             <h5 class="card-title">{{ animal.name }}</h5>

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -128,7 +128,7 @@
         <tr id="animal-row-{{ a.id }}">
           <td>
             {% if a.image %}
-              <img src="{{ a.image }}" alt="Foto de {{ a.name }}" class="rounded-circle me-2" style="width: 32px; height: 32px; object-fit: cover;">
+              <img src="{{ a.image }}" alt="Foto de {{ a.name }}" class="avatar me-2" width="32" height="32">
             {% endif %}
             <span class="animal-name">{{ a.name }}</span>
           </td>

--- a/templates/upload_result.html
+++ b/templates/upload_result.html
@@ -3,7 +3,7 @@
 {% block main %}
 <div class="container py-4">
   <h1 class="mb-3">Upload feito com sucesso!</h1>
-  <img src="{{ image_url }}" alt="Imagem enviada" class="img-fluid" style="max-width:300px;">
+  <img src="{{ image_url }}" alt="Imagem enviada" class="img-fluid" width="300">
   <p class="mt-3"><a href="{{ image_url }}" target="_blank">Abrir imagem</a></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable CSS classes for logos, avatars and card images
- import images.css and apply classes across templates
- replace inline image styling in various views

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4e20c81c0832eb8d5950b5f6ef54d