### PR TITLE
Enable inline editing for exam appointments

### DIFF
--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -275,14 +275,30 @@
     }
   }
 
-  async function editarAgendamentoExame(id) {
-    const date = prompt('Nova data (AAAA-MM-DD):');
-    const time = prompt('Novo horário (HH:MM):');
-    if (!date || !time) return;
+  function editarAgendamentoExame(id) {
+    const li = document.getElementById(`exam-appt-${id}`);
+    if (!li) return;
+    li.querySelector('.exam-view')?.classList.add('d-none');
+    li.querySelector('.exam-edit-form')?.classList.remove('d-none');
+  }
+
+  function cancelarEdicaoExame(id) {
+    const li = document.getElementById(`exam-appt-${id}`);
+    if (!li) return;
+    li.querySelector('.exam-edit-form')?.classList.add('d-none');
+    li.querySelector('.exam-view')?.classList.remove('d-none');
+  }
+
+  async function salvarAgendamentoExame(ev, id) {
+    ev.preventDefault();
+    const form = ev.target;
+    const date = form.querySelector('[name="date"]').value;
+    const time = form.querySelector('[name="time"]').value;
+    const specialistId = form.querySelector('[name="specialist_id"]').value;
     const resp = await fetch(`/exam_appointment/${id}/update`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-      body: JSON.stringify({ date, time })
+      body: JSON.stringify({ date, time, specialist_id: specialistId })
     });
     if (resp.ok) {
       const data = await resp.json();
@@ -290,6 +306,7 @@
         document.getElementById('historico-agendamentos').innerHTML = data.html;
       }
       mostrarFeedback('Agendamento atualizado!');
+      atualizarHorarios();
     } else {
       mostrarFeedback('Erro ao atualizar agendamento.', 'danger');
     }

--- a/templates/partials/historico_exam_appointments.html
+++ b/templates/partials/historico_exam_appointments.html
@@ -2,12 +2,27 @@
   <h5>Exames Agendados</h5>
   <ul class="list-group">
     {% for appt in appointments %}
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <span>{{ appt.scheduled_at|datetime_brazil }} - {{ appt.specialist.user.name }}</span>
-        <div class="btn-group">
-          <button type="button" class="btn btn-sm btn-outline-primary" onclick="editarAgendamentoExame({{ appt.id }})">✏️</button>
-          <button type="button" class="btn btn-sm btn-outline-danger" onclick="deletarAgendamentoExame({{ appt.id }})">🗑️</button>
+      <li class="list-group-item" id="exam-appt-{{ appt.id }}">
+        <div class="d-flex justify-content-between align-items-center exam-view">
+          <span>{{ appt.scheduled_at|datetime_brazil }} - {{ appt.specialist.user.name }}</span>
+          <div class="btn-group">
+            <button type="button" class="btn btn-sm btn-outline-primary" onclick="editarAgendamentoExame({{ appt.id }})">✏️</button>
+            <button type="button" class="btn btn-sm btn-outline-danger" onclick="deletarAgendamentoExame({{ appt.id }})">🗑️</button>
+          </div>
         </div>
+        <form class="row g-2 align-items-center mt-2 d-none exam-edit-form" data-id="{{ appt.id }}" onsubmit="salvarAgendamentoExame(event, {{ appt.id }})">
+          <div class="col-auto">
+            <input type="date" class="form-control" name="date" value="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}">
+          </div>
+          <div class="col-auto">
+            <input type="time" class="form-control" name="time" value="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}">
+          </div>
+          <input type="hidden" name="specialist_id" value="{{ appt.specialist_id }}">
+          <div class="col-auto d-flex gap-2">
+            <button type="submit" class="btn btn-primary btn-sm">Salvar</button>
+            <button type="button" class="btn btn-outline-secondary btn-sm" onclick="cancelarEdicaoExame({{ appt.id }})">Cancelar</button>
+          </div>
+        </form>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
## Summary
- Support inline edit forms for exam appointments in history
- Refactor exam appointment editing script to toggle inline fields and save via AJAX

## Testing
- `pytest -q` *(fails: sqlite3.IntegrityError UNIQUE constraint failed: user.id)*
- `pytest tests/test_veterinarios_routes.py::test_veterinarios_listing_and_detail -q`


------
https://chatgpt.com/codex/tasks/task_e_68b701452350832eb6c106e95d740ece