### PR TITLE
Track exam completion details

### DIFF
--- a/app.py
+++ b/app.py
@@ -4145,7 +4145,10 @@ def salvar_bloco_exames(animal_id):
         exame_modelo = ExameSolicitado(
             bloco_id=bloco.id,
             nome=exame.get('nome'),
-            justificativa=exame.get('justificativa')
+            justificativa=exame.get('justificativa'),
+            status=exame.get('status', 'pendente'),
+            resultado=exame.get('resultado'),
+            performed_at=datetime.fromisoformat(exame['performed_at']) if exame.get('performed_at') else None,
         )
         db.session.add(exame_modelo)
 
@@ -4243,6 +4246,10 @@ def editar_exame(exame_id):
 
     exame.nome = data.get('nome', exame.nome)
     exame.justificativa = data.get('justificativa', exame.justificativa)
+    exame.status = data.get('status', exame.status)
+    exame.resultado = data.get('resultado', exame.resultado)
+    performed_at = data.get('performed_at')
+    exame.performed_at = datetime.fromisoformat(performed_at) if performed_at else exame.performed_at
 
     db.session.commit()
     return jsonify(success=True)
@@ -4267,6 +4274,10 @@ def atualizar_bloco_exames(bloco_id):
         ex_id = ex_json.get('id')
         nome  = ex_json.get('nome', '').strip()
         just  = ex_json.get('justificativa', '').strip()
+        status = ex_json.get('status', 'pendente')
+        resultado = ex_json.get('resultado')
+        performed_at_str = ex_json.get('performed_at')
+        performed_at = datetime.fromisoformat(performed_at_str) if performed_at_str else None
 
         if not nome:                 # pulamos entradas vazias
             continue
@@ -4276,13 +4287,19 @@ def atualizar_bloco_exames(bloco_id):
             exame = existentes[ex_id]
             exame.nome = nome
             exame.justificativa = just
+            exame.status = status
+            exame.resultado = resultado
+            exame.performed_at = performed_at
             enviados_ids.add(ex_id)
         else:
             # --- criar exame novo ---
             novo = ExameSolicitado(
                 bloco=bloco,
                 nome=nome,
-                justificativa=just
+                justificativa=just,
+                status=status,
+                resultado=resultado,
+                performed_at=performed_at,
             )
             db.session.add(novo)
 

--- a/migrations/versions/d3f98e045e2b_add_fields_to_examesolicitado.py
+++ b/migrations/versions/d3f98e045e2b_add_fields_to_examesolicitado.py
@@ -1,0 +1,28 @@
+"""add fields to ExameSolicitado
+
+Revision ID: d3f98e045e2b
+Revises: a1b2c3d4e5f
+Create Date: 2025-09-02 18:14:19.378128
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd3f98e045e2b'
+down_revision = 'a1b2c3d4e5f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('exame_solicitado', sa.Column('status', sa.String(length=20), nullable=True, server_default='pendente'))
+    op.add_column('exame_solicitado', sa.Column('resultado', sa.Text(), nullable=True))
+    op.add_column('exame_solicitado', sa.Column('performed_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('exame_solicitado', 'performed_at')
+    op.drop_column('exame_solicitado', 'resultado')
+    op.drop_column('exame_solicitado', 'status')

--- a/models.py
+++ b/models.py
@@ -905,6 +905,9 @@ class ExameSolicitado(db.Model):
     bloco_id = db.Column(db.Integer, db.ForeignKey('bloco_exames.id'), nullable=False)
     nome = db.Column(db.String(120), nullable=False)
     justificativa = db.Column(db.Text)
+    status = db.Column(db.String(20), default='pendente')
+    resultado = db.Column(db.Text, nullable=True)
+    performed_at = db.Column(db.DateTime, nullable=True)
 
 
 class VacinaModelo(db.Model):

--- a/templates/orcamentos/editar_bloco_exames.html
+++ b/templates/orcamentos/editar_bloco_exames.html
@@ -17,6 +17,22 @@
           <label class="form-label">Justificativa</label>
           <textarea class="form-control exame-justificativa" rows="2">{{ exame.justificativa or '' }}</textarea>
         </div>
+        <div class="mb-2">
+          <label class="form-label">Status</label>
+          <select class="form-select exame-status">
+            <option value="pendente" {% if exame.status == 'pendente' %}selected{% endif %}>Pendente</option>
+            <option value="concluido" {% if exame.status == 'concluido' %}selected{% endif %}>Concluído</option>
+            <option value="cancelado" {% if exame.status == 'cancelado' %}selected{% endif %}>Cancelado</option>
+          </select>
+        </div>
+        <div class="mb-2">
+          <label class="form-label">Resultado</label>
+          <textarea class="form-control exame-resultado" rows="2">{{ exame.resultado or '' }}</textarea>
+        </div>
+        <div class="mb-2">
+          <label class="form-label">Data de Realização</label>
+          <input type="date" class="form-control exame-performed_at" value="{{ exame.performed_at.date() if exame.performed_at else '' }}">
+        </div>
         <button type="button" class="btn btn-danger btn-sm btn-remover">🗑️ Remover</button>
       </div>
     </div>
@@ -78,6 +94,22 @@ function adicionarExame() {
         <label class="form-label">Justificativa</label>
         <textarea class="form-control exame-justificativa" rows="2"></textarea>
       </div>
+      <div class="mb-2">
+        <label class="form-label">Status</label>
+        <select class="form-select exame-status">
+          <option value="pendente" selected>Pendente</option>
+          <option value="concluido">Concluído</option>
+          <option value="cancelado">Cancelado</option>
+        </select>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Resultado</label>
+        <textarea class="form-control exame-resultado" rows="2"></textarea>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Data de Realização</label>
+        <input type="date" class="form-control exame-performed_at">
+      </div>
       <button type="button" class="btn btn-danger btn-sm btn-remover">🗑️ Remover</button>
     </div>
   `;
@@ -118,8 +150,11 @@ function salvarBlocoExames(blocoId, consultaId) {
   document.querySelectorAll('.exame-card').forEach(card => {
     const nome = card.querySelector('.exame-nome')?.value.trim();
     const justificativa = card.querySelector('.exame-justificativa')?.value.trim();
+    const status = card.querySelector('.exame-status')?.value || 'pendente';
+    const resultado = card.querySelector('.exame-resultado')?.value.trim();
+    const performed_at = card.querySelector('.exame-performed_at')?.value;
     if (nome && justificativa) {
-      exames.push({ nome, justificativa });
+      exames.push({ nome, justificativa, status, resultado, performed_at });
     }
   });
 

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -27,9 +27,16 @@
     <div id="exames-view-{{ bloco.id }}">
       <ul class="list-group list-group-flush">
         {% for exame in bloco.exames %}
-        <li class="list-group-item">
-          🧪 <strong>{{ exame.nome }}</strong><br>
-          <em>{{ exame.justificativa }}</em>
+        <li class="list-group-item d-flex justify-content-between align-items-start">
+          <div>
+            🧪 <strong>{{ exame.nome }}</strong><br>
+            <em>{{ exame.justificativa }}</em>
+            {% if exame.resultado %}<div><small>Resultado: {{ exame.resultado }}</small></div>{% endif %}
+            {% if exame.performed_at %}<div><small>Realizado em {{ exame.performed_at|format_datetime_brazil('%d/%m/%Y') }}</small></div>{% endif %}
+          </div>
+          {% if exame.status == 'concluido' %}
+          <i class="bi bi-check-circle-fill text-success" title="Concluído"></i>
+          {% endif %}
         </li>
         {% endfor %}
       </ul>
@@ -55,6 +62,22 @@
             <div class="mb-2">
               <label class="form-label">Justificativa</label>
               <textarea class="form-control exame-justificativa" rows="2">{{ exame.justificativa or '' }}</textarea>
+            </div>
+            <div class="mb-2">
+              <label class="form-label">Status</label>
+              <select class="form-select exame-status">
+                <option value="pendente" {% if exame.status == 'pendente' %}selected{% endif %}>Pendente</option>
+                <option value="concluido" {% if exame.status == 'concluido' %}selected{% endif %}>Concluído</option>
+                <option value="cancelado" {% if exame.status == 'cancelado' %}selected{% endif %}>Cancelado</option>
+              </select>
+            </div>
+            <div class="mb-2">
+              <label class="form-label">Resultado</label>
+              <textarea class="form-control exame-resultado" rows="2">{{ exame.resultado or '' }}</textarea>
+            </div>
+            <div class="mb-2">
+              <label class="form-label">Data de Realização</label>
+              <input type="date" class="form-control exame-performed_at" value="{{ exame.performed_at.date() if exame.performed_at else '' }}">
             </div>
             <button type="button" class="btn btn-danger btn-sm btn-remover" onclick="removerExame(this)">🗑️ Remover</button>
           </div>
@@ -113,6 +136,22 @@ function adicionarExame(blocoId) {
       <div class="mb-2">
         <label class="form-label">Justificativa</label>
         <textarea class="form-control exame-justificativa" rows="2"></textarea>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Status</label>
+        <select class="form-select exame-status">
+          <option value="pendente" selected>Pendente</option>
+          <option value="concluido">Concluído</option>
+          <option value="cancelado">Cancelado</option>
+        </select>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Resultado</label>
+        <textarea class="form-control exame-resultado" rows="2"></textarea>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Data de Realização</label>
+        <input type="date" class="form-control exame-performed_at">
       </div>
       <div class="d-flex gap-2">
         <button type="button" class="btn btn-danger btn-sm btn-remover" onclick="removerExame(this)">🗑️ Remover</button>
@@ -184,13 +223,16 @@ function salvarBlocoExames(blocoId, consultaId) {
   document.querySelectorAll(`#exames-container-${blocoId} .exame-card`).forEach(card => {
     const nome = card.querySelector('.exame-nome')?.value.trim();
     const justificativa = card.querySelector('.exame-justificativa')?.value.trim();
+    const status = card.querySelector('.exame-status')?.value || 'pendente';
+    const resultado = card.querySelector('.exame-resultado')?.value.trim();
+    const performed_at = card.querySelector('.exame-performed_at')?.value;
 
     if (!nome || !justificativa) {
       valid = false;
       card.classList.add('border-danger');
     } else {
       card.classList.remove('border-danger');
-      exames.push({ nome, justificativa });
+      exames.push({ nome, justificativa, status, resultado, performed_at });
     }
   });
 


### PR DESCRIPTION
## Summary
- add status, result and performed_at columns for requested exams
- allow editing of exam status and results and show completed exams with a check icon
- handle new exam data in creation and update routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b732f4cb64832e82b5d38f86e46a6c