### PR TITLE
Sanitize filenames for S3 uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,6 +108,7 @@ def upload_to_s3(file, filename, folder="uploads") -> str | None:
     try:
         fileobj = file
         content_type = file.content_type
+        filename = secure_filename(filename)
 
         if content_type and content_type.startswith("image"):
             image = Image.open(file.stream)
@@ -121,6 +122,8 @@ def upload_to_s3(file, filename, folder="uploads") -> str | None:
             name, ext = os.path.splitext(filename)
             if ext.lower() not in {".jpg", ".jpeg"}:
                 filename = f"{name}.jpg"
+
+        filename = secure_filename(filename)
 
         key = f"{folder}/{filename}"
 


### PR DESCRIPTION
## Summary
- Sanitize filenames before uploading to S3 to avoid errors that trigger local fallback
- Test that upload_to_s3 uses secure filenames and still sets public ACL

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b507c9ce54832ead3501b05f366308