### PR TITLE
feat: summarize consultation and suggest return

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,3 +44,6 @@ class Config:
     # Endereço de retirada padrão (usado se não houver PickupLocation no banco)
     DEFAULT_PICKUP_ADDRESS = os.environ.get("DEFAULT_PICKUP_ADDRESS", "Rua Nove, 990")
 
+    # Política padrão de retorno em dias para consultas
+    DEFAULT_RETURN_DAYS = int(os.environ.get("DEFAULT_RETURN_DAYS", "7"))
+

--- a/templates/agendamentos/confirmar_retorno.html
+++ b/templates/agendamentos/confirmar_retorno.html
@@ -1,0 +1,35 @@
+{% extends "layout.html" %}
+
+{% block main %}
+<div class="container mt-4">
+  <h2>Agendar Retorno</h2>
+  <p>Revise e confirme os dados para o retorno recomendado.</p>
+  <form method="POST" action="{{ url_for('agendar_retorno', consulta_id=consulta.id) }}" class="row g-3">
+    {{ form.hidden_tag() }}
+    <div class="col-md-6">
+      {{ form.animal_id.label(class="form-label") }}
+      {{ form.animal_id(class="form-select") }}
+    </div>
+    <div class="col-md-6">
+      {{ form.veterinario_id.label(class="form-label") }}
+      {{ form.veterinario_id(class="form-select") }}
+    </div>
+    <div class="col-md-6">
+      {{ form.date.label(class="form-label") }}
+      {{ form.date(class="form-control") }}
+    </div>
+    <div class="col-md-6">
+      {{ form.time.label(class="form-label") }}
+      {{ form.time(class="form-control") }}
+    </div>
+    <div class="col-12">
+      {{ form.reason.label(class="form-label") }}
+      {{ form.reason(class="form-control") }}
+    </div>
+    <div class="col-12">
+      {{ form.submit(class="btn btn-primary") }}
+      <a href="{{ url_for('consulta_direct', animal_id=consulta.animal_id) }}" class="btn btn-secondary">Cancelar</a>
+    </div>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- send tutor a message summarizing finalized consultation
- pre-fill return appointment form with default vet and follow-up date
- add dedicated page to confirm return scheduling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b733a6937c832e84c6fc602103eb34