### PR TITLE
Show status of exam appointment requests

### DIFF
--- a/models.py
+++ b/models.py
@@ -821,6 +821,16 @@ class ExamAppointment(db.Model):
         if not self.confirm_by:
             self.confirm_by = (self.request_time or datetime.utcnow()) + timedelta(hours=2)
 
+    @property
+    def status_display(self):
+        if self.status == 'confirmed':
+            return 'Aceito'
+        if self.status == 'canceled':
+            return 'Cancelado'
+        if self.confirm_by and datetime.utcnow() > self.confirm_by:
+            return 'Prazo expirado'
+        return 'Aguardando aceitação'
+
 # Associação many-to-many entre eventos e colaboradores
 EventoColaboradores = db.Table(
     'evento_colaboradores',

--- a/templates/partials/historico_exam_appointments.html
+++ b/templates/partials/historico_exam_appointments.html
@@ -4,7 +4,11 @@
     {% for appt in appointments %}
       <li class="list-group-item" id="exam-appt-{{ appt.id }}">
         <div class="d-flex justify-content-between align-items-center exam-view">
-          <span>{{ appt.scheduled_at|datetime_brazil }} - {{ appt.specialist.user.name }}</span>
+          <div>
+            <span>{{ appt.scheduled_at|datetime_brazil }} - {{ appt.specialist.user.name }}</span>
+            {% set status = appt.status_display %}
+            <span class="badge ms-2 {% if status == 'Aceito' %}bg-success{% elif status == 'Cancelado' %}bg-danger{% elif status == 'Prazo expirado' %}bg-secondary{% else %}bg-warning text-dark{% endif %}">{{ status }}</span>
+          </div>
           <div class="btn-group">
             <button type="button" class="btn btn-sm btn-outline-primary" onclick="editarAgendamentoExame({{ appt.id }})">✏️</button>
             <button type="button" class="btn btn-sm btn-outline-danger" onclick="deletarAgendamentoExame({{ appt.id }})">🗑️</button>


### PR DESCRIPTION
## Summary
- add `status_display` helper on exam appointments
- display status badge in exam appointment history

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b712c9cb84832eaf680c7baf8a7538