### PR TITLE
Fix appointment timezone display

### DIFF
--- a/templates/agendamentos/appointments_admin.html
+++ b/templates/agendamentos/appointments_admin.html
@@ -6,7 +6,7 @@
   <ul class="list-group">
     {% for appt in appointments %}
       <li class="list-group-item d-flex justify-content-between align-items-center">
-        <span>{{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.tutor.name }} &rarr; {{ appt.veterinario.user.name }}</span>
+        <span>{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.tutor.name }} &rarr; {{ appt.veterinario.user.name }}</span>
         <form method="POST" action="{{ url_for('delete_appointment', appointment_id=appt.id) }}" class="ms-2 js-confirm" data-message="Remover agendamento?">
           {{ delete_form.hidden_tag() }}
           <button type="submit" class="btn btn-sm btn-danger"><i class="fas fa-trash"></i></button>

--- a/templates/agendamentos/edit_appointment.html
+++ b/templates/agendamentos/edit_appointment.html
@@ -6,11 +6,11 @@
   <form id="edit-form">
     <div class="mb-3">
       <label for="date" class="form-label">Data</label>
-      <input type="date" id="date" class="form-control" value="{{ appointment.scheduled_at.date() }}">
+      <input type="date" id="date" class="form-control" value="{{ appointment.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}">
     </div>
     <div class="mb-3">
       <label for="time" class="form-label">Horário</label>
-      <input type="time" id="time" class="form-control" value="{{ appointment.scheduled_at.strftime('%H:%M') }}">
+      <input type="time" id="time" class="form-control" value="{{ appointment.scheduled_at|format_datetime_brazil('%H:%M') }}">
     </div>
     <div class="mb-3">
       <label for="veterinario" class="form-label">Veterinário</label>

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -156,7 +156,7 @@
                 <i class="fas fa-clock {% if can_respond %}text-warning{% else %}text-secondary{% endif %} fa-2x"></i>
               </div>
               <div>
-                <h6 class="mb-0">{{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
                 <small class="text-muted">{{ appt.tutor.name if item.kind=='consulta' else appt.animal.owner.name }}{% if item.kind == 'exame' %} <span class="badge bg-info ms-1">Exame</span>{% endif %}</small>
                 <div class="mt-1">
                   {% if can_respond %}
@@ -218,7 +218,7 @@
                   <i class="fas fa-flask fa-2x text-info"></i>
                 </div>
                 <div>
-                  <h6 class="mb-0">{{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                  <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
                   <small class="text-muted">{{ appt.animal.owner.name }} <span class="badge bg-info ms-1">Exame</span></small>
                 </div>
               </div>
@@ -231,8 +231,8 @@
           {% else %}
           <div class="list-group-item list-group-item-action appointment-item"
               data-id="{{ appt.id }}"
-              data-date="{{ appt.scheduled_at.strftime('%Y-%m-%d') }}"
-              data-time="{{ appt.scheduled_at.strftime('%H:%M') }}"
+              data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+              data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
               data-vet="{{ appt.veterinario.user.name }}"
               data-tutor="{{ appt.tutor.name }}"
               data-tutor-id="{{ appt.tutor_id }}"
@@ -249,7 +249,7 @@
                   <i class="fas fa-stethoscope fa-2x text-success"></i>
                 </div>
                 <div>
-                  <h6 class="mb-0">{{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                  <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
                   <small class="text-muted">{{ appt.tutor.name }}
                     {% if item.kind == 'retorno' %}<span class="badge bg-warning text-dark ms-1">Retorno</span>{% endif %}
                   </small>
@@ -286,8 +286,8 @@
         {% for appt in appointments_past %}
           <div class="list-group-item list-group-item-action appointment-item"
               data-id="{{ appt.id }}"
-              data-date="{{ appt.scheduled_at.strftime('%Y-%m-%d') }}"
-              data-time="{{ appt.scheduled_at.strftime('%H:%M') }}"
+              data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+              data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
               data-vet="{{ appt.veterinario.user.name }}"
               data-tutor="{{ appt.tutor.name }}"
               data-tutor-id="{{ appt.tutor_id }}"
@@ -303,7 +303,7 @@
                   <i class="fas fa-history fa-2x text-secondary"></i>
                 </div>
                 <div>
-                  <h6 class="mb-0">{{ appt.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                  <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
                   <small class="text-muted">{{ appt.tutor.name }}</small>
                 </div>
               </div>

--- a/templates/clinica/multi_clinic_dashboard.html
+++ b/templates/clinica/multi_clinic_dashboard.html
@@ -19,7 +19,7 @@
       <h5>Próximos Agendamentos</h5>
       <ul>
         {% for ap in item.appointments %}
-        <li>{{ ap.scheduled_at.strftime('%d/%m/%Y %H:%M') }} - {{ ap.animal.name }}</li>
+        <li>{{ ap.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ ap.animal.name }}</li>
         {% else %}
         <li>Nenhum agendamento.</li>
         {% endfor %}

--- a/templates/partials/edit_appointment_form.html
+++ b/templates/partials/edit_appointment_form.html
@@ -2,11 +2,11 @@
   <input type="hidden" id="csrf_token" value="{{ csrf_token() if csrf_token is defined else '' }}">
   <div class="mb-3">
     <label for="edit-date" class="form-label">Data</label>
-    <input type="date" id="edit-date" class="form-control" value="{{ appointment.scheduled_at.date() }}">
+    <input type="date" id="edit-date" class="form-control" value="{{ appointment.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}">
   </div>
   <div class="mb-3">
     <label for="edit-time" class="form-label">Horário</label>
-    <input type="time" id="edit-time" class="form-control" value="{{ appointment.scheduled_at.strftime('%H:%M') }}">
+    <input type="time" id="edit-time" class="form-control" value="{{ appointment.scheduled_at|format_datetime_brazil('%H:%M') }}">
   </div>
   <div class="mb-3">
     <label for="edit-vet" class="form-label">Veterinário</label>


### PR DESCRIPTION
## Summary
- ensure appointment times are rendered in local Brazil timezone
- use `format_datetime_brazil` filter for appointment editing forms and veterinarian schedule views

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b765980ab0832e847d0c1b7396f904