### PR TITLE
Implement exam scheduling history and specialist filtering

### DIFF
--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -35,6 +35,10 @@
 <div id="agendar-exame" class="mt-5">
   <h5 class="mb-3">Agendar Exame</h5>
   <div class="mb-3">
+    <label for="exam-specialty" class="form-label">Especialidade</label>
+    <select id="exam-specialty" class="form-select"></select>
+  </div>
+  <div class="mb-3">
     <label for="exam-specialist" class="form-label">Especialista</label>
     <select id="exam-specialist" class="form-select"></select>
   </div>
@@ -47,6 +51,12 @@
     <select id="exam-time" class="form-select"><option value="">Selecione...</option></select>
   </div>
   <button type="button" class="btn btn-outline-primary" onclick="agendarExame()">📅 Agendar Exame</button>
+</div>
+
+<!-- Exames agendados -->
+<div id="historico-agendamentos" class="mt-5">
+  {% set appointments = animal.exam_appointments %}
+  {% include 'partials/historico_exam_appointments.html' %}
 </div>
 
 <!-- Histórico de exames -->
@@ -97,20 +107,37 @@
         });
   });
 
+    const specialtySelect = document.getElementById('exam-specialty');
     const specialistSelect = document.getElementById('exam-specialist');
-    if (specialistSelect) {
-      fetch('/api/specialists')
+    if (specialtySelect && specialistSelect) {
+      fetch('/api/specialties')
         .then(r => r.json())
         .then(data => {
-          specialistSelect.innerHTML = '<option value="">Selecione...</option>';
+          specialtySelect.innerHTML = '<option value="">Selecione...</option>';
           data.forEach(sp => {
             const opt = document.createElement('option');
-            const esp = sp.especialidades.join(', ');
             opt.value = sp.id;
-            opt.textContent = esp ? `${sp.nome} - ${esp}` : sp.nome;
-            specialistSelect.appendChild(opt);
+            opt.textContent = sp.nome;
+            specialtySelect.appendChild(opt);
           });
         });
+
+      specialtySelect.addEventListener('change', () => {
+        const specId = specialtySelect.value;
+        specialistSelect.innerHTML = '<option value="">Selecione...</option>';
+        if (!specId) return;
+        fetch(`/api/specialists?specialty_id=${specId}`)
+          .then(r => r.json())
+          .then(data => {
+            data.forEach(sp => {
+              const opt = document.createElement('option');
+              const esp = sp.especialidades.join(', ');
+              opt.value = sp.id;
+              opt.textContent = esp ? `${sp.nome} - ${esp}` : sp.nome;
+              specialistSelect.appendChild(opt);
+            });
+          });
+      });
       specialistSelect.addEventListener('change', atualizarHorarios);
       document.getElementById('exam-date').addEventListener('change', atualizarHorarios);
     }
@@ -218,8 +245,14 @@
       body: JSON.stringify({ specialist_id: vetId, date, time })
     });
     if (resp.ok) {
+      const data = await resp.json();
       mostrarFeedback('Exame agendado! Aguarde confirmação do especialista.');
       document.getElementById('exam-time').innerHTML = '<option value="">Selecione...</option>';
+      if (data.html) {
+        const hist = document.getElementById('historico-agendamentos');
+        hist.innerHTML = data.html;
+      }
+      atualizarHorarios();
     } else {
       mostrarFeedback('Erro ao agendar exame.', 'danger');
     }

--- a/templates/partials/historico_exam_appointments.html
+++ b/templates/partials/historico_exam_appointments.html
@@ -1,0 +1,12 @@
+{% if appointments %}
+  <h5>Exames Agendados</h5>
+  <ul class="list-group">
+    {% for appt in appointments %}
+      <li class="list-group-item d-flex justify-content-between">
+        <span>{{ appt.scheduled_at|datetime_brazil }} - {{ appt.specialist.user.name }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <p class="text-muted">Nenhum exame agendado.</p>
+{% endif %}

--- a/tests/test_schedule_exam.py
+++ b/tests/test_schedule_exam.py
@@ -1,0 +1,66 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import flask_login.utils as login_utils
+from app import app as flask_app, db
+from models import User, Clinica, Animal, Veterinario, Specialty, VetSchedule, ExamAppointment, AgendaEvento
+from datetime import datetime, time, date
+from helpers import get_available_times
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def login(monkeypatch, user):
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def setup_data():
+    clinic = Clinica(nome='Clinica')
+    tutor = User(name='Tutor', email='t@test')
+    tutor.set_password('x')
+    vet_user = User(name='Vet', email='v@test', worker='veterinario')
+    vet_user.set_password('x')
+    vet = Veterinario(user=vet_user, crmv='123', clinica=clinic)
+    spec = Specialty(nome='Raio-X')
+    vet.specialties.append(spec)
+    schedule = VetSchedule(veterinario=vet, dia_semana='Segunda', hora_inicio=time(9,0), hora_fim=time(17,0))
+    animal = Animal(name='Rex', owner=tutor, clinica=clinic)
+    db.session.add_all([clinic, tutor, vet_user, vet, spec, schedule, animal])
+    db.session.commit()
+    return tutor.id, vet_user.id, animal.id, vet.id
+
+
+def test_schedule_exam_creates_event_and_blocks_time(client, monkeypatch):
+    with flask_app.app_context():
+        tutor_id, vet_user_id, animal_id, vet_id = setup_data()
+    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True})()
+    login(monkeypatch, fake_user)
+    resp = client.post(f'/animal/{animal_id}/schedule_exam', json={
+        'specialist_id': vet_id,
+        'date': '2024-05-20',
+        'time': '09:00'
+    }, headers={'Accept': 'application/json'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success']
+    with flask_app.app_context():
+        assert ExamAppointment.query.count() == 1
+        assert AgendaEvento.query.count() == 1
+        times = get_available_times(vet_id, date(2024,5,20))
+        assert '09:00' not in times


### PR DESCRIPTION
## Summary
- add API to list specialties and filter specialists
- show specialist-specific exam slots and record scheduled exams in clinic agenda
- display history of scheduled exams on consultation page and provide tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ef7e25b0832e981794f1e6a9a1ba