### PR TITLE
Improve clinic info layout

### DIFF
--- a/templates/partials/clinic_info.html
+++ b/templates/partials/clinic_info.html
@@ -1,47 +1,49 @@
 <!-- partials/clinic_info.html -->
 {% from 'components/logo.html' import clinic_logo %}
 <div class="card shadow-lg border-0 rounded-3 mb-4">
-  <div class="card-body text-center">
-    <h2 class="fw-bold mb-3">{{ clinica.nome }}</h2>
+  <div class="card-body">
+    <div class="row align-items-center">
+      {% if clinica.logotipo %}
+        <div class="col-md-4 text-center mb-3 mb-md-0">
+          {{ clinic_logo(clinica) }}
+        </div>
+      {% endif %}
+      <div class="{% if clinica.logotipo %}col-md-8{% else %}col-12{% endif %}">
+        <h2 class="fw-bold mb-3 text-center text-md-start">{{ clinica.nome }}</h2>
+        <div class="text-start">
+          {% if clinica.endereco %}
+            <p><i class="fas fa-map-marker-alt text-danger me-2"></i><strong>Endereço:</strong> {{ clinica.endereco }}</p>
+          {% endif %}
+          {% if clinica.telefone %}
+            <p><i class="fas fa-phone-alt text-success me-2"></i><strong>Telefone:</strong> {{ clinica.telefone }}</p>
+          {% endif %}
+          {% if clinica.email %}
+            <p><i class="fas fa-envelope text-primary me-2"></i><strong>Email:</strong> {{ clinica.email }}</p>
+          {% endif %}
+        </div>
 
-    {% if clinica.logotipo %}
-      <div class="mb-3">
-        {{ clinic_logo(clinica) }}
+        {% if pode_editar %}
+          <button class="btn btn-sm btn-outline-primary mt-3" onclick="toggleEditInfo()">Editar</button>
+          <div id="edit-info" class="mt-3" style="display:none;">
+            <form method="post" enctype="multipart/form-data" class="row g-3">
+              {{ clinic_form.hidden_tag() }}
+              <div class="col-md-6">{{ clinic_form.nome.label }} {{ clinic_form.nome(class="form-control") }}</div>
+              <div class="col-md-6">{{ clinic_form.cnpj.label }} {{ clinic_form.cnpj(class="form-control") }}</div>
+              <div class="col-md-12">{{ clinic_form.endereco.label }} {{ clinic_form.endereco(class="form-control") }}</div>
+              <div class="col-md-6">{{ clinic_form.telefone.label }} {{ clinic_form.telefone(class="form-control") }}</div>
+              <div class="col-md-6">{{ clinic_form.email.label }} {{ clinic_form.email(class="form-control") }}</div>
+              <div class="col-md-12">
+                {{ clinic_form.logotipo.label }}
+                {{ photo_cropper(clinic_form.logotipo, clinic_form.photo_rotation, clinic_form.photo_zoom, clinic_form.photo_offset_x, clinic_form.photo_offset_y, clinica.logotipo, 150, 'clinic_logo', 'user') }}
+              </div>
+              <div class="col-12">
+                {{ clinic_form.submit(class="btn btn-primary") }}
+              </div>
+            </form>
+          </div>
+        {% endif %}
       </div>
-    {% endif %}
-
-    <div class="text-start d-inline-block">
-      {% if clinica.endereco %}
-        <p><i class="fas fa-map-marker-alt text-danger me-2"></i><strong>Endereço:</strong> {{ clinica.endereco }}</p>
-      {% endif %}
-      {% if clinica.telefone %}
-        <p><i class="fas fa-phone-alt text-success me-2"></i><strong>Telefone:</strong> {{ clinica.telefone }}</p>
-      {% endif %}
-      {% if clinica.email %}
-        <p><i class="fas fa-envelope text-primary me-2"></i><strong>Email:</strong> {{ clinica.email }}</p>
-      {% endif %}
     </div>
-
-    {% if pode_editar %}
-      <button class="btn btn-sm btn-outline-primary mt-3" onclick="toggleEditInfo()">Editar</button>
-      <div id="edit-info" class="mt-3" style="display:none;">
-        <form method="post" enctype="multipart/form-data" class="row g-3">
-          {{ clinic_form.hidden_tag() }}
-          <div class="col-md-6">{{ clinic_form.nome.label }} {{ clinic_form.nome(class="form-control") }}</div>
-          <div class="col-md-6">{{ clinic_form.cnpj.label }} {{ clinic_form.cnpj(class="form-control") }}</div>
-          <div class="col-md-12">{{ clinic_form.endereco.label }} {{ clinic_form.endereco(class="form-control") }}</div>
-          <div class="col-md-6">{{ clinic_form.telefone.label }} {{ clinic_form.telefone(class="form-control") }}</div>
-          <div class="col-md-6">{{ clinic_form.email.label }} {{ clinic_form.email(class="form-control") }}</div>
-          <div class="col-md-12">
-            {{ clinic_form.logotipo.label }}
-            {{ photo_cropper(clinic_form.logotipo, clinic_form.photo_rotation, clinic_form.photo_zoom, clinic_form.photo_offset_x, clinic_form.photo_offset_y, clinica.logotipo, 150, 'clinic_logo', 'user') }}
-          </div>
-          <div class="col-12">
-            {{ clinic_form.submit(class="btn btn-primary") }}
-          </div>
-        </form>
-      </div>
-    {% endif %}
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Align clinic details beside the clinic logo with responsive columns
- Ensure layout still spans full width when no logo is present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4e613af30832ea15954493ee47a4e