### PR TITLE
Fix specialty loading in exam scheduling

### DIFF
--- a/app.py
+++ b/app.py
@@ -6397,6 +6397,7 @@ def appointment_confirmation(appointment_id):
 @app.route('/appointments', methods=['GET', 'POST'])
 @login_required
 def appointments():
+    from models import ExamAppointment
     if request.method == 'POST' and current_user.worker not in ['veterinario', 'colaborador', 'admin']:
         abort(403)
     if current_user.worker == 'veterinario':
@@ -6803,7 +6804,6 @@ def api_clinic_appointments(clinica_id):
 
 
 @app.route('/api/specialists')
-@login_required
 def api_specialists():
     from models import Veterinario, Specialty
     specialty_id = request.args.get('specialty_id', type=int)
@@ -6822,7 +6822,6 @@ def api_specialists():
 
 
 @app.route('/api/specialties')
-@login_required
 def api_specialties():
     from models import Specialty
     specs = Specialty.query.order_by(Specialty.nome).all()
@@ -6830,7 +6829,6 @@ def api_specialties():
 
 
 @app.route('/api/specialist/<int:veterinario_id>/available_times')
-@login_required
 def api_specialist_available_times(veterinario_id):
     date_str = request.args.get('date')
     if not date_str:

--- a/tests/test_exam_specialty_api.py
+++ b/tests/test_exam_specialty_api.py
@@ -1,0 +1,34 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import Specialty
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+            db.session.add(Specialty(nome='Raio-X'))
+            db.session.commit()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def test_specialties_access_without_login(client):
+    resp = client.get('/api/specialties')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]['nome'] == 'Raio-X'


### PR DESCRIPTION
## Summary
- Remove login requirements from API routes that serve exam specialties and related data
- Import exam appointment model at start of appointments view to avoid runtime error
- Add regression test ensuring specialty API is accessible without login

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7085861d8832e86f14db9eaf02937