### PR TITLE
refactor: use shared modal for creating models

### DIFF
--- a/static/admin/modelos.js
+++ b/static/admin/modelos.js
@@ -1,0 +1,86 @@
+async function criarExameModelo(modalId){
+  const nomeInput = document.getElementById(`${modalId}-nome`);
+  const nome = nomeInput ? nomeInput.value.trim() : '';
+  if(!nome){
+    if(typeof mostrarFeedback === 'function') mostrarFeedback('Informe o nome do exame.', 'danger');
+    return;
+  }
+  try{
+    const resp = await fetch('/exame_modelo', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      body: JSON.stringify({ nome })
+    });
+    if(!resp.ok) throw new Error();
+    const data = await resp.json();
+    if(typeof mostrarFeedback === 'function') mostrarFeedback('Exame criado com sucesso!');
+    closeModal(modalId);
+    if(typeof inputExame !== 'undefined' && inputExame){
+      const li = document.createElement('li');
+      li.className = 'list-group-item list-group-item-action';
+      li.textContent = data.nome;
+      li.onclick = () => {
+        inputExame.value = data.nome;
+        const just = document.getElementById('justificativa-exame');
+        if(just) just.value = '';
+        const sug = document.getElementById('sugestoes-exames');
+        if(sug) sug.innerHTML = '';
+      };
+      const sugestoes = document.getElementById('sugestoes-exames');
+      if(sugestoes){
+        sugestoes.innerHTML='';
+        sugestoes.appendChild(li);
+      }
+      li.click();
+    }
+  }catch(e){
+    if(typeof mostrarFeedback === 'function') mostrarFeedback('Erro ao criar exame.', 'danger');
+  }
+}
+
+async function salvarNovaMedicacao(modalId){
+  const nomeEl = document.getElementById(`${modalId}-nome`);
+  const principioEl = document.getElementById(`${modalId}-principio`);
+  const nome = nomeEl ? nomeEl.value.trim() : '';
+  const principio = principioEl ? principioEl.value.trim() : '';
+  if(!nome || !principio){
+    if(typeof mostrarFeedback === 'function') mostrarFeedback('Preencha nome e princípio ativo.', 'danger');
+    return;
+  }
+  try{
+    const res = await fetch('/medicamento_modelo', {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json', 'Accept':'application/json' },
+      body: JSON.stringify({ nome, principio_ativo: principio })
+    });
+    const data = await res.json();
+    if(!res.ok || data.success === false) throw new Error(data.message || 'Erro ao salvar medicação');
+    if(typeof mostrarFeedback === 'function') mostrarFeedback('Medicação cadastrada com sucesso!');
+    closeModal(modalId);
+    if(nomeEl) nomeEl.value='';
+    if(principioEl) principioEl.value='';
+    const input = document.getElementById('nome-medicamento');
+    const sugestoes = document.getElementById('sugestoes-medicamentos');
+    if(input && sugestoes){
+      const li = document.createElement('li');
+      li.className = 'list-group-item list-group-item-action';
+      li.textContent = data.nome || nome;
+      li.onclick = () => {
+        if(typeof preencherCardMedicamento === 'function') preencherCardMedicamento(data);
+        input.value = data.nome || nome;
+        const dose = document.getElementById('dose');
+        const duracao = document.getElementById('duracao');
+        if(dose) dose.value = data.dosagem_recomendada || '';
+        if(duracao) duracao.value = data.duracao_tratamento || '';
+        sugestoes.innerHTML='';
+        sugestoes.style.display='none';
+      };
+      sugestoes.innerHTML='';
+      sugestoes.appendChild(li);
+      sugestoes.style.display='block';
+      li.click();
+    }
+  }catch(err){
+    if(typeof mostrarFeedback === 'function') mostrarFeedback('Erro ao salvar medicação.', 'danger');
+  }
+}

--- a/templates/components/modal_form.html
+++ b/templates/components/modal_form.html
@@ -1,0 +1,43 @@
+<div class="custom-modal" id="{{ modal_id }}" style="display:none;">
+  <div class="custom-modal-backdrop" data-modal-close="{{ modal_id }}"></div>
+  <div class="custom-modal-content">
+    <div class="custom-modal-header">
+      <h5 class="modal-title">{{ title }}</h5>
+      <button type="button" class="btn-close" data-modal-close="{{ modal_id }}"></button>
+    </div>
+    <div class="custom-modal-body">
+      <div class="mb-3">
+        <label for="{{ modal_id }}-nome" class="form-label">Nome</label>
+        <input type="text" id="{{ modal_id }}-nome" class="form-control">
+      </div>
+      {% if extra_fields %}
+        {{ extra_fields|safe }}
+      {% endif %}
+    </div>
+    <div class="custom-modal-footer text-end">
+      <button type="button" class="btn btn-secondary" data-modal-close="{{ modal_id }}">Cancelar</button>
+      <button type="button" class="btn btn-primary" id="{{ save_button_id }}">Salvar</button>
+    </div>
+  </div>
+</div>
+<script>
+function openModal(id){
+  const m = document.getElementById(id);
+  if(m) m.style.display='flex';
+}
+function closeModal(id){
+  const m = document.getElementById(id);
+  if(m) m.style.display='none';
+}
+(function(){
+  document.querySelectorAll('[data-modal-close="{{ modal_id }}"]').forEach(btn=>{
+    btn.addEventListener('click',()=>closeModal('{{ modal_id }}'));
+  });
+})();
+</script>
+<style>
+.custom-modal{position:fixed;top:0;left:0;width:100%;height:100%;align-items:center;justify-content:center;display:none;z-index:1050;}
+.custom-modal-backdrop{position:absolute;width:100%;height:100%;top:0;left:0;background:rgba(0,0,0,0.5);}
+.custom-modal-content{position:relative;background:#fff;border-radius:.3rem;max-width:500px;width:90%;padding:1rem;z-index:1;}
+.custom-modal-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;}
+</style>

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -3,14 +3,10 @@
   <h5 class="mb-3">Solicitação de Exames</h5>
 
   <!-- Botão para cadastrar novo exame -->
-    <button type="button" class="btn btn-outline-primary mb-3" id="toggle-novo-exame">➕ Novo exame</button>
-  <div id="novo-exame-container" class="border rounded p-3 mb-3 bg-light d-none">
-    <div class="mb-2">
-      <label for="novo-exame-nome" class="form-label">Nome do exame</label>
-      <input type="text" id="novo-exame-nome" class="form-control" placeholder="Ex: Hemograma">
-    </div>
-    <button type="button" class="btn btn-primary" onclick="criarExameModelo()">💾 Salvar Exame</button>
-  </div>
+    <button type="button" class="btn btn-outline-primary mb-3" onclick="openModal('modal-exame')">➕ Novo exame</button>
+  {% with modal_id='modal-exame', title='Novo exame', save_button_id='salvar-exame-modal' %}
+    {% include 'components/modal_form.html' %}
+  {% endwith %}
 
   <!-- Campo com autocomplete -->
   <div class="mb-3 position-relative">
@@ -80,6 +76,7 @@
 
 
 
+<script src="{{ url_for('static', filename='admin/modelos.js') }}"></script>
 <script>
   let exames = [];
   let inputExame, sugestoes;
@@ -102,12 +99,9 @@
         });
       }
 
-      const toggleNovoExameBtn = document.getElementById('toggle-novo-exame');
-      const novoExameBox = document.getElementById('novo-exame-container');
-      if (toggleNovoExameBtn && novoExameBox) {
-        toggleNovoExameBtn.addEventListener('click', () => {
-          novoExameBox.classList.toggle('d-none');
-        });
+      const salvarExameBtn = document.getElementById('salvar-exame-modal');
+      if (salvarExameBtn) {
+        salvarExameBtn.addEventListener('click', () => criarExameModelo('modal-exame'));
       }
 
     inputExame.addEventListener('input', function () {
@@ -135,16 +129,14 @@
             });
           } else {
             const li = document.createElement('li');
-            li.className = 'list-group-item';
-            li.innerHTML = `
-              <div class="input-group">
-                <input type="text" id="novo-exame-nome" class="form-control" placeholder="Novo exame">
-                <button class="btn btn-outline-primary" type="button" id="btn-criar-exame">Criar</button>
-              </div>`;
+            li.className = 'list-group-item list-group-item-action text-primary';
+            li.textContent = 'Adicionar exame';
+            li.onclick = () => {
+              openModal('modal-exame');
+              const input = document.getElementById('modal-exame-nome');
+              if (input) input.value = query;
+            };
             sugestoes.appendChild(li);
-            const novoInput = document.getElementById('novo-exame-nome');
-            novoInput.value = query;
-            document.getElementById('btn-criar-exame').onclick = criarExameModelo;
           }
         });
   });
@@ -186,37 +178,6 @@
 
   renderExamesTemp(); // Inicializa a lista se já houver dados
   });
-
-    async function criarExameModelo() {
-    const nome = document.getElementById('novo-exame-nome')?.value.trim();
-    if (!nome) {
-      mostrarFeedback('Informe o nome do exame.', 'danger');
-      return;
-    }
-    try {
-      const resp = await fetch('/exame_modelo', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-        body: JSON.stringify({ nome })
-      });
-      if (!resp.ok) throw new Error();
-      const data = await resp.json();
-      mostrarFeedback('Exame criado com sucesso!');
-      const li = document.createElement('li');
-      li.className = 'list-group-item list-group-item-action';
-      li.textContent = data.nome;
-      li.onclick = () => {
-        inputExame.value = data.nome;
-        document.getElementById('justificativa-exame').value = '';
-        sugestoes.innerHTML = '';
-      };
-      sugestoes.innerHTML = '';
-      sugestoes.appendChild(li);
-      li.click();
-    } catch (e) {
-      mostrarFeedback('Erro ao criar exame.', 'danger');
-    }
-  }
 
   function adicionarExame() {
     const nome = document.getElementById('nome-exame').value.trim();

--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -4,18 +4,10 @@
 
   <h5 class="mb-3">Prescrição de Medicamentos</h5>
    <!-- Botão para cadastrar nova medicação -->
-   <button type="button" class="btn btn-outline-primary mb-3" id="toggle-nova-medicacao">➕ Nova medicação</button>
-   <div id="nova-medicacao-container" class="border rounded p-3 mb-3 bg-light d-none">
-     <div class="mb-2">
-       <label for="nova-medicacao-nome" class="form-label">Nome da medicação</label>
-       <input type="text" id="nova-medicacao-nome" class="form-control" placeholder="Ex: Dipirona">
-     </div>
-     <div class="mb-2">
-       <label for="nova-medicacao-principio" class="form-label">Princípio ativo</label>
-       <input type="text" id="nova-medicacao-principio" class="form-control">
-     </div>
-     <button type="button" class="btn btn-primary" id="salvar-nova-medicacao">💾 Salvar Medicação</button>
-   </div>
+   <button type="button" class="btn btn-outline-primary mb-3" onclick="openModal('modal-medicacao')">➕ Nova medicação</button>
+   {% with modal_id='modal-medicacao', title='Nova medicação', save_button_id='salvar-medicacao-modal', extra_fields='<div class="mb-2"><label for="modal-medicacao-principio" class="form-label">Princípio ativo</label><input type="text" id="modal-medicacao-principio" class="form-control"></div>' %}
+     {% include 'components/modal_form.html' %}
+   {% endwith %}
 
    <!-- Campo com autocomplete -->
    <div class="mb-3 position-relative">
@@ -104,10 +96,10 @@
   {% include 'partials/historico_prescricoes.html' %}
 </div>
 
+<script src="{{ url_for('static', filename='admin/modelos.js') }}"></script>
 <script>
     let medicamentoSelecionado = null;
     let prescricoes = [];
-    let novaMedicacaoBox;
 
   // Função para mostrar feedback ao usuário
   function mostrarFeedback(mensagem, tipo = 'success') {
@@ -144,36 +136,7 @@
     document.getElementById('info-medicamento').classList.remove('d-none');
   }
 
-    function toggleNovaMedicacao() {
-      if (novaMedicacaoBox) {
-        novaMedicacaoBox.classList.toggle('d-none');
-      }
-    }
-
-    async function salvarNovaMedicacao() {
-      const nome = document.getElementById('nova-medicacao-nome').value.trim();
-      const principio = document.getElementById('nova-medicacao-principio').value.trim();
-      if (!nome || !principio) {
-        mostrarFeedback('Preencha nome e princípio ativo.', 'danger');
-        return;
-      }
-      try {
-        const res = await fetch('/medicamento_modelo', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-          body: JSON.stringify({ nome, principio_ativo: principio })
-        });
-        const data = await res.json();
-        if (!res.ok || !data.success) throw new Error(data.message || 'Erro ao salvar medicação');
-        mostrarFeedback('Medicação cadastrada com sucesso!');
-        document.getElementById('nova-medicacao-nome').value = '';
-        document.getElementById('nova-medicacao-principio').value = '';
-        novaMedicacaoBox.classList.add('d-none');
-      } catch (err) {
-        console.error('Erro ao salvar medicação:', err);
-        mostrarFeedback('Erro ao salvar medicação.', 'danger');
-      }
-    }
+    
 
   // Alternar entre modos de prescrição
   function alternarModo() {
@@ -348,11 +311,8 @@
     document.addEventListener('DOMContentLoaded', function() {
       const input = document.getElementById('nome-medicamento');
       const sugestoes = document.getElementById('sugestoes-medicamentos');
-      novaMedicacaoBox = document.getElementById('nova-medicacao-container');
-      const toggleBtn = document.getElementById('toggle-nova-medicacao');
-      const salvarBtn = document.getElementById('salvar-nova-medicacao');
-      if (toggleBtn) toggleBtn.addEventListener('click', toggleNovaMedicacao);
-      if (salvarBtn) salvarBtn.addEventListener('click', salvarNovaMedicacao);
+      const salvarBtn = document.getElementById('salvar-medicacao-modal');
+      if (salvarBtn) salvarBtn.addEventListener('click', () => salvarNovaMedicacao('modal-medicacao'));
 
     // Busca de medicamentos com debounce
     input.addEventListener('input', debounce(function() {
@@ -401,12 +361,14 @@
             addLi.className = 'list-group-item list-group-item-action text-primary';
             addLi.textContent = 'Adicionar medicação';
             addLi.onclick = () => {
-              const nomeInput = document.getElementById('nova-medicacao-nome');
-              if (nomeInput) nomeInput.value = input.value.trim();
-              toggleNovaMedicacao();
-              sugestoes.style.display = 'none';
-            };
-            sugestoes.appendChild(addLi);
+          const nomeInput = document.getElementById('modal-medicacao-nome');
+          const principioInput = document.getElementById('modal-medicacao-principio');
+          if (nomeInput) nomeInput.value = input.value.trim();
+          if (principioInput) principioInput.value = '';
+          openModal('modal-medicacao');
+          sugestoes.style.display = 'none';
+        };
+        sugestoes.appendChild(addLi);
         })
         .catch(err => {
           sugestoes.innerHTML = '<li class="list-group-item text-danger">Erro ao buscar medicamentos</li>';


### PR DESCRIPTION
## Summary
- create reusable modal component with generic form
- reuse modal for adding exam and medication models
- centralize creation logic into shared modelos.js

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b76377cb74832e954595405d6751e6