### PR TITLE
Preserve veterinarian info across print views

### DIFF
--- a/templates/imprimir_bloco.html
+++ b/templates/imprimir_bloco.html
@@ -33,8 +33,8 @@
   <div class="top-info">
     <div class="info-box">
       <strong>Veterinário Responsável</strong><br>
-      {{ current_user.name }}<br>
-      CRMV: {{ current_user.veterinario.crmv if current_user.veterinario else '—' }}
+      {{ veterinario.name if veterinario else '' }}<br>
+      CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}
     </div>
 
     <div class="info-box">
@@ -84,8 +84,8 @@
   <div class="assinaturas">
     <div>
       ___________________________________________<br>
-      <span>{{ current_user.name }}</span>
-      <span>CRMV: {{ current_user.veterinario.crmv if current_user.veterinario else '—' }}</span>
+      <span>{{ veterinario.name if veterinario else '' }}</span>
+      <span>CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span>
     </div>
   </div>
 

--- a/templates/imprimir_exames.html
+++ b/templates/imprimir_exames.html
@@ -28,14 +28,14 @@
   <h2>Requisicao de Exames Complementares</h2>
 
   <div class="top-info">
-    {% if current_user.name or (current_user.veterinario and current_user.veterinario.crmv) %}
+    {% if veterinario and (veterinario.name or (veterinario.veterinario and veterinario.veterinario.crmv)) %}
       <div class="info-box">
         <strong>Médico Veterinário</strong><br>
-        {% if current_user.name %}
-          {{ current_user.name }}<br>
+        {% if veterinario.name %}
+          {{ veterinario.name }}<br>
         {% endif %}
-        {% if current_user.veterinario and current_user.veterinario.crmv %}
-          CRMV: {{ current_user.veterinario.crmv }}
+        {% if veterinario.veterinario and veterinario.veterinario.crmv %}
+          CRMV: {{ veterinario.veterinario.crmv }}
         {% endif %}
       </div>
     {% endif %}
@@ -96,8 +96,8 @@
 
   <div class="assinatura">
     ___________________________________________<br>
-    <span>{{ current_user.name }}</span>
-    <span>CRMV: {{ current_user.veterinario.crmv if current_user.veterinario else '—' }}</span>
+    <span>{{ veterinario.name if veterinario else '' }}</span>
+    <span>CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span>
   </div>
 
   <footer>

--- a/templates/imprimir_orcamento_padrao.html
+++ b/templates/imprimir_orcamento_padrao.html
@@ -24,8 +24,8 @@
   <div class="top-info">
     <div class="info-box">
       <strong>Profissional Responsável</strong><br>
-      {{ current_user.name }}<br>
-      CRMV: {{ current_user.veterinario.crmv if current_user.veterinario else '—' }}
+      {{ veterinario.name if veterinario else '' }}<br>
+      CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}
     </div>
   </div>
   <table>

--- a/templates/imprimir_vacinas.html
+++ b/templates/imprimir_vacinas.html
@@ -45,7 +45,8 @@
     <div class="info-box">
       <strong>Clínica</strong><br>
       {{ clinica.nome if clinica else '—' }}<br>
-      CRMV: {{ current_user.veterinario.crmv if current_user.veterinario else '—' }}<br>
+      Veterinário: {{ veterinario.name if veterinario else '—' }}<br>
+      CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}<br>
       Telefone: {{ clinica.telefone if clinica and clinica.telefone else '—' }}
     </div>
   </div>
@@ -78,8 +79,8 @@
   <div class="assinaturas">
     <div>
       ___________________________________________<br>
-      <span>Responsável pela Aplicação</span>
-      <span>CRMV: _________________________</span>
+      <span>{{ veterinario.name if veterinario else 'Responsável pela Aplicação' }}</span>
+      <span>CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '_________________________' }}</span>
     </div>
     <div>
       ___________________________________________<br>


### PR DESCRIPTION
## Summary
- Load veterinarian and clinic from the original consultation in all print routes
- Show consultation veterinarian’s name and CRMV in print templates
- Add regression test for printing budget with different user

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5970fca5c832ea046a330c7ede4d1