### PR TITLE
Add exam scheduling feature with specialist availability

### DIFF
--- a/migrations/versions/a1b2c3d4e5f_create_exam_appointment.py
+++ b/migrations/versions/a1b2c3d4e5f_create_exam_appointment.py
@@ -1,0 +1,33 @@
+"""create exam appointment table
+
+Revision ID: a1b2c3d4e5f
+Revises: ee1a3963c0ed
+Create Date: 2025-09-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f'
+down_revision = 'ee1a3963c0ed'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'exam_appointment',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('animal_id', sa.Integer(), nullable=False),
+        sa.Column('specialist_id', sa.Integer(), nullable=False),
+        sa.Column('scheduled_at', sa.DateTime(), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False, server_default='pending'),
+        sa.Column('request_time', sa.DateTime(), nullable=True),
+        sa.Column('confirm_by', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['animal_id'], ['animal.id']),
+        sa.ForeignKeyConstraint(['specialist_id'], ['veterinario.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+def downgrade():
+    op.drop_table('exam_appointment')

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -31,6 +31,24 @@
   <button type="button" class="btn btn-primary mt-2" id="btn-finalizar-exames" onclick="finalizarBlocoExames()">💾 Finalizar Solicitação</button>
 </form>
 
+<!-- Agendamento de exame -->
+<div id="agendar-exame" class="mt-5">
+  <h5 class="mb-3">Agendar Exame</h5>
+  <div class="mb-3">
+    <label for="exam-specialist" class="form-label">Especialista</label>
+    <select id="exam-specialist" class="form-select"></select>
+  </div>
+  <div class="mb-3">
+    <label for="exam-date" class="form-label">Data</label>
+    <input type="date" id="exam-date" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label for="exam-time" class="form-label">Horário</label>
+    <select id="exam-time" class="form-select"><option value="">Selecione...</option></select>
+  </div>
+  <button type="button" class="btn btn-outline-primary" onclick="agendarExame()">📅 Agendar Exame</button>
+</div>
+
 <!-- Histórico de exames -->
 <div id="historico-exames" class="mt-5">
   {% include 'partials/historico_exames.html' %}
@@ -78,6 +96,24 @@
           });
         });
   });
+
+    const specialistSelect = document.getElementById('exam-specialist');
+    if (specialistSelect) {
+      fetch('/api/specialists')
+        .then(r => r.json())
+        .then(data => {
+          specialistSelect.innerHTML = '<option value="">Selecione...</option>';
+          data.forEach(sp => {
+            const opt = document.createElement('option');
+            const esp = sp.especialidades.join(', ');
+            opt.value = sp.id;
+            opt.textContent = esp ? `${sp.nome} - ${esp}` : sp.nome;
+            specialistSelect.appendChild(opt);
+          });
+        });
+      specialistSelect.addEventListener('change', atualizarHorarios);
+      document.getElementById('exam-date').addEventListener('change', atualizarHorarios);
+    }
 
   renderExamesTemp(); // Inicializa a lista se já houver dados
   });
@@ -150,6 +186,43 @@
       `;
       lista.appendChild(div);
     });
+  }
+
+  async function atualizarHorarios() {
+    const vetId = document.getElementById('exam-specialist').value;
+    const date = document.getElementById('exam-date').value;
+    if (!vetId || !date) return;
+    const resp = await fetch(`/api/specialist/${vetId}/available_times?date=${date}`);
+    const horarios = await resp.json();
+    const select = document.getElementById('exam-time');
+    select.innerHTML = '<option value="">Selecione...</option>';
+    horarios.forEach(h => {
+      const opt = document.createElement('option');
+      opt.value = h;
+      opt.textContent = h;
+      select.appendChild(opt);
+    });
+  }
+
+  async function agendarExame() {
+    const vetId = document.getElementById('exam-specialist').value;
+    const date = document.getElementById('exam-date').value;
+    const time = document.getElementById('exam-time').value;
+    if (!vetId || !date || !time) {
+      alert('Selecione especialista, data e horário.');
+      return;
+    }
+    const resp = await fetch(`/animal/{{ animal.id }}/schedule_exam`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      body: JSON.stringify({ specialist_id: vetId, date, time })
+    });
+    if (resp.ok) {
+      mostrarFeedback('Exame agendado! Aguarde confirmação do especialista.');
+      document.getElementById('exam-time').innerHTML = '<option value="">Selecione...</option>';
+    } else {
+      mostrarFeedback('Erro ao agendar exame.', 'danger');
+    }
   }
 
   async function finalizarBlocoExames() {


### PR DESCRIPTION
## Summary
- allow veterinarians to book exams selecting specialists and time slots
- provide API endpoints to retrieve specialists, available times and schedule exams
- auto-create exam appointments with 2-hour confirmation window

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5b81017f8832eb3b46c5d567de316