### PR TITLE
feat: centralize avatar transforms

### DIFF
--- a/static/avatar_helper.js
+++ b/static/avatar_helper.js
@@ -1,0 +1,19 @@
+function updateAvatarTransform(img, offsetX, offsetY, rotation, zoom) {
+  if (!img) return;
+  img.style.setProperty('--offset-x', (offsetX || 0) + 'px');
+  img.style.setProperty('--offset-y', (offsetY || 0) + 'px');
+  img.style.setProperty('--rotation', (rotation || 0) + 'deg');
+  img.style.setProperty('--zoom', zoom || 1);
+}
+
+function initAvatarTransforms() {
+  document.querySelectorAll('img.avatar').forEach(img => {
+    const offsetX = parseFloat(img.dataset.offsetX) || 0;
+    const offsetY = parseFloat(img.dataset.offsetY) || 0;
+    const rotation = parseFloat(img.dataset.rotation) || 0;
+    const zoom = parseFloat(img.dataset.zoom) || 1;
+    updateAvatarTransform(img, offsetX, offsetY, rotation, zoom);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initAvatarTransforms);

--- a/static/images.css
+++ b/static/images.css
@@ -6,9 +6,12 @@
 }
 
 .avatar {
-    object-fit: cover;
+    width: var(--avatar-size, 50px);
+    height: var(--avatar-size, 50px);
     border-radius: 50%;
+    object-fit: cover;
     display: block;
+    transform: translate(var(--offset-x, 0), var(--offset-y, 0)) rotate(var(--rotation, 0deg)) scale(var(--zoom, 1));
 }
 
 .card-img {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -855,6 +855,7 @@
       });
     });
   </script>
+  <script src="{{ url_for('static', filename='avatar_helper.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -15,7 +15,15 @@
 
           {% if current_user.profile_photo %}
             <div id="photo-container" class="img-thumbnail shadow-sm mb-2 position-relative overflow-hidden" style="width: 240px; height: 240px; border-radius: 1rem;">
-              <img id="profile-photo-img" src="{{ current_user.profile_photo }}" class="avatar w-100 h-100" style="transform: translate({{ current_user.photo_offset_x or 0 }}px, {{ current_user.photo_offset_y or 0 }}px) rotate({{ current_user.photo_rotation or 0 }}deg) scale({{ current_user.photo_zoom or 1 }});" alt="Foto de {{ current_user.name }}">
+              <img id="profile-photo-img"
+                   src="{{ current_user.profile_photo }}"
+                   class="avatar"
+                   data-offset-x="{{ current_user.photo_offset_x or 0 }}"
+                   data-offset-y="{{ current_user.photo_offset_y or 0 }}"
+                   data-rotation="{{ current_user.photo_rotation or 0 }}"
+                   data-zoom="{{ current_user.photo_zoom or 1 }}"
+                   style="--avatar-size:100%;"
+                   alt="Foto de {{ current_user.name }}">
             </div>
           {% else %}
             <div class="bg-light border d-flex align-items-center justify-content-center mb-2" style="width: 240px; height: 240px; border-radius: 1rem; font-size: 1.2rem; color: #555;">

--- a/templates/tutor_detail.html
+++ b/templates/tutor_detail.html
@@ -25,11 +25,13 @@
           id="preview-tutor"
           src="{{ tutor.profile_photo or '' }}"
           alt="Foto do Tutor"
-          class="img-thumbnail {% if not tutor.profile_photo %}d-none{% endif %}"
-          style="width:150px; height:150px; object-fit: cover;"
+          class="avatar img-thumbnail {% if not tutor.profile_photo %}d-none{% endif %}"
+          style="--avatar-size:150px;"
           loading="lazy"
-          width="150"
-          height="150"
+          data-offset-x="{{ tutor.photo_offset_x or 0 }}"
+          data-offset-y="{{ tutor.photo_offset_y or 0 }}"
+          data-rotation="{{ tutor.photo_rotation or 0 }}"
+          data-zoom="{{ tutor.photo_zoom or 1 }}"
         >
       </div>
 
@@ -132,7 +134,14 @@
           <td>
             {% if a.image %}
  
-              <img src="{{ a.image }}" alt="Foto de {{ a.name }}" class="avatar me-2" width="32" height="32">
+              <img src="{{ a.image }}"
+                   alt="Foto de {{ a.name }}"
+                   class="avatar me-2"
+                   data-offset-x="{{ a.photo_offset_x or 0 }}"
+                   data-offset-y="{{ a.photo_offset_y or 0 }}"
+                   data-rotation="{{ a.photo_rotation or 0 }}"
+                   data-zoom="{{ a.photo_zoom or 1 }}"
+                   style="--avatar-size:32px;">
  
             {% endif %}
             <span class="animal-name">{{ a.name }}</span>


### PR DESCRIPTION
## Summary
- add configurable avatar CSS class with transform via variables
- move image offset/rotation/zoom logic to JS helper
- use avatar helper on profile and tutor pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4e63eb080832ea835988dbad9a7c6