### PR TITLE
Validate exam block entries

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,3 +44,8 @@ class Config:
     # Endereço de retirada padrão (usado se não houver PickupLocation no banco)
     DEFAULT_PICKUP_ADDRESS = os.environ.get("DEFAULT_PICKUP_ADDRESS", "Rua Nove, 990")
 
+    # Exigir que nomes de exames correspondam a um ExameModelo existente
+    REQUIRE_EXISTING_EXAME_MODELO = bool(
+        int(os.environ.get("REQUIRE_EXISTING_EXAME_MODELO", "0"))
+    )
+


### PR DESCRIPTION
## Summary
- Validate exam blocks ensure each exam has a name and justification
- Optionally enforce exam name exists in ExameModelo
- Add config flag to toggle ExameModelo enforcement

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b733732254832e804243a9a045cf1b