### PR TITLE
feat: centralize avatar transforms

### DIFF
--- a/static/avatar_helper.js
+++ b/static/avatar_helper.js
@@ -1,0 +1,17 @@
+function updateAvatarTransform(img) {
+  if (!img) return;
+  const offsetX = img.dataset.offsetX || 0;
+  const offsetY = img.dataset.offsetY || 0;
+  const rotation = img.dataset.rotation || 0;
+  const zoom = img.dataset.zoom || 1;
+  img.style.setProperty('--avatar-offset-x', `${offsetX}px`);
+  img.style.setProperty('--avatar-offset-y', `${offsetY}px`);
+  img.style.setProperty('--avatar-rotation', `${rotation}deg`);
+  img.style.setProperty('--avatar-zoom', zoom);
+}
+
+function applyAvatarTransforms() {
+  document.querySelectorAll('.avatar').forEach(updateAvatarTransform);
+}
+
+document.addEventListener('DOMContentLoaded', applyAvatarTransforms);

--- a/static/images.css
+++ b/static/images.css
@@ -1,0 +1,13 @@
+.avatar {
+  --avatar-size: 64px;
+  --avatar-radius: 50%;
+  --avatar-offset-x: 0px;
+  --avatar-offset-y: 0px;
+  --avatar-rotation: 0deg;
+  --avatar-zoom: 1;
+  width: var(--avatar-size);
+  height: var(--avatar-size);
+  border-radius: var(--avatar-radius);
+  object-fit: cover;
+  transform: translate(var(--avatar-offset-x), var(--avatar-offset-y)) rotate(var(--avatar-rotation)) scale(var(--avatar-zoom));
+}

--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -33,7 +33,7 @@
     {% if animal %}
       <div class="animal-photo shadow-sm rounded-circle border border-2 border-primary">
         {% if animal.photo %}
-          <img src="{{ animal.photo.url }}" alt="{{ animal.name }}" class="rounded-circle" width="56" height="56">
+          <img src="{{ animal.photo.url }}" alt="{{ animal.name }}" class="avatar" data-offset-x="{{ animal.photo_offset_x or 0 }}" data-offset-y="{{ animal.photo_offset_y or 0 }}" data-rotation="{{ animal.photo_rotation or 0 }}" data-zoom="{{ animal.photo_zoom or 1 }}" style="--avatar-size:56px;">
         {% else %}
           <div class="no-photo-placeholder rounded-circle bg-light d-flex align-items-center justify-content-center" style="width: 56px; height: 56px;">
             <i class="fa-solid fa-camera text-muted"></i>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -23,6 +23,10 @@
     <!-- Font Awesome 6 -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
+    <!-- Images helpers -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='images.css') }}">
+    <script src="{{ url_for('static', filename='avatar_helper.js') }}" defer></script>
+
     <style>
         :root {
             --primary-color: #4e73df;

--- a/templates/planosaude_animal.html
+++ b/templates/planosaude_animal.html
@@ -6,9 +6,7 @@
 
     {% if animal.image %}
         <div class="text-center mb-4">
-            <img src="{{ animal.image }}" alt="Foto de {{ animal.name }}"
-                 class="rounded-circle shadow-sm" loading="lazy"
-                 style="width: 150px; height: 150px; object-fit: cover;">
+            <img src="{{ animal.image }}" alt="Foto de {{ animal.name }}" class="avatar shadow-sm" loading="lazy" data-offset-x="{{ animal.photo_offset_x or 0 }}" data-offset-y="{{ animal.photo_offset_y or 0 }}" data-rotation="{{ animal.photo_rotation or 0 }}" data-zoom="{{ animal.photo_zoom or 1 }}" style="--avatar-size:150px;">
         </div>
     {% endif %}
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -15,7 +15,7 @@
 
           {% if current_user.profile_photo %}
             <div id="photo-container" class="img-thumbnail shadow-sm mb-2 position-relative overflow-hidden" style="width: 240px; height: 240px; border-radius: 1rem;">
-              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" style="width:100%; height:100%; object-fit: cover; transform: translate({{ current_user.photo_offset_x or 0 }}px, {{ current_user.photo_offset_y or 0 }}px) rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});" alt="Foto de {{ current_user.name }}">
+              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" class="avatar" data-offset-x="{{ current_user.photo_offset_x or 0 }}" data-offset-y="{{ current_user.photo_offset_y or 0 }}" data-rotation="{{ current_user.photo_rotation or 0 }}" data-zoom="{{ current_user.photo_zoom or 1 }}" style="--avatar-size:240px; --avatar-radius:1rem;" alt="Foto de {{ current_user.name }}">
             </div>
           {% else %}
             <div class="bg-light border d-flex align-items-center justify-content-center mb-2" style="width: 240px; height: 240px; border-radius: 1rem; font-size: 1.2rem; color: #555;">

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -25,8 +25,12 @@
           id="preview-tutor"
           src="{{ tutor.profile_photo or '' }}"
           alt="Foto do Tutor"
-          class="img-thumbnail {% if not tutor.profile_photo %}d-none{% endif %}"
-          style="max-height: 150px;"
+          class="img-thumbnail avatar {% if not tutor.profile_photo %}d-none{% endif %}"
+          data-offset-x="{{ tutor.photo_offset_x or 0 }}"
+          data-offset-y="{{ tutor.photo_offset_y or 0 }}"
+          data-rotation="{{ tutor.photo_rotation or 0 }}"
+          data-zoom="{{ tutor.photo_zoom or 1 }}"
+          style="--avatar-size:150px;"
         >
       </div>
 
@@ -128,9 +132,9 @@
         <tr id="animal-row-{{ a.id }}">
           <td>
             {% if a.image %}
-              <img src="{{ a.image }}" alt="Foto de {{ a.name }}" class="rounded-circle me-2" style="width: 32px; height: 32px; object-fit: cover;">
+              <img src="{{ a.image }}" alt="Foto de {{ a.name }}" class="avatar me-2" data-offset-x="{{ a.photo_offset_x or 0 }}" data-offset-y="{{ a.photo_offset_y or 0 }}" data-rotation="{{ a.photo_rotation or 0 }}" data-zoom="{{ a.photo_zoom or 1 }}" style="--avatar-size:32px;">
             {% endif %}
-            <span class="animal-name">{{ a.name }}</span>
+              <span class="animal-name">{{ a.name }}</span>
           </td>
           <td class="animal-species">{{ a.species }} / {{ a.breed }}</td>
           <td class="animal-sex">{{ a.sex or '—' }}</td>


### PR DESCRIPTION
## Summary
- add reusable `.avatar` CSS class with size and transform variables
- add JS helper to set avatar translation, rotation, and zoom
- apply avatar class and helper across profile, tutor, and animal listings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4e23c717c832e8fd21d433b3ef6f5