### PR TITLE
Add buttons for creating new exams and medications

### DIFF
--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -2,6 +2,16 @@
   <div id="feedback-exames" class="alert d-none position-fixed" style="top: 20px; right: 20px; z-index: 1000;"></div>
   <h5 class="mb-3">Solicitação de Exames</h5>
 
+  <!-- Botão para cadastrar novo exame -->
+  <button type="button" class="btn btn-outline-primary mb-3" onclick="toggleNovoExame()">➕ Novo exame</button>
+  <div id="novo-exame-container" class="border rounded p-3 mb-3 bg-light d-none">
+    <div class="mb-2">
+      <label for="novo-exame-nome" class="form-label">Nome do exame</label>
+      <input type="text" id="novo-exame-nome" class="form-control" placeholder="Ex: Hemograma">
+    </div>
+    <button type="button" class="btn btn-primary" onclick="criarExameModelo()">💾 Salvar Exame</button>
+  </div>
+
   <!-- Campo com autocomplete -->
   <div class="mb-3 position-relative">
     <label for="nome-exame" class="form-label">Tipo de Exame</label>
@@ -168,6 +178,11 @@
 
   renderExamesTemp(); // Inicializa a lista se já houver dados
   });
+
+  function toggleNovoExame() {
+    const box = document.getElementById('novo-exame-container');
+    if (box) box.classList.toggle('d-none');
+  }
 
   async function criarExameModelo() {
     const nome = document.getElementById('novo-exame-nome')?.value.trim();

--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -3,6 +3,8 @@
   <div id="feedback-message" class="alert d-none position-fixed" style="top: 20px; right: 20px; z-index: 1000;"></div>
 
   <h5 class="mb-3">Prescrição de Medicamentos</h5>
+  <!-- Botão para cadastrar novo medicamento -->
+  <button type="button" class="btn btn-outline-primary mb-3" onclick="mostrarFormNovoMedicamento()">➕ Novo medicamento</button>
 
   <!-- Campo com autocomplete -->
   <div class="mb-3 position-relative">


### PR DESCRIPTION
## Summary
- Add 'Novo exame' button and container to exam form, enabling creation of exam models.
- Add 'Novo medicamento' button to prescription form to show medication creation form.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7574f4190832e8d2429f41fd15110