### PR TITLE
Add clinic-level pending appointment count for vets

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -458,7 +458,7 @@
                                 <li class="nav-item position-relative">
                                     <a class="nav-link" href="{{ url_for('appointments') }}">
                                         <i class="fas fa-calendar-alt me-1 text-success"></i> Agenda
-                                        {% set total_pending = pending_exam_count + pending_appointment_count %}
+                                        {% set total_pending = pending_exam_count + pending_appointment_count + clinic_pending_appointment_count %}
                                         {% if total_pending > 0 %}
                                             <span class="badge rounded-pill bg-danger position-absolute top-0 start-100 translate-middle">{{ total_pending }}</span>
                                         {% endif %}


### PR DESCRIPTION
## Summary
- expose `clinic_pending_appointment_count` context variable counting scheduled appointments for other vets in the same clinic
- include clinic pending appointment count in navbar badge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b70444d134832e992489c9ad343241