### PR TITLE
Add support for creating vaccine templates from UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -3683,6 +3683,25 @@ def buscar_vacinas():
         print(f"Erro ao buscar vacinas: {e}")
         return jsonify([])  # Não quebra o front se der erro
 
+@app.route('/vacina_modelo', methods=['POST'])
+def criar_vacina_modelo():
+    data = request.get_json(silent=True) or {}
+    nome = (data.get('nome') or '').strip()
+    tipo = (data.get('tipo') or '').strip()
+    if not nome or not tipo:
+        return jsonify({'success': False, 'message': 'Nome e tipo são obrigatórios.'}), 400
+    try:
+        existente = VacinaModelo.query.filter(func.lower(VacinaModelo.nome) == nome.lower()).first()
+        if existente:
+            return jsonify({'success': False, 'message': 'Vacina já cadastrada.'}), 400
+        vacina = VacinaModelo(nome=nome, tipo=tipo)
+        db.session.add(vacina)
+        db.session.commit()
+        return jsonify({'success': True, 'vacina': {'id': vacina.id, 'nome': vacina.nome, 'tipo': vacina.tipo}})
+    except Exception as e:
+        db.session.rollback()
+        print('Erro ao salvar vacina modelo:', e)
+        return jsonify({'success': False, 'message': 'Erro ao salvar vacina.'}), 500
 
 from datetime import datetime
 

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -2,6 +2,20 @@
     <div id="feedback-vacinas" class="alert d-none position-fixed" style="top: 20px; right: 20px; z-index: 1000;"></div>
     <h5 class="mb-3">💉 Registro de Vacinas</h5>
 
+    <!-- Botão para cadastrar nova vacina -->
+    <button type="button" class="btn btn-outline-primary mb-3" onclick="toggleNovaVacina()">➕ Nova vacina</button>
+    <div id="nova-vacina-container" class="border rounded p-3 mb-3 bg-light d-none">
+      <div class="mb-2">
+        <label for="nova-vacina-nome" class="form-label">Nome da vacina</label>
+        <input type="text" id="nova-vacina-nome" class="form-control" placeholder="Ex: Antirrábica">
+      </div>
+      <div class="mb-2">
+        <label for="nova-vacina-tipo" class="form-label">Tipo</label>
+        <input type="text" id="nova-vacina-tipo" class="form-control" placeholder="Campanha, Reforço...">
+      </div>
+      <button type="button" class="btn btn-primary" onclick="salvarVacinaModelo()">💾 Salvar Vacina</button>
+    </div>
+
     <!-- Campo com autocomplete -->
     <div class="mb-3 position-relative">
       <label for="nome-vacina" class="form-label">Vacina</label>
@@ -50,6 +64,7 @@
 
   <script>
     let vacinas = [];
+    let inputVacina, sugestoesVacinas;
     function mostrarFeedback(msg, tipo = 'success') {
       const fb = document.getElementById('feedback-vacinas');
       fb.textContent = msg;
@@ -58,15 +73,15 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
-      const input = document.getElementById('nome-vacina');
-      const sugestoes = document.getElementById('sugestoes-vacinas');
+      inputVacina = document.getElementById('nome-vacina');
+      sugestoesVacinas = document.getElementById('sugestoes-vacinas');
 
-      input.addEventListener('input', function () {
+      inputVacina.addEventListener('input', function () {
         const q = this.value.trim();
         console.log("🟡 Buscando vacina:", q);
 
         if (q.length < 2) {
-          sugestoes.innerHTML = '';
+          sugestoesVacinas.innerHTML = '';
           return;
         }
 
@@ -74,10 +89,10 @@
           .then(res => res.json())
           .then(data => {
             console.log("🟢 Resultados:", data);
-            sugestoes.innerHTML = '';
+            sugestoesVacinas.innerHTML = '';
 
             if (!data.length) {
-              sugestoes.innerHTML = '<li class="list-group-item text-muted">Nenhuma vacina encontrada</li>';
+              sugestoesVacinas.innerHTML = '<li class="list-group-item text-muted">Nenhuma vacina encontrada</li>';
               return;
             }
 
@@ -86,10 +101,10 @@
               li.className = 'list-group-item list-group-item-action';
               li.textContent = item.nome;
               li.onclick = () => {
-                input.value = item.nome;
-                sugestoes.innerHTML = '';
+                inputVacina.value = item.nome;
+                sugestoesVacinas.innerHTML = '';
               };
-              sugestoes.appendChild(li);
+              sugestoesVacinas.appendChild(li);
             });
           })
           .catch(err => {
@@ -99,13 +114,52 @@
 
       // Fecha sugestões ao clicar fora
       document.addEventListener('click', e => {
-        if (!sugestoes.contains(e.target) && e.target !== input) {
-          sugestoes.innerHTML = '';
+        if (!sugestoesVacinas.contains(e.target) && e.target !== inputVacina) {
+          sugestoesVacinas.innerHTML = '';
         }
       });
 
       renderVacinasTemp();
     });
+
+    function toggleNovaVacina() {
+      const box = document.getElementById('nova-vacina-container');
+      box.classList.toggle('d-none');
+    }
+
+    async function salvarVacinaModelo() {
+      const nome = document.getElementById('nova-vacina-nome').value.trim();
+      const tipo = document.getElementById('nova-vacina-tipo').value.trim();
+      if (!nome || !tipo) {
+        mostrarFeedback('Preencha nome e tipo da vacina.', 'warning');
+        return;
+      }
+      try {
+        const resp = await fetch('/vacina_modelo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+          body: JSON.stringify({ nome, tipo })
+        });
+        const data = await resp.json();
+        if (data.success) {
+          mostrarFeedback('Vacina cadastrada com sucesso!');
+          const li = document.createElement('li');
+          li.className = 'list-group-item list-group-item-action';
+          li.textContent = nome;
+          li.onclick = () => { inputVacina.value = nome; sugestoesVacinas.innerHTML = ''; };
+          sugestoesVacinas.prepend(li);
+          inputVacina.value = nome;
+          document.getElementById('nova-vacina-nome').value = '';
+          document.getElementById('nova-vacina-tipo').value = '';
+          document.getElementById('nova-vacina-container').classList.add('d-none');
+        } else {
+          mostrarFeedback(data.message || 'Erro ao cadastrar vacina.', 'danger');
+        }
+      } catch (err) {
+        console.error('❌ Erro ao salvar vacina modelo:', err);
+        mostrarFeedback('Erro ao cadastrar vacina.', 'danger');
+      }
+    }
 
     function adicionarVacina() {
       const nome = document.getElementById('nome-vacina').value.trim();

--- a/tests/test_vacinas.py
+++ b/tests/test_vacinas.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 from app import app as flask_app, db
-from models import User, Animal, Clinica, Vacina
+from models import User, Animal, Clinica, Vacina, VacinaModelo
 
 @pytest.fixture
 def app():
@@ -50,3 +50,16 @@ def test_salvar_vacina_data_invalida(app):
         vacina = Vacina.query.filter_by(animal_id=animal.id).first()
         assert vacina is not None
         assert vacina.data is None
+
+
+def test_criar_vacina_modelo(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        client = app.test_client()
+        resp = client.post('/vacina_modelo', json={'nome': 'V10', 'tipo': 'Obrigatória'})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is True
+        vm = VacinaModelo.query.filter_by(nome='V10').first()
+        assert vm is not None


### PR DESCRIPTION
## Summary
- add "Nova vacina" button and form to vaccinations UI
- implement `/vacina_modelo` route to persist `VacinaModelo`
- wire up JS to post new vaccines and refresh autocomplete

## Testing
- `pytest tests/test_vacinas.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b736873604832eb20ed4a47fb193f7