### PR TITLE
Hide return and exam scheduling forms

### DIFF
--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -112,8 +112,9 @@
   </form>
 {% elif appointment_form %}
   <hr class="my-4">
-  <h5>Agendar Retorno</h5>
-  <form method="POST" action="{{ url_for('agendar_retorno', consulta_id=consulta.id) }}" class="row g-3">
+  <button type="button" class="btn btn-outline-primary mb-3" id="toggle-retorno-form">Agendar Retorno</button>
+  <form id="agendar-retorno-form" method="POST" action="{{ url_for('agendar_retorno', consulta_id=consulta.id) }}" class="row g-3 d-none">
+    <h5 class="mb-3">Agendar Retorno</h5>
     {{ appointment_form.hidden_tag() }}
     <input type="hidden" name="animal_id" value="{{ animal.id }}">
     <input type="hidden" name="veterinario_id" value="{{ consulta.veterinario.veterinario.id }}">
@@ -181,6 +182,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // --- Retorno edit/delete handlers ---
   const retornoContainer = document.getElementById('retorno-container');
+  const toggleRetornoBtn = document.getElementById('toggle-retorno-form');
+  if (toggleRetornoBtn) {
+    toggleRetornoBtn.addEventListener('click', function() {
+      const form = document.getElementById('agendar-retorno-form');
+      if (form) {
+        form.classList.toggle('d-none');
+      }
+    });
+  }
   if (retornoContainer) {
     document.addEventListener('click', function(event) {
       const card = event.target.closest('#retorno-card');

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -32,7 +32,8 @@
 </form>
 
 <!-- Agendamento de exame -->
-<div id="agendar-exame" class="mt-5">
+<button type="button" class="btn btn-outline-primary mt-4" id="toggle-agendar-exame">Agendar Exame</button>
+<div id="agendar-exame" class="mt-5 d-none">
   <h5 class="mb-3">Agendar Exame</h5>
   <div class="mb-3">
     <label for="exam-specialty" class="form-label">Especialidade</label>
@@ -82,6 +83,14 @@
   document.addEventListener('DOMContentLoaded', function () {
     inputExame = document.getElementById('nome-exame');
     sugestoes = document.getElementById('sugestoes-exames');
+
+    const toggleAgendarBtn = document.getElementById('toggle-agendar-exame');
+    const agendarDiv = document.getElementById('agendar-exame');
+    if (toggleAgendarBtn && agendarDiv) {
+      toggleAgendarBtn.addEventListener('click', function () {
+        agendarDiv.classList.toggle('d-none');
+      });
+    }
 
     inputExame.addEventListener('input', function () {
       const query = this.value;


### PR DESCRIPTION
## Summary
- Hide return scheduling form behind a button on consultation page
- Hide exam scheduling form and reveal with toggle

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7391a56b4832ea917cab74b93880a