### PR TITLE
Organiza agenda invertendo horários e consultas

### DIFF
--- a/app.py
+++ b/app.py
@@ -6382,9 +6382,17 @@ def appointments():
         horarios = VetSchedule.query.filter_by(
             veterinario_id=veterinario.id
         ).all()
-        appointments = (
+        now = datetime.utcnow()
+        appointments_upcoming = (
             Appointment.query.filter_by(veterinario_id=veterinario.id)
+            .filter(Appointment.scheduled_at >= now)
             .order_by(Appointment.scheduled_at)
+            .all()
+        )
+        appointments_past = (
+            Appointment.query.filter_by(veterinario_id=veterinario.id)
+            .filter(Appointment.scheduled_at < now)
+            .order_by(Appointment.scheduled_at.desc())
             .all()
         )
 
@@ -6394,7 +6402,8 @@ def appointments():
             appointment_form=appointment_form,
             veterinario=veterinario,
             horarios=horarios,
-            appointments=appointments,
+            appointments_upcoming=appointments_upcoming,
+            appointments_past=appointments_past,
         )
     else:
         if current_user.worker in ['colaborador', 'admin']:

--- a/templates/edit_vet_schedule.html
+++ b/templates/edit_vet_schedule.html
@@ -79,7 +79,53 @@
     </div>
   </div>
 
-  <h3>Horários Cadastrados</h3>
+  <h3 class="text-primary"><i class="fas fa-calendar-alt me-2"></i>Consultas Agendadas</h3>
+  <ul class="list-group mb-4">
+    {% for appt in appointments_upcoming %}
+      <li class="list-group-item list-group-item-success appointment-item"
+          data-id="{{ appt.id }}"
+          data-date="{{ appt.scheduled_at.strftime('%Y-%m-%d') }}"
+          data-time="{{ appt.scheduled_at.strftime('%H:%M') }}"
+          data-vet="{{ appt.veterinario.user.name }}"
+          data-tutor="{{ appt.tutor.name }}"
+          data-tutor-id="{{ appt.tutor_id }}"
+          data-animal="{{ appt.animal.name }}"
+          data-animal-id="{{ appt.animal_id }}"
+          data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
+          data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
+          data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}"
+          data-notes="{{ appt.notes or '' }}">
+        {{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }} ({{ appt.tutor.name }})
+      </li>
+    {% else %}
+      <li class="list-group-item">Nenhuma consulta agendada.</li>
+    {% endfor %}
+  </ul>
+
+  <h4 class="text-secondary mt-4"><i class="fas fa-history me-2"></i>Consultas Passadas</h4>
+  <ul class="list-group mb-4">
+    {% for appt in appointments_past %}
+      <li class="list-group-item list-group-item-secondary appointment-item"
+          data-id="{{ appt.id }}"
+          data-date="{{ appt.scheduled_at.strftime('%Y-%m-%d') }}"
+          data-time="{{ appt.scheduled_at.strftime('%H:%M') }}"
+          data-vet="{{ appt.veterinario.user.name }}"
+          data-tutor="{{ appt.tutor.name }}"
+          data-tutor-id="{{ appt.tutor_id }}"
+          data-animal="{{ appt.animal.name }}"
+          data-animal-id="{{ appt.animal_id }}"
+          data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
+          data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
+          data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}"
+          data-notes="{{ appt.notes or '' }}">
+        {{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }} ({{ appt.tutor.name }})
+      </li>
+    {% else %}
+      <li class="list-group-item">Nenhuma consulta passada.</li>
+    {% endfor %}
+  </ul>
+
+  <h3 class="text-success mt-4"><i class="fas fa-clock me-2"></i>Horários Cadastrados</h3>
   <button class="btn btn-sm btn-outline-secondary mb-2" onclick="toggleScheduleEdit()">Editar horários</button>
   <ul class="list-unstyled">
     {% for dia, itens in horarios|sort(attribute='dia_semana')|groupby('dia_semana') %}
@@ -112,29 +158,6 @@
       </li>
     {% else %}
       <li>Nenhum horário cadastrado.</li>
-    {% endfor %}
-  </ul>
-
-  <h3>Consultas Agendadas</h3>
-  <ul class="list-group">
-    {% for appt in appointments %}
-      <li class="list-group-item appointment-item"
-          data-id="{{ appt.id }}"
-          data-date="{{ appt.scheduled_at.strftime('%Y-%m-%d') }}"
-          data-time="{{ appt.scheduled_at.strftime('%H:%M') }}"
-          data-vet="{{ appt.veterinario.user.name }}"
-          data-tutor="{{ appt.tutor.name }}"
-          data-tutor-id="{{ appt.tutor_id }}"
-          data-animal="{{ appt.animal.name }}"
-          data-animal-id="{{ appt.animal_id }}"
-          data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
-          data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
-          data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}"
-          data-notes="{{ appt.notes or '' }}">
-        {{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }} ({{ appt.tutor.name }})
-      </li>
-    {% else %}
-      <li class="list-group-item">Nenhuma consulta agendada.</li>
     {% endfor %}
   </ul>
 


### PR DESCRIPTION
## Summary
- Ordena consultas do veterinário mostrando as mais próximas primeiro
- Separa consultas passadas em sua própria lista
- Adiciona ícones e cores e inverte a ordem de exibição com horários cadastrados

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4f2b353d8832ea67fc6a088843cb2