### PR TITLE
Enable appointment status updates and deletions

### DIFF
--- a/app.py
+++ b/app.py
@@ -6585,6 +6585,35 @@ def edit_appointment(appointment_id):
     return render_template('edit_appointment.html', appointment=appointment, veterinarios=veterinarios)
 
 
+@app.route('/appointments/<int:appointment_id>/status', methods=['POST'])
+@login_required
+def update_appointment_status(appointment_id):
+    """Update the status of an appointment."""
+    appointment = Appointment.query.get_or_404(appointment_id)
+    if current_user.worker in ['veterinario', 'colaborador']:
+        if current_user.worker == 'veterinario':
+            user_clinic = current_user.veterinario.clinica_id
+        else:
+            user_clinic = current_user.clinica_id
+        appointment_clinic = appointment.clinica_id
+        if appointment_clinic is None and appointment.veterinario:
+            appointment_clinic = appointment.veterinario.clinica_id
+        if appointment_clinic != user_clinic:
+            abort(403)
+    elif current_user.role != 'admin' and appointment.tutor_id != current_user.id:
+        abort(403)
+
+    status = request.form.get('status') or (request.get_json(silent=True) or {}).get('status')
+    if status not in {'scheduled', 'completed', 'canceled'}:
+        return jsonify({'success': False, 'message': 'Status inválido.'}), 400
+    appointment.status = status
+    db.session.commit()
+    if request.is_json:
+        return jsonify({'success': True})
+    flash('Status atualizado.', 'success')
+    return redirect(request.referrer or url_for('appointments'))
+
+
 @app.route('/appointments/<int:appointment_id>/delete', methods=['POST'])
 @login_required
 def delete_appointment(appointment_id):

--- a/templates/partials/appointments_table.html
+++ b/templates/partials/appointments_table.html
@@ -4,6 +4,7 @@
       <th>Hora</th>
       <th>Animal</th>
       <th>Veterinário</th>
+      <th>Status</th>
       <th>Ações</th>
     </tr>
   </thead>
@@ -11,13 +12,14 @@
     {% if appointments_grouped %}
       {% for day, items in appointments_grouped %}
         <tr class="table-light">
-          <th colspan="4">{{ day|format_datetime_brazil('%d/%m/%Y') }}</th>
+          <th colspan="5">{{ day|format_datetime_brazil('%d/%m/%Y') }}</th>
         </tr>
         {% for appt in items %}
           <tr class="appointment-row" data-href="{{ url_for('edit_appointment', appointment_id=appt.id) }}">
             <td>{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}</td>
             <td>{{ appt.animal.name }}</td>
             <td>{{ appt.veterinario.user.name }}</td>
+            <td>{{ {'scheduled':'A fazer','completed':'Realizada','canceled':'Cancelada'}.get(appt.status, appt.status) }}</td>
             <td>
               <div class="btn-group">
                 <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary">📋 Ficha Animal</a>
@@ -25,13 +27,32 @@
                 {% if current_user.worker in ['veterinario', 'colaborador'] %}
                 <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success">🩺 Iniciar Consulta</a>
                 {% endif %}
+                <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="d-inline">
+                  {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
+                  <input type="hidden" name="status" value="completed">
+                  <button class="btn btn-sm btn-outline-success" title="Marcar como realizada">✔️</button>
+                </form>
+                <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="d-inline">
+                  {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
+                  <input type="hidden" name="status" value="canceled">
+                  <button class="btn btn-sm btn-outline-warning" title="Cancelar">✖️</button>
+                </form>
+                <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="d-inline">
+                  {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
+                  <input type="hidden" name="status" value="scheduled">
+                  <button class="btn btn-sm btn-outline-secondary" title="Marcar como a fazer">⏳</button>
+                </form>
+                <form method="POST" action="{{ url_for('delete_appointment', appointment_id=appt.id) }}" class="d-inline" data-confirm="Excluir este agendamento?">
+                  {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
+                  <button class="btn btn-sm btn-outline-danger" title="Excluir">🗑️</button>
+                </form>
               </div>
             </td>
           </tr>
         {% endfor %}
       {% endfor %}
     {% else %}
-      <tr><td colspan="4">Nenhum agendamento encontrado.</td></tr>
+      <tr><td colspan="5">Nenhum agendamento encontrado.</td></tr>
     {% endif %}
   </tbody>
 </table>

--- a/tests/test_appointment_status.py
+++ b/tests/test_appointment_status.py
@@ -1,0 +1,73 @@
+import pytest
+import flask_login.utils as login_utils
+from datetime import datetime
+
+from app import app as flask_app, db
+from models import User, Clinica, Veterinario, Animal, Appointment, HealthPlan, HealthSubscription
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def login(monkeypatch, user):
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def _setup_data():
+    clinic = Clinica(id=1, nome="Clinica")
+    tutor = User(id=1, name="Tutor", email="t@test")
+    tutor.set_password("x")
+    vet_user = User(id=2, name="Vet", email="v@test", worker="veterinario")
+    vet_user.set_password("x")
+    vet = Veterinario(id=1, user_id=vet_user.id, crmv="123", clinica_id=clinic.id)
+    animal = Animal(id=1, name="Rex", user_id=tutor.id, clinica_id=clinic.id)
+    plan = HealthPlan(id=1, name="Basic", price=10.0)
+    sub = HealthSubscription(animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True)
+    db.session.add_all([clinic, tutor, vet_user, vet, animal, plan, sub])
+    db.session.commit()
+    appt = Appointment(
+        id=1,
+        animal_id=animal.id,
+        tutor_id=tutor.id,
+        veterinario_id=vet.id,
+        scheduled_at=datetime.utcnow(),
+        clinica_id=clinic.id,
+    )
+    db.session.add(appt)
+    db.session.commit()
+    return appt.id, clinic.id
+
+
+def test_update_status_and_delete(client, monkeypatch):
+    with flask_app.app_context():
+        appt_id, clinic_id = _setup_data()
+    user = type('U', (), {
+        'id': 99,
+        'worker': 'colaborador',
+        'role': 'adotante',
+        'is_authenticated': True,
+        'clinica_id': clinic_id,
+    })()
+    login(monkeypatch, user)
+    resp = client.post(f'/appointments/{appt_id}/status', data={'status': 'completed'})
+    assert resp.status_code == 302
+    with flask_app.app_context():
+        appt = Appointment.query.get(appt_id)
+        assert appt.status == 'completed'
+    resp = client.post(f'/appointments/{appt_id}/status', data={'status': 'canceled'})
+    assert resp.status_code == 302
+    with flask_app.app_context():
+        appt = Appointment.query.get(appt_id)
+        assert appt.status == 'canceled'
+    resp = client.post(f'/appointments/{appt_id}/delete', data={})
+    assert resp.status_code == 302
+    with flask_app.app_context():
+        assert Appointment.query.get(appt_id) is None


### PR DESCRIPTION
## Summary
- Allow updating appointment status (scheduled/completed/canceled)
- Add action buttons and status column to appointments table
- Test appointment status workflow and deletion

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b589a63e2c832e822bcd3c43caffb7