### PR TITLE
Add additional veterinary consent terms

### DIFF
--- a/app.py
+++ b/app.py
@@ -1333,6 +1333,12 @@ def termo_animal(animal_id, tipo):
     templates = {
         'internacao': 'termo_internacao.html',
         'eutanasia': 'termo_eutanasia.html',
+        'procedimentos': 'termo_procedimentos.html',
+        'exames': 'termo_exames.html',
+        'imagem': 'termo_imagem.html',
+        'medicacao': 'termo_medicacao.html',
+        'planos': 'termo_planos.html',
+        'adocao': 'termo_adocao.html',
     }
     template = templates.get(tipo)
     if not template:

--- a/templates/partials/documentos.html
+++ b/templates/partials/documentos.html
@@ -1,9 +1,15 @@
 <h5 class="mb-3">Documentos</h5>
 {% if current_user.worker == 'veterinario' %}
 <div class="mb-3">
-  <div class="btn-group">
+  <div class="btn-group flex-wrap">
     <a href="{{ url_for('termo_animal', animal_id=animal.id, tipo='internacao') }}" target="_blank" class="btn btn-sm btn-outline-primary">Termo de Internação</a>
     <a href="{{ url_for('termo_animal', animal_id=animal.id, tipo='eutanasia') }}" target="_blank" class="btn btn-sm btn-outline-primary">Termo de Eutanásia</a>
+    <a href="{{ url_for('termo_animal', animal_id=animal.id, tipo='procedimentos') }}" target="_blank" class="btn btn-sm btn-outline-primary">Termo de Consentimento para Procedimentos</a>
+    <a href="{{ url_for('termo_animal', animal_id=animal.id, tipo='exames') }}" target="_blank" class="btn btn-sm btn-outline-primary">Termo de Responsabilidade para Exames</a>
+    <a href="{{ url_for('termo_animal', animal_id=animal.id, tipo='imagem') }}" target="_blank" class="btn btn-sm btn-outline-primary">Termo de Uso de Imagem</a>
+    <a href="{{ url_for('termo_animal', animal_id=animal.id, tipo='medicacao') }}" target="_blank" class="btn btn-sm btn-outline-primary">Termo de Responsabilidade de Medicação</a>
+    <a href="{{ url_for('termo_animal', animal_id=animal.id, tipo='planos') }}" target="_blank" class="btn btn-sm btn-outline-primary">Contrato de Planos de Saúde / Pacotes</a>
+    <a href="{{ url_for('termo_animal', animal_id=animal.id, tipo='adocao') }}" target="_blank" class="btn btn-sm btn-outline-primary">Termo de Adoção Responsável</a>
   </div>
 </div>
 {% endif %}

--- a/templates/termo_adocao.html
+++ b/templates/termo_adocao.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Termo de Eutanásia | {{ clinica.nome }}</title>
+  <title>Termo de Adoção Responsável | {{ clinica.nome }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}">
 </head>
 <body>
@@ -25,15 +25,13 @@
     </div>
   {% endif %}
 
-  <h2>Termo de Eutanásia</h2>
+  <h2>Termo de Adoção Responsável</h2>
 
-  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a realização do procedimento de eutanásia no animal {{ animal.name }} na clínica {{ clinica.nome }}.</p>
+  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, assumo a guarda do animal {{ animal.name }} de forma responsável.</p>
 
-  <p>Estou ciente de que a eutanásia é um procedimento irreversível, indicado com o objetivo de evitar sofrimento ao paciente, e que todas as outras alternativas terapêuticas foram discutidas com a equipe veterinária.</p>
+  <p>Comprometo-me a fornecer alimentação adequada, vacinação, cuidados veterinários e um ambiente seguro para o animal.</p>
 
-  <p>Declaro que recebi todas as informações necessárias e assumo a responsabilidade pela decisão tomada.</p>
-
-  <p>Fica definido que o destino do corpo será: ____________________________________________ (sepultamento, cremação ou descarte adequado).</p>
+  <p>Estou ciente de que, em caso de maus-tratos ou abandono, o animal poderá ser recolhido e a adoção cancelada.</p>
 
   <div class="assinatura">
     ___________________________________________<br>
@@ -68,7 +66,7 @@
       alert('Número de telefone do responsável não informado.');
       return;
     }
-    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de eutanásia de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
+    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de adoção responsável de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
     const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
     try {
       const wpp = window.open(url, '_blank');

--- a/templates/termo_exames.html
+++ b/templates/termo_exames.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Termo de Eutanásia | {{ clinica.nome }}</title>
+  <title>Termo de Responsabilidade para Exames | {{ clinica.nome }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}">
 </head>
 <body>
@@ -25,15 +25,13 @@
     </div>
   {% endif %}
 
-  <h2>Termo de Eutanásia</h2>
+  <h2>Termo de Responsabilidade para Exames</h2>
 
-  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a realização do procedimento de eutanásia no animal {{ animal.name }} na clínica {{ clinica.nome }}.</p>
+  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a coleta de amostras e a realização de exames no animal {{ animal.name }}.</p>
 
-  <p>Estou ciente de que a eutanásia é um procedimento irreversível, indicado com o objetivo de evitar sofrimento ao paciente, e que todas as outras alternativas terapêuticas foram discutidas com a equipe veterinária.</p>
+  <p>Estou ciente dos riscos envolvidos, incluindo a possibilidade de sedação para realização de determinados procedimentos.</p>
 
-  <p>Declaro que recebi todas as informações necessárias e assumo a responsabilidade pela decisão tomada.</p>
-
-  <p>Fica definido que o destino do corpo será: ____________________________________________ (sepultamento, cremação ou descarte adequado).</p>
+  <p>Autorizo o compartilhamento dos resultados com laboratórios parceiros quando necessário para o diagnóstico.</p>
 
   <div class="assinatura">
     ___________________________________________<br>
@@ -68,7 +66,7 @@
       alert('Número de telefone do responsável não informado.');
       return;
     }
-    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de eutanásia de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
+    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de responsabilidade para exames de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
     const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
     try {
       const wpp = window.open(url, '_blank');

--- a/templates/termo_imagem.html
+++ b/templates/termo_imagem.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Termo de Eutanásia | {{ clinica.nome }}</title>
+  <title>Termo de Uso de Imagem | {{ clinica.nome }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}">
 </head>
 <body>
@@ -25,15 +25,11 @@
     </div>
   {% endif %}
 
-  <h2>Termo de Eutanásia</h2>
+  <h2>Termo de Uso de Imagem</h2>
 
-  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a realização do procedimento de eutanásia no animal {{ animal.name }} na clínica {{ clinica.nome }}.</p>
+  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a utilização de fotos e vídeos do animal {{ animal.name }} pela clínica {{ clinica.nome }} para fins de divulgação, como registros de procedimentos, campanhas de adoção e publicações em redes sociais.</p>
 
-  <p>Estou ciente de que a eutanásia é um procedimento irreversível, indicado com o objetivo de evitar sofrimento ao paciente, e que todas as outras alternativas terapêuticas foram discutidas com a equipe veterinária.</p>
-
-  <p>Declaro que recebi todas as informações necessárias e assumo a responsabilidade pela decisão tomada.</p>
-
-  <p>Fica definido que o destino do corpo será: ____________________________________________ (sepultamento, cremação ou descarte adequado).</p>
+  <p>Esta autorização é concedida sem ônus e poderá ser revogada a qualquer momento mediante solicitação por escrito.</p>
 
   <div class="assinatura">
     ___________________________________________<br>
@@ -68,7 +64,7 @@
       alert('Número de telefone do responsável não informado.');
       return;
     }
-    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de eutanásia de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
+    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de uso de imagem de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
     const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
     try {
       const wpp = window.open(url, '_blank');

--- a/templates/termo_medicacao.html
+++ b/templates/termo_medicacao.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Termo de Eutanásia | {{ clinica.nome }}</title>
+  <title>Termo de Responsabilidade de Medicação | {{ clinica.nome }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}">
 </head>
 <body>
@@ -25,15 +25,11 @@
     </div>
   {% endif %}
 
-  <h2>Termo de Eutanásia</h2>
+  <h2>Termo de Responsabilidade de Medicação</h2>
 
-  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a realização do procedimento de eutanásia no animal {{ animal.name }} na clínica {{ clinica.nome }}.</p>
+  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a aplicação de medicações no animal {{ animal.name }} durante o tratamento prestado pela clínica {{ clinica.nome }}.</p>
 
-  <p>Estou ciente de que a eutanásia é um procedimento irreversível, indicado com o objetivo de evitar sofrimento ao paciente, e que todas as outras alternativas terapêuticas foram discutidas com a equipe veterinária.</p>
-
-  <p>Declaro que recebi todas as informações necessárias e assumo a responsabilidade pela decisão tomada.</p>
-
-  <p>Fica definido que o destino do corpo será: ____________________________________________ (sepultamento, cremação ou descarte adequado).</p>
+  <p>Estou ciente de que, após a alta hospitalar, é minha responsabilidade administrar corretamente os medicamentos prescritos e seguir todas as orientações fornecidas pela equipe veterinária.</p>
 
   <div class="assinatura">
     ___________________________________________<br>
@@ -68,7 +64,7 @@
       alert('Número de telefone do responsável não informado.');
       return;
     }
-    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de eutanásia de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
+    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de responsabilidade de medicação de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
     const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
     try {
       const wpp = window.open(url, '_blank');

--- a/templates/termo_planos.html
+++ b/templates/termo_planos.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Termo de Eutanásia | {{ clinica.nome }}</title>
+  <title>Contrato de Planos de Saúde / Pacotes | {{ clinica.nome }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}">
 </head>
 <body>
@@ -25,15 +25,11 @@
     </div>
   {% endif %}
 
-  <h2>Termo de Eutanásia</h2>
+  <h2>Contrato de Planos de Saúde / Pacotes</h2>
 
-  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a realização do procedimento de eutanásia no animal {{ animal.name }} na clínica {{ clinica.nome }}.</p>
+  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, declaro aderir ao plano ou pacote de serviços veterinários oferecido pela clínica {{ clinica.nome }} para o animal {{ animal.name }}.</p>
 
-  <p>Estou ciente de que a eutanásia é um procedimento irreversível, indicado com o objetivo de evitar sofrimento ao paciente, e que todas as outras alternativas terapêuticas foram discutidas com a equipe veterinária.</p>
-
-  <p>Declaro que recebi todas as informações necessárias e assumo a responsabilidade pela decisão tomada.</p>
-
-  <p>Fica definido que o destino do corpo será: ____________________________________________ (sepultamento, cremação ou descarte adequado).</p>
+  <p>Estou ciente da mensalidade, das coberturas e exclusões, bem como das condições de cancelamento e demais cláusulas apresentadas pela clínica.</p>
 
   <div class="assinatura">
     ___________________________________________<br>
@@ -68,7 +64,7 @@
       alert('Número de telefone do responsável não informado.');
       return;
     }
-    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de eutanásia de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
+    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o contrato de plano de saúde/pacote de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
     const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
     try {
       const wpp = window.open(url, '_blank');

--- a/templates/termo_procedimentos.html
+++ b/templates/termo_procedimentos.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Termo de Eutanásia | {{ clinica.nome }}</title>
+  <title>Termo de Consentimento para Procedimentos | {{ clinica.nome }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}">
 </head>
 <body>
@@ -25,15 +25,15 @@
     </div>
   {% endif %}
 
-  <h2>Termo de Eutanásia</h2>
+  <h2>Termo de Consentimento para Procedimentos</h2>
 
-  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a realização do procedimento de eutanásia no animal {{ animal.name }} na clínica {{ clinica.nome }}.</p>
+  <p>Eu, {{ tutor.name }}, CPF {{ tutor.cpf or '—' }}, autorizo a realização de procedimentos veterinários no animal {{ animal.name }} na clínica {{ clinica.nome }}.</p>
 
-  <p>Estou ciente de que a eutanásia é um procedimento irreversível, indicado com o objetivo de evitar sofrimento ao paciente, e que todas as outras alternativas terapêuticas foram discutidas com a equipe veterinária.</p>
+  <p>Fui informado sobre os riscos, benefícios e alternativas aos procedimentos propostos, incluindo cirurgias como castração, intervenções ortopédicas e remoção de tumores.</p>
 
-  <p>Declaro que recebi todas as informações necessárias e assumo a responsabilidade pela decisão tomada.</p>
+  <p>Estou ciente de que podem ocorrer complicações ou óbito mesmo com todos os cuidados adotados.</p>
 
-  <p>Fica definido que o destino do corpo será: ____________________________________________ (sepultamento, cremação ou descarte adequado).</p>
+  <p>Autorizo o uso de anestesia, medicações e exames necessários à execução do procedimento.</p>
 
   <div class="assinatura">
     ___________________________________________<br>
@@ -68,7 +68,7 @@
       alert('Número de telefone do responsável não informado.');
       return;
     }
-    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de eutanásia de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
+    const mensagem = encodeURIComponent(`Olá {{ tutor.name }}! Segue o termo de consentimento para procedimentos de {{ animal.name }}:\n\n${window.location.href}\n\nQualquer dúvida, estamos à disposição.\nAtenciosamente,\nEquipe {{ clinica.nome }}`);
     const url = `https://api.whatsapp.com/send?phone=${numeroWhatsApp}&text=${mensagem}`;
     try {
       const wpp = window.open(url, '_blank');


### PR DESCRIPTION
## Summary
- Extend document tab to offer eight veterinary consent forms
- Provide templates for procedure consent, exam responsibility, image use, medication, health plans, and adoption
- Include body disposition paragraph in euthanasia consent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f123cda8832eb61f6e7c2638d71a