### PR TITLE
Enable creation of new exam models from form

### DIFF
--- a/app.py
+++ b/app.py
@@ -4203,6 +4203,19 @@ def buscar_exames():
     ])
 
 
+@app.route('/exame_modelo', methods=['POST'])
+@login_required
+def criar_exame_modelo():
+    data = request.get_json(silent=True) or {}
+    nome = (data.get('nome') or '').strip()
+    if not nome:
+        return jsonify({'error': 'Nome é obrigatório'}), 400
+    exame = ExameModelo(nome=nome)
+    db.session.add(exame)
+    db.session.commit()
+    return jsonify({'id': exame.id, 'nome': exame.nome})
+
+
 @app.route('/imprimir_bloco_exames/<int:bloco_id>')
 @login_required
 def imprimir_bloco_exames(bloco_id):

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -71,6 +71,7 @@
 
 <script>
   let exames = [];
+  let inputExame, sugestoes;
   function mostrarFeedback(msg, tipo = 'success') {
     const fb = document.getElementById('feedback-exames');
     fb.textContent = msg;
@@ -79,8 +80,8 @@
   }
 
   document.addEventListener('DOMContentLoaded', function () {
-    const inputExame = document.getElementById('nome-exame');
-    const sugestoes = document.getElementById('sugestoes-exames');
+    inputExame = document.getElementById('nome-exame');
+    sugestoes = document.getElementById('sugestoes-exames');
 
     inputExame.addEventListener('input', function () {
       const query = this.value;
@@ -93,17 +94,31 @@
         .then(res => res.json())
         .then(data => {
           sugestoes.innerHTML = '';
-          data.forEach(item => {
+          if (data.length) {
+            data.forEach(item => {
+              const li = document.createElement('li');
+              li.className = 'list-group-item list-group-item-action';
+              li.textContent = item.nome;
+              li.onclick = () => {
+                inputExame.value = item.nome;
+                document.getElementById('justificativa-exame').value = item.justificativa || '';
+                sugestoes.innerHTML = '';
+              };
+              sugestoes.appendChild(li);
+            });
+          } else {
             const li = document.createElement('li');
-            li.className = 'list-group-item list-group-item-action';
-            li.textContent = item.nome;
-            li.onclick = () => {
-              inputExame.value = item.nome;
-              document.getElementById('justificativa-exame').value = item.justificativa || '';
-              sugestoes.innerHTML = '';
-            };
+            li.className = 'list-group-item';
+            li.innerHTML = `
+              <div class="input-group">
+                <input type="text" id="novo-exame-nome" class="form-control" placeholder="Novo exame">
+                <button class="btn btn-outline-primary" type="button" id="btn-criar-exame">Criar</button>
+              </div>`;
             sugestoes.appendChild(li);
-          });
+            const novoInput = document.getElementById('novo-exame-nome');
+            novoInput.value = query;
+            document.getElementById('btn-criar-exame').onclick = criarExameModelo;
+          }
         });
   });
 
@@ -144,6 +159,37 @@
 
   renderExamesTemp(); // Inicializa a lista se já houver dados
   });
+
+  async function criarExameModelo() {
+    const nome = document.getElementById('novo-exame-nome')?.value.trim();
+    if (!nome) {
+      mostrarFeedback('Informe o nome do exame.', 'danger');
+      return;
+    }
+    try {
+      const resp = await fetch('/exame_modelo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify({ nome })
+      });
+      if (!resp.ok) throw new Error();
+      const data = await resp.json();
+      mostrarFeedback('Exame criado com sucesso!');
+      const li = document.createElement('li');
+      li.className = 'list-group-item list-group-item-action';
+      li.textContent = data.nome;
+      li.onclick = () => {
+        inputExame.value = data.nome;
+        document.getElementById('justificativa-exame').value = '';
+        sugestoes.innerHTML = '';
+      };
+      sugestoes.innerHTML = '';
+      sugestoes.appendChild(li);
+      li.click();
+    } catch (e) {
+      mostrarFeedback('Erro ao criar exame.', 'danger');
+    }
+  }
 
   function adicionarExame() {
     const nome = document.getElementById('nome-exame').value.trim();

--- a/tests/test_exame_modelo.py
+++ b/tests/test_exame_modelo.py
@@ -1,0 +1,51 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from app import app as flask_app, db
+from models import User, ExameModelo
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    yield flask_app
+
+
+def test_criar_exame_modelo(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(name="Vet", email="vet@example.com", worker="veterinario", role="admin")
+        user.set_password("x")
+        db.session.add(user)
+        db.session.commit()
+
+    client = app.test_client()
+    with client:
+        client.post('/login', data={'email': 'vet@example.com', 'password': 'x'}, follow_redirects=True)
+        resp = client.post('/exame_modelo', json={'nome': 'Hemograma'})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['nome'] == 'Hemograma'
+        with app.app_context():
+            exame = ExameModelo.query.first()
+            assert exame and exame.nome == 'Hemograma'
+
+
+def test_criar_exame_modelo_nome_obrigatorio(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(name="Vet", email="vet@example.com")
+        user.set_password("x")
+        db.session.add(user)
+        db.session.commit()
+
+    client = app.test_client()
+    with client:
+        client.post('/login', data={'email': 'vet@example.com', 'password': 'x'}, follow_redirects=True)
+        resp = client.post('/exame_modelo', json={})
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow users to create `ExameModelo` via new `/exame_modelo` endpoint
- enhance exam request form to offer creation UI and auto-select newly added exam
- add tests for exam model creation and validation

## Testing
- `pytest tests/test_exame_modelo.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7367a4d70832e8031566981ef7736