### PR TITLE
Show birth date inputs in Brazilian format

### DIFF
--- a/templates/add_animal.html
+++ b/templates/add_animal.html
@@ -49,21 +49,19 @@
                 </select>
             </div>
 
-            <div class="mb-3">
-                {{ form.age.label(class="form-label") }}
-                {{ form.age(class="form-control rounded-pill" + (" is-invalid" if form.age.errors else ""), id="age", placeholder="Ex: 2") }}
-                {% for error in form.age.errors %}
-                    <div class="invalid-feedback d-block">{{ error }}</div>
-                {% endfor %}
-            </div>
-
-            <div class="mb-3">
-                {{ form.date_of_birth.label(class="form-label") }}
-                {{ form.date_of_birth(class="form-control rounded-pill" + (" is-invalid" if form.date_of_birth.errors else ""), id="date_of_birth", lang="pt-BR", placeholder="dd/mm/aaaa") }}
-                {% for error in form.date_of_birth.errors %}
-                    <div class="invalid-feedback d-block">{{ error }}</div>
-                {% endfor %}
-            </div>
+            {% set prefixo = 'animal' %}
+            {% set nome_data = 'date_of_birth' %}
+            {% set nome_idade = 'age' %}
+            {% set valor_data = form.date_of_birth.data.strftime('%d/%m/%Y') if form.date_of_birth.data else '' %}
+            {% set valor_data_iso = form.date_of_birth.data.strftime('%Y-%m-%d') if form.date_of_birth.data else '' %}
+            {% set valor_idade = form.age.data if form.age.data else '' %}
+            {% include 'components/campo_data_idade.html' %}
+            {% for error in form.age.errors %}
+                <div class="invalid-feedback d-block">{{ error }}</div>
+            {% endfor %}
+            {% for error in form.date_of_birth.errors %}
+                <div class="invalid-feedback d-block">{{ error }}</div>
+            {% endfor %}
 
             <div class="mb-3">
                 {{ form.sex.label(class="form-label") }}
@@ -114,12 +112,15 @@
     </div>
 </div>
 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.8/dist/inputmask.min.js"></script>
+
 <script>
     document.addEventListener("DOMContentLoaded", function () {
         const modoSelect = document.getElementById("modo");
         const priceField = document.getElementById("price-field");
-        const ageInput = document.getElementById("age");
-        const dobInput = document.getElementById("date_of_birth");
 
         function togglePriceField() {
             if (modoSelect.value === "venda") {
@@ -131,33 +132,6 @@
 
         modoSelect.addEventListener("change", togglePriceField);
         togglePriceField();
-
-        function calcularDataNascimentoPorIdade() {
-            const idade = parseInt(ageInput.value);
-            if (!isNaN(idade)) {
-                const hoje = new Date();
-                const nascimento = new Date();
-                nascimento.setFullYear(hoje.getFullYear() - idade);
-                dobInput.value = nascimento.toISOString().split('T')[0];
-            }
-        }
-
-        function calcularIdadePorDataNascimento() {
-            const dataNascStr = dobInput.value;
-            if (dataNascStr) {
-                const nascimento = new Date(dataNascStr);
-                const hoje = new Date();
-                let idade = hoje.getFullYear() - nascimento.getFullYear();
-                const m = hoje.getMonth() - nascimento.getMonth();
-                if (m < 0 || (m === 0 && hoje.getDate() < nascimento.getDate())) {
-                    idade--;
-                }
-                ageInput.value = idade;
-            }
-        }
-
-        ageInput.addEventListener('input', calcularDataNascimentoPorIdade);
-        dobInput.addEventListener('change', calcularIdadePorDataNascimento);
 
     });
 </script>

--- a/templates/components/campo_data_idade.html
+++ b/templates/components/campo_data_idade.html
@@ -22,6 +22,7 @@
         min="0"
         class="form-control"
         id="{{ prefixo }}_age"
+        name="{{ nome_idade or 'age' }}"
         value="{{ valor_idade or '' }}"
         data-age
       >
@@ -44,6 +45,12 @@
     // Máscara de input dd/mm/yyyy
     Inputmask("99/99/9999").mask(dobInput);
 
+    // Função utilitária para formatar datas no padrão YYYY-MM-DD
+    const formatISO = (d) => {
+      const pad = (n) => String(n).padStart(2, '0');
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    };
+
     // Inicializa flatpickr diretamente no campo visível
     const fp = flatpickr(dobInput, {
       locale: "pt",
@@ -55,7 +62,7 @@
       onReady: function () {
         const parsed = parseData(dobInput.value);
         if (parsed) atualizarIdade(parsed);
-        if (parsed && hiddenInput) hiddenInput.value = parsed.toISOString().split('T')[0];
+        if (parsed && hiddenInput) hiddenInput.value = formatISO(parsed);
       },
 
       onChange: function (selectedDates) {
@@ -84,7 +91,7 @@
           ageUnit.textContent = meses === 1 ? 'mês' : 'meses';
         }
       }
-      if (hiddenInput) hiddenInput.value = dataNascimento.toISOString().split('T')[0];
+      if (hiddenInput) hiddenInput.value = formatISO(dataNascimento);
     }
 
     // Quando o usuário digita a idade
@@ -94,7 +101,7 @@
         const hoje = new Date();
         const estimada = new Date(hoje.getFullYear() - idade, hoje.getMonth(), hoje.getDate());
         fp.setDate(estimada, true);
-        if (hiddenInput) hiddenInput.value = estimada.toISOString().split('T')[0];
+        if (hiddenInput) hiddenInput.value = formatISO(estimada);
         if (ageUnit) ageUnit.textContent = 'anos';
       }
     });
@@ -104,7 +111,7 @@
       const parsed = parseData(dobInput.value);
       if (parsed) {
         fp.setDate(parsed, true);
-        if (hiddenInput) hiddenInput.value = parsed.toISOString().split('T')[0];
+        if (hiddenInput) hiddenInput.value = formatISO(parsed);
       }
     });
 

--- a/templates/editar_animal.html
+++ b/templates/editar_animal.html
@@ -27,8 +27,19 @@
         {% endfor %}
     </select>
 
-    {{ form.age.label(class="mt-2") }} {{ form.age(class="form-control", id="age") }}
-    {{ form.date_of_birth.label(class="mt-2") }} {{ form.date_of_birth(class="form-control", id="date_of_birth", lang="pt-BR", placeholder="dd/mm/aaaa") }}
+    {% set prefixo = 'animal' %}
+    {% set nome_data = 'date_of_birth' %}
+    {% set nome_idade = 'age' %}
+    {% set valor_data = form.date_of_birth.data.strftime('%d/%m/%Y') if form.date_of_birth.data else (animal.date_of_birth.strftime('%d/%m/%Y') if animal.date_of_birth else '') %}
+    {% set valor_data_iso = form.date_of_birth.data.strftime('%Y-%m-%d') if form.date_of_birth.data else (animal.date_of_birth.strftime('%Y-%m-%d') if animal.date_of_birth else '') %}
+    {% set valor_idade = form.age.data if form.age.data else (animal.age if animal.age else '') %}
+    {% include 'components/campo_data_idade.html' %}
+    {% for error in form.age.errors %}
+      <div class="invalid-feedback d-block">{{ error }}</div>
+    {% endfor %}
+    {% for error in form.date_of_birth.errors %}
+      <div class="invalid-feedback d-block">{{ error }}</div>
+    {% endfor %}
     {{ form.sex.label(class="mt-2") }} {{ form.sex(class="form-select") }}
     {{ form.description.label(class="mt-2") }} {{ form.description(class="form-control") }}
     {{ form.image.label(class="mt-2") }}
@@ -52,6 +63,11 @@
     <button type="submit" class="btn btn-danger mt-3">🗑️ Deletar Animal</button>
 </form>
 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.8/dist/inputmask.min.js"></script>
+
 <script>
     const modoSelect = document.getElementById("modo");
     const priceField = document.getElementById("price-field");
@@ -66,32 +82,5 @@
 
     modoSelect.addEventListener("change", togglePriceField);
     document.addEventListener("DOMContentLoaded", togglePriceField);
-
-    function calcularDataNascimentoPorIdade() {
-        const idade = parseInt(document.getElementById('age').value);
-        if (!isNaN(idade)) {
-            const hoje = new Date();
-            const nascimento = new Date();
-            nascimento.setFullYear(hoje.getFullYear() - idade);
-            document.getElementById('date_of_birth').value = nascimento.toISOString().split('T')[0];
-        }
-    }
-
-    function calcularIdadePorDataNascimento() {
-        const dataNascStr = document.getElementById('date_of_birth').value;
-        if (dataNascStr) {
-            const nascimento = new Date(dataNascStr);
-            const hoje = new Date();
-            let idade = hoje.getFullYear() - nascimento.getFullYear();
-            const m = hoje.getMonth() - nascimento.getMonth();
-            if (m < 0 || (m === 0 && hoje.getDate() < nascimento.getDate())) {
-                idade--;
-            }
-            document.getElementById('age').value = idade;
-        }
-    }
-
-    document.getElementById('age').addEventListener('input', calcularDataNascimentoPorIdade);
-    document.getElementById('date_of_birth').addEventListener('change', calcularIdadePorDataNascimento);
 </script>
 {% endblock %}

--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -52,14 +52,10 @@
           <option value="Fêmea">Fêmea</option>
         </select>
       </div>
-      <div class="col-md-6">
-        <label class="form-label">Data de Nascimento</label>
-        <input type="date" name="date_of_birth" id="date_of_birth" class="form-control" lang="pt-BR" placeholder="dd/mm/aaaa">
-      </div>
-      <div class="col-md-6">
-        <label class="form-label">Idade (anos)</label>
-        <input type="number" name="age" id="age" class="form-control" min="0">
-      </div>
+      {% set prefixo = 'animal_reg' %}
+      {% set nome_data = 'date_of_birth' %}
+      {% set nome_idade = 'age' %}
+      {% include 'components/campo_data_idade.html' %}
       <div class="col-md-6">
         <label class="form-label">Microchip</label>
         <input type="text" name="microchip_number" class="form-control">
@@ -87,36 +83,14 @@
         📂 Salvar Animal
       </button>
     </div>
-  </form>
+    </form>
 
-  <script>
-    function calcularDataNascimentoPorIdade() {
-      const idade = parseInt(document.getElementById('age').value);
-      if (!isNaN(idade)) {
-        const hoje = new Date();
-        const nascimento = new Date();
-        nascimento.setFullYear(hoje.getFullYear() - idade);
-        document.getElementById('date_of_birth').value = nascimento.toISOString().split('T')[0];
-      }
-    }
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.8/dist/inputmask.min.js"></script>
 
-    function calcularIdadePorDataNascimento() {
-      const dataNascStr = document.getElementById('date_of_birth').value;
-      if (dataNascStr) {
-        const nascimento = new Date(dataNascStr);
-        const hoje = new Date();
-        let idade = hoje.getFullYear() - nascimento.getFullYear();
-        const m = hoje.getMonth() - nascimento.getMonth();
-        if (m < 0 || (m === 0 && hoje.getDate() < nascimento.getDate())) {
-          idade--;
-        }
-        document.getElementById('age').value = idade;
-      }
-    }
-
-    document.getElementById('age').addEventListener('input', calcularDataNascimentoPorIdade);
-    document.getElementById('date_of_birth').addEventListener('change', calcularIdadePorDataNascimento);
-
+    <script>
     function validarTutor() {
       {% if not tutor %}
       if (!document.getElementById('tutor_id').value) {


### PR DESCRIPTION
## Summary
- allow age field to submit by naming it in shared date/age widget
- use Brazilian `dd/mm/aaaa` formatting for visible dates in animal forms
- load flatpickr and Inputmask where the widget is used

## Testing
- `pytest tests/test_age_display.py tests/test_calcular_idade.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5895fd210832e824a9b6aacc06ce6