### PR TITLE
Display exam appointments in appointment schedule

### DIFF
--- a/app.py
+++ b/app.py
@@ -6517,6 +6517,13 @@ def appointments():
                 .order_by(Appointment.scheduled_at)
                 .all()
             )
+            exam_appointments = (
+                ExamAppointment.query
+                .join(ExamAppointment.animal)
+                .filter(Animal.clinica_id == current_user.clinica_id)
+                .order_by(ExamAppointment.scheduled_at)
+                .all()
+            )
             form = None
         else:
             appointments = (
@@ -6524,12 +6531,22 @@ def appointments():
                 .order_by(Appointment.scheduled_at)
                 .all()
             )
+            exam_appointments = (
+                ExamAppointment.query
+                .join(ExamAppointment.animal)
+                .filter(Animal.user_id == current_user.id)
+                .order_by(ExamAppointment.scheduled_at)
+                .all()
+            )
             form = None
         appointments_grouped = group_appointments_by_day(appointments)
+        exam_appointments_grouped = group_appointments_by_day(exam_appointments)
         return render_template(
             'agendamentos/appointments.html',
             appointments=appointments,
             appointments_grouped=appointments_grouped,
+            exam_appointments=exam_appointments,
+            exam_appointments_grouped=exam_appointments_grouped,
             form=form,
         )
 

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -41,6 +41,9 @@
 
 {% include 'partials/appointments_table.html' %}
 
+  <h2 class="mt-4">Agenda de Exames</h2>
+  {% include 'partials/exam_appointments_table.html' %}
+
 <div class="modal fade" id="appointmentEditModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">

--- a/templates/partials/exam_appointments_table.html
+++ b/templates/partials/exam_appointments_table.html
@@ -1,0 +1,29 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>Hora</th>
+      <th>Animal</th>
+      <th>Especialista</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% if exam_appointments_grouped %}
+      {% for day, items in exam_appointments_grouped %}
+        <tr class="table-light">
+          <th colspan="4">{{ day|format_datetime_brazil('%d/%m/%Y') }}</th>
+        </tr>
+        {% for appt in items %}
+          <tr>
+            <td>{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}</td>
+            <td>{{ appt.animal.name }}</td>
+            <td>{{ appt.specialist.user.name }}</td>
+            <td>{{ {'pending':'Pendente','confirmed':'Confirmado'}.get(appt.status, appt.status) }}</td>
+          </tr>
+        {% endfor %}
+      {% endfor %}
+    {% else %}
+      <tr><td colspan="4">Nenhum exame agendado.</td></tr>
+    {% endif %}
+  </tbody>
+</table>

--- a/tests/test_schedule_exam.py
+++ b/tests/test_schedule_exam.py
@@ -49,7 +49,7 @@ def setup_data():
 def test_schedule_exam_creates_event_and_blocks_time(client, monkeypatch):
     with flask_app.app_context():
         tutor_id, vet_user_id, animal_id, vet_id = setup_data()
-    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True})()
+    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
     login(monkeypatch, fake_user)
     resp = client.post(f'/animal/{animal_id}/schedule_exam', json={
         'specialist_id': vet_id,
@@ -69,7 +69,7 @@ def test_schedule_exam_creates_event_and_blocks_time(client, monkeypatch):
 def test_schedule_exam_message_and_confirm_by(client, monkeypatch):
     with flask_app.app_context():
         tutor_id, vet_user_id, animal_id, vet_id = setup_data()
-    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True})()
+    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
     login(monkeypatch, fake_user)
     resp = client.post(f'/animal/{animal_id}/schedule_exam', json={
         'specialist_id': vet_id,
@@ -88,7 +88,7 @@ def test_schedule_exam_message_and_confirm_by(client, monkeypatch):
 def test_update_exam_appointment_changes_time(client, monkeypatch):
     with flask_app.app_context():
         tutor_id, vet_user_id, animal_id, vet_id = setup_data()
-    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True})()
+    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
     login(monkeypatch, fake_user)
     client.post(f'/animal/{animal_id}/schedule_exam', json={
         'specialist_id': vet_id,
@@ -105,7 +105,7 @@ def test_update_exam_appointment_changes_time(client, monkeypatch):
 def test_delete_exam_appointment_removes_record(client, monkeypatch):
     with flask_app.app_context():
         tutor_id, vet_user_id, animal_id, vet_id = setup_data()
-    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True})()
+    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
     login(monkeypatch, fake_user)
     client.post(f'/animal/{animal_id}/schedule_exam', json={
         'specialist_id': vet_id,
@@ -116,3 +116,21 @@ def test_delete_exam_appointment_removes_record(client, monkeypatch):
     assert resp.status_code == 200
     with flask_app.app_context():
         assert ExamAppointment.query.count() == 0
+
+
+def test_exam_appointments_listed_on_page(client, monkeypatch):
+    with flask_app.app_context():
+        tutor_id, vet_user_id, animal_id, vet_id = setup_data()
+    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
+    login(monkeypatch, fake_user)
+    client.post(
+        f'/animal/{animal_id}/schedule_exam',
+        json={'specialist_id': vet_id, 'date': '2024-05-20', 'time': '09:00'},
+        headers={'Accept': 'application/json'}
+    )
+    resp = client.get('/appointments')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Agenda de Exames' in html
+    assert '09:00' in html
+    assert 'Vet' in html


### PR DESCRIPTION
## Summary
- show exam appointments alongside consultations on the appointments page
- support exam appointment listings grouped by day
- test listing of exam appointments on appointments page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b704de29c4832eb41f1531ffb2bfbe