### PR TITLE
Add appointment notifications with vet response window

### DIFF
--- a/templates/agendamentos/pending_appointments.html
+++ b/templates/agendamentos/pending_appointments.html
@@ -1,0 +1,33 @@
+{% extends 'layout.html' %}
+{% block main %}
+<h1>Agendamentos Pendentes</h1>
+{% if appointments %}
+  <ul class="list-group">
+  {% for appt in appointments %}
+    {% set can_respond = (appt.scheduled_at - now).total_seconds() >= 7200 %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <div>
+        {{ appt.animal.name if appt.animal else 'Consulta' }} -
+        {{ appt.scheduled_at|datetime_brazil }}
+      </div>
+      {% if can_respond %}
+        <div class="d-flex gap-2">
+          <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
+            <input type="hidden" name="status" value="accepted">
+            <button type="submit" class="btn btn-success btn-sm">Aceitar</button>
+          </form>
+          <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
+            <input type="hidden" name="status" value="canceled">
+            <button type="submit" class="btn btn-danger btn-sm">Cancelar</button>
+          </form>
+        </div>
+      {% else %}
+        <span class="text-muted">Prazo expirado</span>
+      {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
+{% else %}
+  <p>Não há agendamentos pendentes.</p>
+{% endif %}
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -456,10 +456,11 @@
 
                             {% if current_user.worker == 'veterinario' %}
                                 <li class="nav-item position-relative">
-                                    <a class="nav-link" href="{{ url_for('appointments') }}">
+                                    <a class="nav-link" href="{{ url_for('pending_appointments') }}">
                                         <i class="fas fa-calendar-alt me-1 text-success"></i> Agenda
-                                        {% if pending_exam_count > 0 %}
-                                            <span class="badge rounded-pill bg-danger position-absolute top-0 start-100 translate-middle">{{ pending_exam_count }}</span>
+                                        {% set total_pending = pending_exam_count + pending_appointment_count %}
+                                        {% if total_pending > 0 %}
+                                            <span class="badge rounded-pill bg-danger position-absolute top-0 start-100 translate-middle">{{ total_pending }}</span>
                                         {% endif %}
                                     </a>
                                 </li>

--- a/tests/test_appointment_notifications.py
+++ b/tests/test_appointment_notifications.py
@@ -1,0 +1,94 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import flask_login.utils as login_utils
+from datetime import datetime, timedelta
+from app import app as flask_app, db
+from models import User, Clinica, Animal, Veterinario, HealthPlan, HealthSubscription, Appointment
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def login(monkeypatch, user):
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def create_base_data(hours_ahead):
+    clinic = Clinica(id=1, nome='Clinica')
+    tutor = User(id=1, name='Tutor', email='t@test')
+    tutor.set_password('x')
+    vet_user = User(id=2, name='Vet', email='v@test', worker='veterinario')
+    vet_user.set_password('x')
+    vet = Veterinario(id=1, user_id=vet_user.id, crmv='123', clinica_id=clinic.id)
+    animal = Animal(id=1, name='Rex', user_id=tutor.id, clinica_id=clinic.id)
+    plan = HealthPlan(id=1, name='Basic', price=10.0)
+    sub = HealthSubscription(animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True)
+    db.session.add_all([clinic, tutor, vet_user, vet, animal, plan, sub])
+    db.session.commit()
+    appt = Appointment(
+        id=1,
+        animal_id=animal.id,
+        tutor_id=tutor.id,
+        veterinario_id=vet.id,
+        scheduled_at=datetime.utcnow() + timedelta(hours=hours_ahead),
+        clinica_id=clinic.id,
+    )
+    db.session.add(appt)
+    db.session.commit()
+    return vet_user.id, vet.id, appt.id
+
+
+def test_pending_page_allows_accept(client, monkeypatch):
+    with flask_app.app_context():
+        vet_user_id, vet_id, appt_id = create_base_data(3)
+    fake_vet = type('U', (), {
+        'id': vet_user_id,
+        'worker': 'veterinario',
+        'role': 'adotante',
+        'name': 'Vet',
+        'is_authenticated': True,
+        'veterinario': type('V', (), {'id': vet_id, 'clinica_id': 1})()
+    })()
+    login(monkeypatch, fake_vet)
+    resp = client.get('/appointments/pending')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Aceitar' in html
+    resp = client.post(f'/appointments/{appt_id}/status', data={'status': 'accepted'})
+    assert resp.status_code == 302
+    with flask_app.app_context():
+        assert Appointment.query.get(appt_id).status == 'accepted'
+
+
+def test_cannot_accept_within_two_hours(client, monkeypatch):
+    with flask_app.app_context():
+        vet_user_id, vet_id, appt_id = create_base_data(1)
+    fake_vet = type('U', (), {
+        'id': vet_user_id,
+        'worker': 'veterinario',
+        'role': 'adotante',
+        'name': 'Vet',
+        'is_authenticated': True,
+        'veterinario': type('V', (), {'id': vet_id, 'clinica_id': 1})()
+    })()
+    login(monkeypatch, fake_vet)
+    resp = client.post(f'/appointments/{appt_id}/status', data={'status': 'accepted'})
+    assert resp.status_code == 400
+    with flask_app.app_context():
+        assert Appointment.query.get(appt_id).status == 'scheduled'

--- a/tests/test_appointment_status.py
+++ b/tests/test_appointment_status.py
@@ -1,6 +1,6 @@
 import pytest
 import flask_login.utils as login_utils
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from app import app as flask_app, db
 from models import User, Clinica, Veterinario, Animal, Appointment, HealthPlan, HealthSubscription
@@ -38,7 +38,7 @@ def _setup_data():
         animal_id=animal.id,
         tutor_id=tutor.id,
         veterinario_id=vet.id,
-        scheduled_at=datetime.utcnow(),
+        scheduled_at=datetime.utcnow() + timedelta(hours=3),
         clinica_id=clinic.id,
     )
     db.session.add(appt)


### PR DESCRIPTION
## Summary
- show pending appointment notifications in navbar for veterinarians
- add page for vets to accept or cancel appointments until two hours before
- cover acceptance deadline with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6fb264508832e93ed908efece3c54