### PR TITLE
Fix misaligned logo on home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -60,7 +60,7 @@
             <div class="text-center">
                 <img src="{{ url_for('static', filename='logo_pet.png') }}"
                      alt="Logo PetOrlândia"
-                     class="mb-4 logo-img">
+                     class="mb-4 logo-img mx-auto">
             </div>
 
             <p class="lead">


### PR DESCRIPTION
## Summary
- Center the landing page logo by adding Bootstrap's `mx-auto`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4e5a39874832eacfc6b460a2c3236