### PR TITLE
Amplia tamanho das fotos de tutor e animal na consulta QR

### DIFF
--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -31,11 +31,11 @@
     </div>
 
     {% if animal %}
-      <div class="animal-photo shadow-sm rounded-circle border border-2 border-primary">
+      <div class="animal-photo shadow-sm rounded-circle border border-2 border-primary" style="width: 120px; height: 120px;">
         {% if animal.photo %}
-          <img src="{{ animal.photo.url }}" alt="{{ animal.name }}" class="rounded-circle" width="56" height="56">
+          <img src="{{ animal.photo.url }}" alt="{{ animal.name }}" class="rounded-circle" width="120" height="120">
         {% else %}
-          <div class="no-photo-placeholder rounded-circle bg-light d-flex align-items-center justify-content-center" style="width: 56px; height: 56px;">
+          <div class="no-photo-placeholder rounded-circle bg-light d-flex align-items-center justify-content-center" style="width: 120px; height: 120px;">
             <i class="fa-solid fa-camera text-muted"></i>
           </div>
         {% endif %}

--- a/templates/partials/animal_form.html
+++ b/templates/partials/animal_form.html
@@ -10,7 +10,7 @@
     <div class="col-md-6">
       <label for="animal-name" class="form-label">Foto e Nome do Animal</label>
         <div class="d-flex align-items-center gap-3">
-          {{ photo_cropper(form.image, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, animal.image, 60, 'animal-image', 'animal') }}
+          {{ photo_cropper(form.image, form.photo_rotation, form.photo_zoom, form.photo_offset_x, form.photo_offset_y, animal.image, 120, 'animal-image', 'animal') }}
           <input id="animal-name" type="text" name="name" class="form-control"
                  placeholder="Nome do animal" value="{{ animal.name or '' }}" required
                  minlength="2" maxlength="50">

--- a/templates/partials/tutor_form.html
+++ b/templates/partials/tutor_form.html
@@ -36,7 +36,7 @@
       <div class="d-flex align-items-center gap-3">
         {{ photo_cropper(tutor_form.profile_photo, tutor_form.photo_rotation, tutor_form.photo_zoom,
                          tutor_form.photo_offset_x, tutor_form.photo_offset_y,
-                         tutor.profile_photo if has_tutor else '', 60, 'profile_photo') }}
+                         tutor.profile_photo if has_tutor else '', 120, 'profile_photo') }}
         <input type="text" name="name" class="form-control" placeholder="Nome completo do tutor"
                value="{{ tutor.name|default('', true) if has_tutor else '' }}" required minlength="3" maxlength="100">
         <div class="invalid-feedback">Por favor, insira um nome válido (3-100 caracteres)</div>


### PR DESCRIPTION
## Summary
- exibe foto do animal na consulta QR em tamanho maior
- amplia campos de foto de tutor e animal para facilitar visualização

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4e734567c832ebed812e88e5617b8