### PR TITLE
Avoid JSON redirect on appointment status change

### DIFF
--- a/app.py
+++ b/app.py
@@ -6795,14 +6795,17 @@ def update_appointment_status(appointment_id):
     if status not in {'scheduled', 'completed', 'canceled', 'accepted'}:
         return jsonify({'success': False, 'message': 'Status inválido.'}), 400
     if status in {'accepted', 'canceled'} and appointment.scheduled_at - datetime.utcnow() < timedelta(hours=2):
+        # A resposta JSON levava o usuário para uma página vazia. Manter o
+        # comportamento simples de texto quando o prazo expira.
         if request.is_json:
             return jsonify({'success': False, 'message': 'Prazo expirado.'}), 400
         return 'Prazo expirado.', 400
+
     appointment.status = status
     db.session.commit()
-    if request.is_json:
-        return jsonify({'success': True})
     flash('Status atualizado.', 'success')
+    # Sempre redireciona de volta à página anterior para evitar exibir apenas
+    # o JSON "{\"success\": true}".
     return redirect(request.referrer or url_for('appointments'))
 
 

--- a/templates/partials/appointments_table.html
+++ b/templates/partials/appointments_table.html
@@ -27,6 +27,7 @@
                 {% if current_user.worker in ['veterinario', 'colaborador'] %}
                 <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success">🩺 Iniciar Consulta</a>
                 {% endif %}
+                <a href="{{ url_for('edit_appointment', appointment_id=appt.id) }}" class="btn btn-sm btn-outline-info" title="Propor novo horário">🔄</a>
                 <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="d-inline">
                   {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
                   <input type="hidden" name="status" value="completed">


### PR DESCRIPTION
## Summary
- prevent JSON response from redirecting vets away when updating appointment status
- add quick link to propose a new appointment time

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71292abe4832e8c486734200eb055