### PR TITLE
Handle S3 ACL restrictions for photo uploads

### DIFF
--- a/tests/test_s3_upload.py
+++ b/tests/test_s3_upload.py
@@ -1,10 +1,14 @@
+import os
+import sys
 from io import BytesIO
 from werkzeug.datastructures import FileStorage
 from PIL import Image
-import app
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app  # noqa: E402
 
 
-def test_upload_to_s3_sets_public_read_acl(monkeypatch):
+def test_upload_to_s3_uses_content_type(monkeypatch):
     monkeypatch.setattr(app, "BUCKET", "test-bucket")
 
     captured = {}
@@ -24,10 +28,10 @@ def test_upload_to_s3_sets_public_read_acl(monkeypatch):
     fs = FileStorage(stream=img_bytes, filename='logo.png', content_type='image/png')
     url = app.upload_to_s3(fs, 'logo.png', folder='clinicas')
 
-    assert captured['extra']['ACL'] == 'public-read'
-    assert captured['extra']['ContentType'] == 'image/jpeg'
     assert captured['bucket'] == 'test-bucket'
     assert captured['key'].startswith('clinicas/logo.jpg')
+    assert captured['extra']['ContentType'] == 'image/jpeg'
+    assert 'ACL' not in captured['extra']
     assert url == f"https://test-bucket.s3.amazonaws.com/{captured['key']}"
 
 


### PR DESCRIPTION
## Summary
- Remove hard-coded `public-read` ACL from S3 uploads and buffer files to support retry/local fallback
- Adjust S3 upload tests to verify content type and absence of ACL

## Testing
- `pytest tests/test_s3_upload.py tests/test_upload_to_s3_local_fallback.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b50a7a1d60832e97056161f5a63593