### PR TITLE
Normalize exam appointment times to UTC

### DIFF
--- a/app.py
+++ b/app.py
@@ -6815,7 +6815,13 @@ def schedule_exam(animal_id):
     time_str = data.get('time')
     if not all([specialist_id, date_str, time_str]):
         return jsonify({'success': False, 'message': 'Dados incompletos.'}), 400
-    scheduled_at = datetime.strptime(f"{date_str} {time_str}", '%Y-%m-%d %H:%M')
+    scheduled_at_local = datetime.strptime(f"{date_str} {time_str}", '%Y-%m-%d %H:%M')
+    scheduled_at = (
+        scheduled_at_local
+        .replace(tzinfo=BR_TZ)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
     conflito = (
         Appointment.query.filter_by(veterinario_id=specialist_id, scheduled_at=scheduled_at).first()
         or ExamAppointment.query.filter_by(specialist_id=specialist_id, scheduled_at=scheduled_at).first()
@@ -6843,8 +6849,8 @@ def schedule_exam(animal_id):
             receiver_id=vet.user_id,
             animal_id=animal_id,
             content=(
-                f"Exame agendado para {animal.name} em {scheduled_at.strftime('%d/%m/%Y %H:%M')}. "
-                f"Confirme até {appt.confirm_by.strftime('%H:%M')}"
+                f"Exame agendado para {animal.name} em {scheduled_at_local.strftime('%d/%m/%Y %H:%M')}. "
+                f"Confirme até {appt.confirm_by.replace(tzinfo=timezone.utc).astimezone(BR_TZ).strftime('%H:%M')}"
             ),
         )
         db.session.add(msg)
@@ -6878,7 +6884,13 @@ def update_exam_appointment(appointment_id):
     specialist_id = data.get('specialist_id', appt.specialist_id)
     if not date_str or not time_str:
         return jsonify({'success': False, 'message': 'Dados incompletos.'}), 400
-    scheduled_at = datetime.strptime(f"{date_str} {time_str}", '%Y-%m-%d %H:%M')
+    scheduled_at_local = datetime.strptime(f"{date_str} {time_str}", '%Y-%m-%d %H:%M')
+    scheduled_at = (
+        scheduled_at_local
+        .replace(tzinfo=BR_TZ)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
     conflito = (
         Appointment.query.filter_by(veterinario_id=specialist_id, scheduled_at=scheduled_at).first()
         or ExamAppointment.query.filter(

--- a/tests/test_schedule_exam.py
+++ b/tests/test_schedule_exam.py
@@ -99,7 +99,7 @@ def test_update_exam_appointment_changes_time(client, monkeypatch):
     assert resp.status_code == 200
     with flask_app.app_context():
         appt = ExamAppointment.query.get(1)
-        assert appt.scheduled_at == datetime(2024, 5, 22, 10, 0)
+        assert appt.scheduled_at == datetime(2024, 5, 22, 13, 0)
 
 
 def test_delete_exam_appointment_removes_record(client, monkeypatch):


### PR DESCRIPTION
## Summary
- Save exam appointment datetimes in UTC and format messages in Brazil time
- Convert edited exam appointments and availability checks to use UTC
- Update tests to reflect new timezone handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7027ad7cc832e91b15f295fb694bf