### PR TITLE
Notify exam requester on exam confirmation

### DIFF
--- a/app.py
+++ b/app.py
@@ -6987,6 +6987,18 @@ def update_exam_appointment_status(appointment_id):
             content=f"Especialista não aceitou exame para {appt.animal.name}. Reagende com outro profissional.",
         )
         db.session.add(msg)
+    elif status == 'confirmed':
+        scheduled_local = appt.scheduled_at.replace(tzinfo=timezone.utc).astimezone(BR_TZ)
+        msg = Message(
+            sender_id=current_user.id,
+            receiver_id=appt.requester_id,
+            animal_id=appt.animal_id,
+            content=(
+                f"Exame de {appt.animal.name} confirmado para "
+                f"{scheduled_local.strftime('%d/%m/%Y %H:%M')} com {appt.specialist.user.name}."
+            ),
+        )
+        db.session.add(msg)
     db.session.commit()
     return jsonify({'success': True})
 

--- a/tests/test_schedule_exam.py
+++ b/tests/test_schedule_exam.py
@@ -159,6 +159,10 @@ def test_exam_appointment_requires_acceptance(client, monkeypatch):
     with flask_app.app_context():
         appt = ExamAppointment.query.get(1)
         assert appt.status == 'confirmed'
+        msg = Message.query.filter_by(receiver_id=tutor_id).first()
+        assert msg is not None
+        assert '20/05/2024 09:00' in msg.content
+        assert 'Vet' in msg.content
 
 
 def test_schedule_exam_same_user_auto_confirms(client, monkeypatch):


### PR DESCRIPTION
## Summary
- Send confirmation messages to exam requesters with exam date/time and specialist name.
- Update tests to expect confirmation notification.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b733936c78832ea811deecf0f42e2a