### PR TITLE
Add consistent alt text for images

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -10,6 +10,14 @@ import uuid
 from werkzeug.utils import secure_filename
 from sqlalchemy import func
 
+# Alt text constants for image consistency
+ALT_PHOTO = "Foto de {}"
+ALT_LOGOTIPO = "Logotipo de {}"
+ALT_PRODUCT = "Foto do produto {}"
+ALT_CURRENT_PHOTO = "Foto atual"
+ALT_CURRENT_LOGO = "Logotipo atual"
+ALT_CURRENT_IMAGE = "Imagem atual"
+
 def _is_admin():
     """Return True if the current user has the admin role."""
     return current_user.is_authenticated and current_user.role == "admin"
@@ -179,7 +187,7 @@ class UserAdminView(MyModelView):
             f'<a href="https://wa.me/55{re.sub("[^0-9]", "", m.phone)}" target="_blank">{m.phone}</a>'
         ) if m.phone else '—',
         'profile_photo': lambda v, c, m, p: Markup(
-            f'<img src="{m.profile_photo}" width="100">'
+            f'<img src="{m.profile_photo}" width="100" alt="{ALT_PHOTO.format(m.name)}">'
         ) if m.profile_photo else '',
         'added_by': lambda v, c, m, p: m.added_by.name if m.added_by else '—'
     }
@@ -205,7 +213,7 @@ class UserAdminView(MyModelView):
         obj = self.get_one(id)
         if obj and obj.profile_photo:
             form.profile_photo_upload.description = Markup(
-                f'<img src="{obj.profile_photo}" alt="Foto atual" '
+                f'<img src="{obj.profile_photo}" alt="{ALT_CURRENT_PHOTO}" '
                 f'style="max-height:150px;margin-top:10px;">'
             )
 
@@ -252,7 +260,7 @@ class ClinicaAdmin(MyModelView):
 
     column_formatters = {
         'logotipo': lambda v, c, m, p: Markup(
-            f'<img src="{m.logotipo}" width="100">'
+            f'<img src="{m.logotipo}" width="100" alt="{ALT_LOGOTIPO.format(m.nome)}">'
         ) if m.logotipo else ''
     }
 
@@ -269,7 +277,7 @@ class ClinicaAdmin(MyModelView):
         obj = self.get_one(id)
         if obj and obj.logotipo:
             form.logotipo_upload.description = Markup(
-                f'<img src="{obj.logotipo}" alt="Logotipo atual" '
+                f'<img src="{obj.logotipo}" alt="{ALT_CURRENT_LOGO}" '
                 f'style="max-height:150px;margin-top:10px;">'
             )
 
@@ -348,14 +356,14 @@ class AnimalAdminView(MyModelView):
         obj = self.get_one(id)
         if obj and obj.image:
             form.image_upload.description = Markup(
-                f'<img src="{obj.image}" alt="Imagem atual" '
+                f'<img src="{obj.image}" alt="{ALT_CURRENT_IMAGE}" '
                 f'style="max-height:150px;margin-top:10px;">'
             )
 
 
     column_formatters = {
         'image': lambda v, c, m, p: Markup(
-            f'<img src="{m.image}" width="100">'
+            f'<img src="{m.image}" width="100" alt="{ALT_PHOTO.format(m.name)}">'
         ) if m.image else '',
         'name': lambda v, c, m, p: Markup(
             f'<a href="{url_for("consulta_direct", animal_id=m.id)}" target="_blank">{m.name}</a>'
@@ -405,7 +413,7 @@ class ProductAdmin(MyModelView):
     column_sortable_list = ('name', 'price', 'stock', 'id')
     column_formatters = {
         'image_url': lambda v, c, m, p: Markup(
-            f'<img src="{m.image_url}" width="100">'
+            f'<img src="{m.image_url}" width="100" alt="{ALT_PRODUCT.format(m.name)}">'
         ) if m.image_url else ''
     }
 
@@ -421,7 +429,7 @@ class ProductAdmin(MyModelView):
         obj = self.get_one(id)
         if obj and obj.image_url:
             form.image_upload.description = Markup(
-                f'<img src="{obj.image_url}" alt="Imagem atual" '
+                f'<img src="{obj.image_url}" alt="{ALT_CURRENT_IMAGE}" '
                 f'style="max-height:150px;margin-top:10px;">'
             )
 

--- a/templates/admin/master.html
+++ b/templates/admin/master.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="pt-br">
+{% import 'components/alt_macros.html' as alt %}
 <head>
   <meta charset="UTF-8" />
   <title>Painel Administrativo - PetOrlândia</title>
@@ -423,7 +424,7 @@
   <div class="sidebar">
     <div class="logo">
       <a href="{{ url_for('index') }}">
-        <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo PetOrlândia">
+        <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="{{ alt.logo() }}">
         <span class="logo-text">PetOrlândia</span>
         <span class="logo-icon"><i class="fas fa-paw"></i></span>
       </a>

--- a/templates/animals.html
+++ b/templates/animals.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 {% set ns = namespace(items=[]) %}
 {% for a in animals %}
   {% set ns.items = ns.items + [{"@type": "Offer", "name": a.name, "description": a.description, "image": a.image}] %}
@@ -82,7 +83,7 @@
         <div class="card h-100 shadow-sm border-0 rounded-4 position-relative {% if animal.modo == 'perdido' %}border border-danger{% endif %}">
 
           {% if animal.image %}
-          <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 200px; object-fit: cover;" loading="lazy" alt="Imagem de {{ animal.name }}">
+          <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 200px; object-fit: cover;" loading="lazy" alt="{{ alt.animal(animal.name) }}">
           {% endif %}
           <div class="card-body">
             <h5 class="card-title d-flex justify-content-between align-items-start">
@@ -178,7 +179,7 @@
               </div>
               <div class="modal-body text-start">
                 {% if animal.image %}
-                <img src="{{ animal.image }}" class="img-fluid rounded mb-3" loading="lazy" alt="Imagem de {{ animal.name }}">
+                <img src="{{ animal.image }}" class="img-fluid rounded mb-3" loading="lazy" alt="{{ alt.animal(animal.name) }}">
                 {% endif %}
                 <p><strong>Espécie:</strong> {{ animal.species }}</p>
                 <p><strong>Raça:</strong> {{ animal.breed }}</p>

--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -73,7 +73,7 @@
 
   {% else %}
   <div class="text-center text-muted mt-5">
-    <img src="https://cdn-icons-png.flaticon.com/512/2038/2038854.png" alt="Carrinho vazio" style="width: 120px; opacity: 0.5;">
+    <img src="https://cdn-icons-png.flaticon.com/512/2038/2038854.png" alt="" role="presentation" style="width: 120px; opacity: 0.5;">
     <p class="mt-4 fs-5">Seu carrinho está vazio 😿</p>
     <a href="{{ url_for('loja') }}" class="btn btn-outline-primary mt-3">
       <i class="bi bi-arrow-left-circle"></i> Voltar à loja

--- a/templates/components/alt_macros.html
+++ b/templates/components/alt_macros.html
@@ -1,0 +1,4 @@
+{% macro logo() %}PetOrlândia logo{% endmacro %}
+{% macro animal(name) %}Foto de {{ name }}{% endmacro %}
+{% macro user(name) %}Foto de {{ name }}{% endmacro %}
+{% macro product(name) %}Foto do produto {{ name }}{% endmacro %}

--- a/templates/components/photo_cropper.html
+++ b/templates/components/photo_cropper.html
@@ -13,7 +13,7 @@
   {% endif %}
   <div id="{{ id }}-editor" class="photo-cropper{% if image_url %} d-none{% endif %}">
     <div id="{{ id }}-container" class="img-thumbnail shadow-sm mb-3 position-relative overflow-hidden" style="width: {{ size }}px; height: {{ size }}px; border-radius: 1rem; background-color: #f8f9fa;">
-      <img id="{{ id }}-img" src="{{ image_url if image_url else placeholder_url }}" style="width:100%; height:100%; object-fit: cover; cursor: grab; transition: transform 0.2s ease; {% if not image_url %}opacity:0.5;{% endif %} transform: translate({{ offset_x_field.data or 0 }}px, {{ offset_y_field.data or 0 }}px) rotate({{ rot_field.data or 0 }}deg) scale({{ zoom_field.data or 1 }});" alt="Imagem">
+      <img id="{{ id }}-img" src="{{ image_url if image_url else placeholder_url }}" style="width:100%; height:100%; object-fit: cover; cursor: grab; transition: transform 0.2s ease; {% if not image_url %}opacity:0.5;{% endif %} transform: translate({{ offset_x_field.data or 0 }}px, {{ offset_y_field.data or 0 }}px) rotate({{ rot_field.data or 0 }}deg) scale({{ zoom_field.data or 1 }});" {% if image_url %}alt="Imagem para recorte"{% else %}alt="" role="presentation"{% endif %}>
       {% if not image_url %}
       <div class="position-absolute top-50 start-50 translate-middle text-center" style="pointer-events: none;">
         <i class="fas fa-camera fa-3x text-secondary"></i>

--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -1,4 +1,5 @@
 {% extends 'layout.html' %}
+{% import 'components/alt_macros.html' as alt %}
 
 {% block head %}
   {{ super() }}
@@ -33,7 +34,7 @@
     {% if animal %}
       <div class="animal-photo shadow-sm rounded-circle border border-2 border-primary">
         {% if animal.photo %}
-          <img src="{{ animal.photo.url }}" alt="{{ animal.name }}" class="rounded-circle" width="56" height="56">
+          <img src="{{ animal.photo.url }}" alt="{{ alt.animal(animal.name) }}" class="rounded-circle" width="56" height="56">
         {% else %}
           <div class="no-photo-placeholder rounded-circle bg-light d-flex align-items-center justify-content-center" style="width: 56px; height: 56px;">
             <i class="fa-solid fa-camera text-muted"></i>

--- a/templates/delivery_detail.html
+++ b/templates/delivery_detail.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 <div class="container py-4">
 
@@ -90,8 +91,10 @@
           <div class="card h-100">
             <div class="row g-0">
               <div class="col-4">
-                <img src="{{ item.product.image_url or url_for('static', filename='placeholder.png') }}"
-                     class="img-fluid rounded-start" alt="{{ item.product.name }}">
+                {% set img_src = item.product.image_url %}
+                <img src="{{ img_src or url_for('static', filename='placeholder.png') }}"
+                     class="img-fluid rounded-start"
+                     {% if img_src %}alt="{{ alt.product(item.product.name) }}"{% else %}alt="" role="presentation"{% endif %}>
               </div>
               <div class="col-8">
                 <div class="card-body py-2 px-3">

--- a/templates/ficha_animal.html
+++ b/templates/ficha_animal.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 
 <div class="container py-4">
@@ -23,7 +24,7 @@
     <div class="row g-3 align-items-center">
       {% if animal.image %}
       <div class="col-md-3 text-center">
-        <img src="{{ animal.image }}" class="img-fluid rounded shadow-sm" style="max-height: 200px;" loading="lazy" alt="Foto de {{ animal.name }}">
+        <img src="{{ animal.image }}" class="img-fluid rounded shadow-sm" style="max-height: 200px;" loading="lazy" alt="{{ alt.animal(animal.name) }}">
       </div>
       {% endif %}
       <div class="col-md">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 
 {% block main %}
 <div class="container text-center">
@@ -59,7 +60,7 @@
         <div class="card shadow-lg p-5 rounded-4 mt-5" style="background: white;">
             <div class="text-center">
                 <img src="{{ url_for('static', filename='logo_pet.png') }}"
-                     alt="Logo PetOrlândia"
+                     alt="{{ alt.logo() }}"
                      class="mb-4"
                      style="max-width: 275px; height: auto; border-radius: 1rem;">
             </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="pt-br">
+{% import 'components/alt_macros.html' as alt %}
 <head>
     {% block head %}
     {% endblock %}
@@ -406,12 +407,12 @@
         <div class="container-fluid">
             {% if current_user.is_authenticated and current_user.role == "admin" %}
                 <a href="{{ url_for('painel_admin.index') }}" class="navbar-brand">
-                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo">
+                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="{{ alt.logo() }}">
                     <span>PetOrlândia</span>
                 </a>
             {% else %}
                 <a href="{{ url_for('index') }}" class="navbar-brand">
-                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="Logo">
+                    <img src="{{ url_for('static', filename='pastorgato.png') }}" alt="{{ alt.logo() }}">
                     <span>PetOrlândia</span>
                 </a>
             {% endif %}

--- a/templates/mensagens.html
+++ b/templates/mensagens.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 <h2>Minhas Mensagens Recebidas 📥</h2>
 
@@ -12,7 +13,7 @@
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center">
                         {% if msg.sender.profile_photo %}
-                            <img src="{{ msg.sender.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width: 50px; height: 50px; object-fit: cover;">
+                            <img src="{{ msg.sender.profile_photo }}" alt="{{ alt.user(msg.sender.name) }}" class="rounded-circle me-3" style="width: 50px; height: 50px; object-fit: cover;">
                         {% else %}
                             <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width: 50px; height: 50px; color: white;">
                                 {{ msg.sender.name[0] }}

--- a/templates/mensagens_admin.html
+++ b/templates/mensagens_admin.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 <h2>Mensagens sobre Animais</h2>
 
@@ -9,7 +10,7 @@
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <div class="d-flex align-items-center">
                 {% if other_user.profile_photo %}
-                    <img src="{{ other_user.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
+                    <img src="{{ other_user.profile_photo }}" alt="{{ alt.user(other_user.name) }}" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
                 {% else %}
                     <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width:50px;height:50px;color:white;">
                         {{ other_user.name[0] }}
@@ -43,7 +44,7 @@
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <div class="d-flex align-items-center">
                 {% if other_user.profile_photo %}
-                    <img src="{{ other_user.profile_photo }}" alt="Foto" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
+                    <img src="{{ other_user.profile_photo }}" alt="{{ alt.user(other_user.name) }}" class="rounded-circle me-3" style="width:50px;height:50px;object-fit:cover;">
                 {% else %}
                     <div class="rounded-circle bg-secondary me-3 d-flex justify-content-center align-items-center" style="width:50px;height:50px;color:white;">
                         {{ other_user.name[0] }}

--- a/templates/partials/_product_grid.html
+++ b/templates/partials/_product_grid.html
@@ -1,3 +1,4 @@
+{% import 'components/alt_macros.html' as alt %}
 {% if products %}
 <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
   {% for product in products %}
@@ -8,9 +9,9 @@
          class="ratio ratio-4x3 product-image-wrap d-block position-relative" aria-label="Abrir {{ product.name }}">
         {% if product.image_url %}
           {% if 'http' in product.image_url %}
-            <img src="{{ product.image_url }}" class="product-image" alt="{{ product.name }}" loading="lazy">
+            <img src="{{ product.image_url }}" class="product-image" alt="{{ alt.product(product.name) }}" loading="lazy">
           {% else %}
-            <img src="{{ url_for('static', filename=product.image_url) }}" class="product-image" alt="{{ product.name }}" loading="lazy">
+            <img src="{{ url_for('static', filename=product.image_url) }}" class="product-image" alt="{{ alt.product(product.name) }}" loading="lazy">
           {% endif %}
         {% else %}
           <div class="product-image-placeholder">

--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -1,3 +1,4 @@
+{% import 'components/alt_macros.html' as alt %}
 <!-- partials/animais_adicionados.html -->
 <div class="container d-flex justify-content-center my-5">
   <div style="width: 100%; max-width: 700px;">
@@ -33,7 +34,7 @@
         <div class="col-md-6 d-flex" data-name="{{ animal.name|lower }}" data-date="{{ animal.date_added.isoformat() if animal.date_added else '' }}" data-age="{{ animal.age_years or 0 }}">
           <div class="card shadow-sm rounded-4 h-100 flex-fill">
             {% if animal.image %}
-              <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 180px; object-fit: cover;" loading="lazy" alt="Foto de {{ animal.name }}">
+              <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 180px; object-fit: cover;" loading="lazy" alt="{{ alt.animal(animal.name) }}">
             {% else %}
               <div class="d-flex align-items-center justify-content-center bg-light rounded-top-4" style="height: 180px;">
                 <span class="text-muted" style="font-size: 2rem;">🐾</span>

--- a/templates/plano_saude_overview.html
+++ b/templates/plano_saude_overview.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 <div class="container mt-4">
 
@@ -53,7 +54,7 @@
                 <div class="col">
                     <div class="card h-100 shadow-sm border-0 rounded-4">
                         {% if animal.image %}
-                            <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="max-height: 200px; object-fit: cover;" loading="lazy" alt="Foto de {{ animal.name }}">
+                            <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="max-height: 200px; object-fit: cover;" loading="lazy" alt="{{ alt.animal(animal.name) }}">
                         {% endif %}
                         <div class="card-body">
                             <h5 class="card-title">{{ animal.name }}</h5>

--- a/templates/planosaude_animal.html
+++ b/templates/planosaude_animal.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 <div class="container mt-4">
 
@@ -6,7 +7,7 @@
 
     {% if animal.image %}
         <div class="text-center mb-4">
-            <img src="{{ animal.image }}" alt="Foto de {{ animal.name }}"
+            <img src="{{ animal.image }}" alt="{{ alt.animal(animal.name) }}"
                  class="rounded-circle shadow-sm" loading="lazy"
                  style="width: 150px; height: 150px; object-fit: cover;">
         </div>

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -1,13 +1,14 @@
 {% extends "layout.html" %}
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 <div class="container py-4">
   <div class="row">
     <div class="col-md-6">
       {% if product.image_url %}
-      <img src="{{ product.image_url }}" class="img-fluid mb-3" alt="{{ product.name }}">
+      <img src="{{ product.image_url }}" class="img-fluid mb-3" alt="{{ alt.product(product.name) }}">
       {% endif %}
       {% for photo in product.extra_photos %}
-        <img src="{{ photo.image_url }}" class="img-thumbnail me-2 mb-2" style="height:100px" alt="Foto extra">
+        <img src="{{ photo.image_url }}" class="img-thumbnail me-2 mb-2" style="height:100px" alt="{{ alt.product(product.name) }}">
       {% endfor %}
     </div>
     <div class="col-md-6">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% from 'components/photo_cropper.html' import photo_cropper %}
 
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 <div class="container py-4">
 
@@ -15,7 +16,7 @@
 
           {% if current_user.profile_photo %}
             <div id="photo-container" class="img-thumbnail shadow-sm mb-2 position-relative overflow-hidden" style="width: 240px; height: 240px; border-radius: 1rem;">
-              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" style="width:100%; height:100%; object-fit: cover; transform: translate({{ current_user.photo_offset_x or 0 }}px, {{ current_user.photo_offset_y or 0 }}px) rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});" alt="Foto de {{ current_user.name }}">
+              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" style="width:100%; height:100%; object-fit: cover; transform: translate({{ current_user.photo_offset_x or 0 }}px, {{ current_user.photo_offset_y or 0 }}px) rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});" alt="{{ alt.user(current_user.name) }}">
             </div>
           {% else %}
             <div class="bg-light border d-flex align-items-center justify-content-center mb-2" style="width: 240px; height: 240px; border-radius: 1rem; font-size: 1.2rem; color: #555;">
@@ -136,7 +137,7 @@
       <div class="col-md-4">
         <div class="card shadow-sm rounded-4 h-100">
           {% if animal.image %}
-          <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 180px; object-fit: cover;" loading="lazy" alt="Foto de {{ animal.name }}">
+          <img src="{{ animal.image }}" class="card-img-top rounded-top-4" style="height: 180px; object-fit: cover;" loading="lazy" alt="{{ alt.animal(animal.name) }}">
           {% endif %}
           <div class="card-body">
             <h5 class="card-title">{{ animal.name }}</h5>

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -1,5 +1,6 @@
 {% extends 'layout.html' %}
 {% from 'components/photo_cropper.html' import photo_cropper %}
+{% import 'components/alt_macros.html' as alt %}
 {% block main %}
 <div class="container py-4">
 
@@ -21,10 +22,10 @@
       <h3 class="card-title mb-3">👤 Dados do Tutor</h3>
 
       <div class="mb-3 text-center">
-        <img
+          <img
           id="preview-tutor"
           src="{{ tutor.profile_photo or '' }}"
-          alt="Foto do Tutor"
+          alt="{{ alt.user(tutor.name) }}"
           class="img-thumbnail {% if not tutor.profile_photo %}d-none{% endif %}"
           style="max-height: 150px;"
         >
@@ -128,7 +129,7 @@
         <tr id="animal-row-{{ a.id }}">
           <td>
             {% if a.image %}
-              <img src="{{ a.image }}" alt="Foto de {{ a.name }}" class="rounded-circle me-2" style="width: 32px; height: 32px; object-fit: cover;">
+              <img src="{{ a.image }}" alt="{{ alt.animal(a.name) }}" class="rounded-circle me-2" style="width: 32px; height: 32px; object-fit: cover;">
             {% endif %}
             <span class="animal-name">{{ a.name }}</span>
           </td>


### PR DESCRIPTION
## Summary
- centralize common image descriptions in Jinja macros
- use constants for admin image alt text
- provide meaningful alt text and hide decorative imagery

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4e22bfb70832e956c1e00c5333054