### PR TITLE
Fix photo preview on consultation tabs

### DIFF
--- a/templates/components/photo_cropper.html
+++ b/templates/components/photo_cropper.html
@@ -7,6 +7,9 @@
 {% endif %}
 <div class="photo-cropper-wrapper text-center">
   {% if image_url %}
+  <div id="{{ id }}-preview" class="mb-2">
+    <img src="{{ image_url }}" class="img-thumbnail shadow-sm" style="width: {{ size }}px; height: {{ size }}px; border-radius: 1rem; object-fit: cover;" alt="Imagem atual">
+  </div>
   <button type="button" id="{{ id }}-toggle" class="btn btn-outline-secondary btn-sm mb-2">
     <i class="fas fa-edit me-1"></i> Alterar imagem
   </button>
@@ -56,7 +59,11 @@
   document.addEventListener('DOMContentLoaded', function () {
     const editor = document.getElementById('{{ id }}-editor');
     const toggleBtn = document.getElementById('{{ id }}-toggle');
-    toggleBtn?.addEventListener('click', () => editor.classList.toggle('d-none'));
+    const preview = document.getElementById('{{ id }}-preview');
+    toggleBtn?.addEventListener('click', () => {
+      editor.classList.toggle('d-none');
+      preview?.classList.toggle('d-none');
+    });
 
     const img = document.getElementById('{{ id }}-img');
     const container = document.getElementById('{{ id }}-container');


### PR DESCRIPTION
## Summary
- show existing tutor/animal images in photo cropper
- toggle preview and editor when changing photos

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4e56ec164832ea24846999d709759