### PR TITLE
Correct exam scheduling timezone handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -6764,10 +6764,22 @@ def schedule_exam(animal_id):
     time_str = data.get('time')
     if not all([specialist_id, date_str, time_str]):
         return jsonify({'success': False, 'message': 'Dados incompletos.'}), 400
-    scheduled_at = datetime.strptime(f"{date_str} {time_str}", '%Y-%m-%d %H:%M')
+    scheduled_at_local = datetime.strptime(
+        f"{date_str} {time_str}", "%Y-%m-%d %H:%M"
+    )
+    scheduled_at = (
+        scheduled_at_local
+        .replace(tzinfo=BR_TZ)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
     conflito = (
-        Appointment.query.filter_by(veterinario_id=specialist_id, scheduled_at=scheduled_at).first()
-        or ExamAppointment.query.filter_by(specialist_id=specialist_id, scheduled_at=scheduled_at).first()
+        Appointment.query.filter_by(
+            veterinario_id=specialist_id, scheduled_at=scheduled_at
+        ).first()
+        or ExamAppointment.query.filter_by(
+            specialist_id=specialist_id, scheduled_at=scheduled_at
+        ).first()
     )
     if conflito:
         return jsonify({'success': False, 'message': 'Horário indisponível.'}), 400
@@ -6792,7 +6804,7 @@ def schedule_exam(animal_id):
             receiver_id=vet.user_id,
             animal_id=animal_id,
             content=(
-                f"Exame agendado para {animal.name} em {scheduled_at.strftime('%d/%m/%Y %H:%M')}. "
+                f"Exame agendado para {animal.name} em {scheduled_at_local.strftime('%d/%m/%Y %H:%M')}. "
                 f"Confirme até {appt.confirm_by.strftime('%H:%M')}"
             ),
         )
@@ -6827,9 +6839,19 @@ def update_exam_appointment(appointment_id):
     specialist_id = data.get('specialist_id', appt.specialist_id)
     if not date_str or not time_str:
         return jsonify({'success': False, 'message': 'Dados incompletos.'}), 400
-    scheduled_at = datetime.strptime(f"{date_str} {time_str}", '%Y-%m-%d %H:%M')
+    scheduled_at_local = datetime.strptime(
+        f"{date_str} {time_str}", "%Y-%m-%d %H:%M"
+    )
+    scheduled_at = (
+        scheduled_at_local
+        .replace(tzinfo=BR_TZ)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
     conflito = (
-        Appointment.query.filter_by(veterinario_id=specialist_id, scheduled_at=scheduled_at).first()
+        Appointment.query.filter_by(
+            veterinario_id=specialist_id, scheduled_at=scheduled_at
+        ).first()
         or ExamAppointment.query.filter(
             ExamAppointment.specialist_id == specialist_id,
             ExamAppointment.scheduled_at == scheduled_at,

--- a/tests/test_schedule_exam.py
+++ b/tests/test_schedule_exam.py
@@ -7,7 +7,8 @@ import pytest
 import flask_login.utils as login_utils
 from app import app as flask_app, db
 from models import User, Clinica, Animal, Veterinario, Specialty, VetSchedule, ExamAppointment, AgendaEvento, Message
-from datetime import datetime, time, date
+from datetime import datetime, time, date, timezone
+from zoneinfo import ZoneInfo
 from helpers import get_available_times
 
 
@@ -99,7 +100,9 @@ def test_update_exam_appointment_changes_time(client, monkeypatch):
     assert resp.status_code == 200
     with flask_app.app_context():
         appt = ExamAppointment.query.get(1)
-        assert appt.scheduled_at == datetime(2024, 5, 22, 10, 0)
+        br_tz = ZoneInfo("America/Sao_Paulo")
+        scheduled_local = appt.scheduled_at.replace(tzinfo=timezone.utc).astimezone(br_tz)
+        assert scheduled_local == datetime(2024, 5, 22, 10, 0, tzinfo=br_tz)
 
 
 def test_delete_exam_appointment_removes_record(client, monkeypatch):


### PR DESCRIPTION
## Summary
- Convert exam appointments from Brazil time to UTC on save
- Adjust availability helpers to query using UTC times
- Test that exam rescheduling preserves local time

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6f7023b04832eba5fb59e625bdfc2