### PR TITLE
Fix lingering appointment notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -334,6 +334,8 @@ def inject_pending_exam_count():
         pending = ExamAppointment.query.filter_by(
             specialist_id=current_user.veterinario.id, status='pending'
         ).count()
+        seen = session.get('exam_pending_seen_count', 0)
+        pending = max(pending - seen, 0)
     else:
         pending = 0
     return dict(pending_exam_count=pending)
@@ -355,6 +357,8 @@ def inject_pending_appointment_count():
             Appointment.status == "scheduled",
             Appointment.scheduled_at >= now + timedelta(hours=2),
         ).count()
+        seen = session.get('appointment_pending_seen_count', 0)
+        pending = max(pending - seen, 0)
     else:
         pending = 0
     return dict(pending_appointment_count=pending)
@@ -6498,6 +6502,16 @@ def appointments():
             .order_by(Appointment.scheduled_at.desc())
             .all()
         )
+        from models import ExamAppointment
+
+        session['exam_pending_seen_count'] = ExamAppointment.query.filter_by(
+            specialist_id=veterinario.id, status='pending'
+        ).count()
+        session['appointment_pending_seen_count'] = Appointment.query.filter(
+            Appointment.veterinario_id == veterinario.id,
+            Appointment.status == 'scheduled',
+            Appointment.scheduled_at >= now + timedelta(hours=2),
+        ).count()
 
         return render_template(
             'agendamentos/edit_vet_schedule.html',


### PR DESCRIPTION
## Summary
- track the number of unseen appointments and exam requests per veterinarian
- reset seen counts when appointments page is visited so the agenda badge only shows new items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b703a9f3b0832ea12655c1b6162052