### PR TITLE
Group vet schedule by weekday

### DIFF
--- a/app.py
+++ b/app.py
@@ -6618,6 +6618,11 @@ def appointments():
             'Domingo': 6,
         }
         horarios.sort(key=lambda h: weekday_order.get(h.dia_semana, 7))
+        horarios_grouped = []
+        for h in horarios:
+            if not horarios_grouped or horarios_grouped[-1]['dia'] != h.dia_semana:
+                horarios_grouped.append({'dia': h.dia_semana, 'itens': []})
+            horarios_grouped[-1]['itens'].append(h)
         now = datetime.utcnow()
         start_str = request.args.get('start')
         end_str = request.args.get('end')
@@ -6706,7 +6711,7 @@ def appointments():
             schedule_form=schedule_form,
             appointment_form=appointment_form,
             veterinario=veterinario,
-            horarios=horarios,
+            horarios_grouped=horarios_grouped,
             appointments_pending=appointments_pending,
             appointments_upcoming=appointments_upcoming,
             appointments_past=appointments_past,

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -332,14 +332,14 @@
     </div>
     <div class="card-body">
       <div class="row">
-        {% for dia, itens in horarios|groupby('dia_semana') %}
+        {% for grupo in horarios_grouped %}
           <div class="col-md-6 col-lg-4 mb-3">
             <div class="card h-100">
               <div class="card-header py-2">
-                <h6 class="mb-0">{{ dia }}</h6>
+                <h6 class="mb-0">{{ grupo.dia }}</h6>
               </div>
               <div class="card-body py-2">
-                {% for h in itens %}
+                {% for h in grupo.itens %}
                   <div class="d-flex justify-content-between align-items-center mb-2">
                     <div>
                       <span class="badge bg-light text-dark">{{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}</span>


### PR DESCRIPTION
## Summary
- Build ordered `horarios_grouped` for veterinarian schedules without re-sorting
- Pass grouped data to edit schedule template and iterate without Jinja groupby

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b79d91d028832e9bcb0ce29e7d97c0