### PR TITLE
feat: manage and notify exam appointments

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -454,6 +454,17 @@
                                 </li>
                             {% endif %}
 
+                            {% if current_user.worker == 'veterinario' %}
+                                <li class="nav-item position-relative">
+                                    <a class="nav-link" href="{{ url_for('appointments') }}">
+                                        <i class="fas fa-calendar-alt me-1 text-success"></i> Agenda
+                                        {% if pending_exam_count > 0 %}
+                                            <span class="badge rounded-pill bg-danger position-absolute top-0 start-100 translate-middle">{{ pending_exam_count }}</span>
+                                        {% endif %}
+                                    </a>
+                                </li>
+                            {% endif %}
+
                         <li class="nav-item position-relative">
                             {% if current_user.role == 'admin' %}
                                 <a class="nav-link" href="{{ url_for('mensagens_admin') }}">

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -258,6 +258,43 @@
     }
   }
 
+  async function deletarAgendamentoExame(id) {
+    if (!confirm('Excluir este agendamento?')) return;
+    const resp = await fetch(`/exam_appointment/${id}/delete`, {
+      method: 'POST',
+      headers: { 'Accept': 'application/json' }
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      if (data.html) {
+        document.getElementById('historico-agendamentos').innerHTML = data.html;
+      }
+      mostrarFeedback('Agendamento excluído.');
+    } else {
+      mostrarFeedback('Erro ao excluir agendamento.', 'danger');
+    }
+  }
+
+  async function editarAgendamentoExame(id) {
+    const date = prompt('Nova data (AAAA-MM-DD):');
+    const time = prompt('Novo horário (HH:MM):');
+    if (!date || !time) return;
+    const resp = await fetch(`/exam_appointment/${id}/update`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      body: JSON.stringify({ date, time })
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      if (data.html) {
+        document.getElementById('historico-agendamentos').innerHTML = data.html;
+      }
+      mostrarFeedback('Agendamento atualizado!');
+    } else {
+      mostrarFeedback('Erro ao atualizar agendamento.', 'danger');
+    }
+  }
+
   async function finalizarBlocoExames() {
     if (exames.length === 0) {
       mostrarFeedback('Adicione pelo menos um exame antes de finalizar.', 'warning');

--- a/templates/partials/historico_exam_appointments.html
+++ b/templates/partials/historico_exam_appointments.html
@@ -2,8 +2,12 @@
   <h5>Exames Agendados</h5>
   <ul class="list-group">
     {% for appt in appointments %}
-      <li class="list-group-item d-flex justify-content-between">
+      <li class="list-group-item d-flex justify-content-between align-items-center">
         <span>{{ appt.scheduled_at|datetime_brazil }} - {{ appt.specialist.user.name }}</span>
+        <div class="btn-group">
+          <button type="button" class="btn btn-sm btn-outline-primary" onclick="editarAgendamentoExame({{ appt.id }})">✏️</button>
+          <button type="button" class="btn btn-sm btn-outline-danger" onclick="deletarAgendamentoExame({{ appt.id }})">🗑️</button>
+        </div>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
## Summary
- allow veterinarians to edit and delete exam appointments
- notify assigned veterinarian via message and agenda badge with 2h confirmation window
- add tests for exam appointment management

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f4b3dd88832eaa12d70c16a73bde