### PR TITLE
Allow optional medication fields in QR consultation

### DIFF
--- a/app.py
+++ b/app.py
@@ -3983,16 +3983,38 @@ def importar_medicamentos():
 def criar_medicamento():
     data = request.get_json(silent=True) or {}
     nome = (data.get("nome") or "").strip()
-    principio = (data.get("principio_ativo") or "").strip()
 
-    if not nome or not principio:
-        return jsonify({"success": False, "message": "Nome e princípio ativo são obrigatórios"}), 400
+    if not nome:
+        return jsonify({"success": False, "message": "Nome é obrigatório"}), 400
 
     try:
-        novo = Medicamento(nome=nome, principio_ativo=principio, created_by=current_user.id)
+        novo = Medicamento(
+            nome=nome,
+            principio_ativo=(data.get("principio_ativo") or "").strip() or None,
+            classificacao=(data.get("classificacao") or "").strip() or None,
+            via_administracao=(data.get("via_administracao") or "").strip() or None,
+            dosagem_recomendada=(data.get("dosagem_recomendada") or "").strip() or None,
+            frequencia=(data.get("frequencia") or "").strip() or None,
+            duracao_tratamento=(data.get("duracao_tratamento") or "").strip() or None,
+            observacoes=(data.get("observacoes") or "").strip() or None,
+            bula=(data.get("bula") or "").strip() or None,
+            created_by=current_user.id,
+        )
         db.session.add(novo)
         db.session.commit()
-        return jsonify({"success": True, "id": novo.id})
+        return jsonify({
+            "success": True,
+            "id": novo.id,
+            "nome": novo.nome,
+            "classificacao": novo.classificacao,
+            "principio_ativo": novo.principio_ativo,
+            "via_administracao": novo.via_administracao,
+            "dosagem_recomendada": novo.dosagem_recomendada,
+            "frequencia": novo.frequencia,
+            "duracao_tratamento": novo.duracao_tratamento,
+            "observacoes": novo.observacoes,
+            "bula": novo.bula,
+        })
     except Exception as e:
         db.session.rollback()
         return jsonify({"success": False, "message": str(e)}), 500
@@ -4075,6 +4097,7 @@ def buscar_medicamentos():
             "principio_ativo": m.principio_ativo,
             "via_administracao": m.via_administracao,
             "dosagem_recomendada": m.dosagem_recomendada,
+            "frequencia": m.frequencia,
             "duracao_tratamento": m.duracao_tratamento,
             "observacoes": m.observacoes,
             "bula": m.bula,

--- a/static/admin/modelos.js
+++ b/static/admin/modelos.js
@@ -69,8 +69,10 @@ async function salvarNovaMedicacao(modalId){
         if(typeof preencherCardMedicamento === 'function') preencherCardMedicamento(data);
         input.value = data.nome || nome;
         const dose = document.getElementById('dose');
+        const freq = document.getElementById('frequencia');
         const duracao = document.getElementById('duracao');
         if(dose) dose.value = data.dosagem_recomendada || '';
+        if(freq) freq.value = data.frequencia || '';
         if(duracao) duracao.value = data.duracao_tratamento || '';
         sugestoes.innerHTML='';
         sugestoes.style.display='none';

--- a/templates/partials/prescricao_form.html
+++ b/templates/partials/prescricao_form.html
@@ -7,12 +7,40 @@
    <button type="button" class="btn btn-outline-primary mb-3" onclick="toggleNovaMedicacao()">➕ Nova medicação</button>
    <div id="nova-medicacao-container" class="border rounded p-3 mb-3 bg-light d-none">
      <div class="mb-2">
-       <label for="nova-medicacao-nome" class="form-label">Nome do medicamento</label>
+       <label for="nova-medicacao-nome" class="form-label">Nome do medicamento*</label>
        <input type="text" id="nova-medicacao-nome" class="form-control">
      </div>
      <div class="mb-2">
        <label for="nova-medicacao-principio" class="form-label">Princípio ativo</label>
        <input type="text" id="nova-medicacao-principio" class="form-control">
+     </div>
+     <div class="mb-2">
+       <label for="nova-medicacao-classificacao" class="form-label">Classificação</label>
+       <input type="text" id="nova-medicacao-classificacao" class="form-control">
+     </div>
+     <div class="mb-2">
+       <label for="nova-medicacao-via" class="form-label">Via de administração</label>
+       <input type="text" id="nova-medicacao-via" class="form-control">
+     </div>
+     <div class="mb-2">
+       <label for="nova-medicacao-dosagem" class="form-label">Dosagem recomendada</label>
+       <input type="text" id="nova-medicacao-dosagem" class="form-control">
+     </div>
+     <div class="mb-2">
+       <label for="nova-medicacao-frequencia" class="form-label">Frequência</label>
+       <input type="text" id="nova-medicacao-frequencia" class="form-control">
+     </div>
+     <div class="mb-2">
+       <label for="nova-medicacao-duracao" class="form-label">Duração do tratamento</label>
+       <input type="text" id="nova-medicacao-duracao" class="form-control">
+     </div>
+     <div class="mb-2">
+       <label for="nova-medicacao-observacoes" class="form-label">Observações</label>
+       <textarea id="nova-medicacao-observacoes" class="form-control" rows="2"></textarea>
+     </div>
+     <div class="mb-2">
+       <label for="nova-medicacao-bula" class="form-label">Bula</label>
+       <textarea id="nova-medicacao-bula" class="form-control" rows="2"></textarea>
      </div>
      <button type="button" class="btn btn-primary" onclick="salvarMedicamentoModelo()">💾 Salvar Medicamento</button>
    </div>
@@ -35,10 +63,12 @@
       <div class="row">
         <div class="col-md-6">
           <p><strong>Classificação:</strong> <span id="med-classificacao" class="text-muted">–</span></p>
+          <p><strong>Princípio ativo:</strong> <span id="med-principio" class="text-muted">–</span></p>
           <p><strong>Via:</strong> <span id="med-via" class="text-muted">–</span></p>
         </div>
         <div class="col-md-6">
           <p><strong>Dosagem:</strong> <span id="med-dosagem" class="text-muted">–</span></p>
+          <p><strong>Frequência:</strong> <span id="med-frequencia" class="text-muted">–</span></p>
           <p><strong>Duração:</strong> <span id="med-duracao" class="text-muted">–</span></p>
         </div>
       </div>
@@ -116,15 +146,32 @@
   async function salvarMedicamentoModelo() {
     const nome = document.getElementById('nova-medicacao-nome').value.trim();
     const principio = document.getElementById('nova-medicacao-principio').value.trim();
-    if (!nome || !principio) {
-      mostrarFeedback('Preencha nome e princípio ativo.', 'warning');
+    const classificacao = document.getElementById('nova-medicacao-classificacao').value.trim();
+    const via = document.getElementById('nova-medicacao-via').value.trim();
+    const dosagem = document.getElementById('nova-medicacao-dosagem').value.trim();
+    const frequencia = document.getElementById('nova-medicacao-frequencia').value.trim();
+    const duracao = document.getElementById('nova-medicacao-duracao').value.trim();
+    const observacoes = document.getElementById('nova-medicacao-observacoes').value.trim();
+    const bula = document.getElementById('nova-medicacao-bula').value.trim();
+    if (!nome) {
+      mostrarFeedback('Informe o nome do medicamento.', 'warning');
       return;
     }
     try {
       const resp = await fetch('/medicamento', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-        body: JSON.stringify({ nome, principio_ativo: principio })
+        body: JSON.stringify({
+          nome,
+          principio_ativo: principio || null,
+          classificacao: classificacao || null,
+          via_administracao: via || null,
+          dosagem_recomendada: dosagem || null,
+          frequencia: frequencia || null,
+          duracao_tratamento: duracao || null,
+          observacoes: observacoes || null,
+          bula: bula || null
+        })
       });
       const data = await resp.json();
       if (resp.ok && data.id) {
@@ -132,7 +179,18 @@
         document.getElementById('nome-medicamento').value = nome;
         document.getElementById('nova-medicacao-nome').value = '';
         document.getElementById('nova-medicacao-principio').value = '';
+        document.getElementById('nova-medicacao-classificacao').value = '';
+        document.getElementById('nova-medicacao-via').value = '';
+        document.getElementById('nova-medicacao-dosagem').value = '';
+        document.getElementById('nova-medicacao-frequencia').value = '';
+        document.getElementById('nova-medicacao-duracao').value = '';
+        document.getElementById('nova-medicacao-observacoes').value = '';
+        document.getElementById('nova-medicacao-bula').value = '';
         document.getElementById('nova-medicacao-container').classList.add('d-none');
+        preencherCardMedicamento(data);
+        document.getElementById('dose').value = data.dosagem_recomendada || '';
+        document.getElementById('frequencia').value = data.frequencia || '';
+        document.getElementById('duracao').value = data.duracao_tratamento || '';
       } else {
         mostrarFeedback(data.message || 'Erro ao cadastrar medicação.', 'danger');
       }
@@ -162,8 +220,10 @@
   function preencherCardMedicamento(m) {
     document.getElementById('med-nome-card').textContent = m.nome;
     document.getElementById('med-classificacao').textContent = m.classificacao || '–';
+    document.getElementById('med-principio').textContent = m.principio_ativo || '–';
     document.getElementById('med-via').textContent = m.via_administracao || '–';
     document.getElementById('med-dosagem').textContent = m.dosagem_recomendada || '–';
+    document.getElementById('med-frequencia').textContent = m.frequencia || '–';
     document.getElementById('med-duracao').textContent = m.duracao_tratamento || '–';
     document.getElementById('med-observacoes').textContent = m.observacoes || '–';
     
@@ -426,6 +486,7 @@
                 preencherCardMedicamento(item);
                 input.value = item.nome;
                 document.getElementById('dose').value = item.dosagem_recomendada || '';
+                document.getElementById('frequencia').value = item.frequencia || '';
                 document.getElementById('duracao').value = item.duracao_tratamento || '';
                 sugestoes.innerHTML = '';
                 sugestoes.style.display = 'none';
@@ -441,8 +502,22 @@
               document.getElementById('nova-medicacao-container').classList.remove('d-none');
               const nomeInput = document.getElementById('nova-medicacao-nome');
               const principioInput = document.getElementById('nova-medicacao-principio');
+              const classInput = document.getElementById('nova-medicacao-classificacao');
+              const viaInput = document.getElementById('nova-medicacao-via');
+              const doseInput = document.getElementById('nova-medicacao-dosagem');
+              const freqInput = document.getElementById('nova-medicacao-frequencia');
+              const durInput = document.getElementById('nova-medicacao-duracao');
+              const obsInput = document.getElementById('nova-medicacao-observacoes');
+              const bulaInput = document.getElementById('nova-medicacao-bula');
               if (nomeInput) nomeInput.value = input.value.trim();
               if (principioInput) principioInput.value = '';
+              if (classInput) classInput.value = '';
+              if (viaInput) viaInput.value = '';
+              if (doseInput) doseInput.value = '';
+              if (freqInput) freqInput.value = '';
+              if (durInput) durInput.value = '';
+              if (obsInput) obsInput.value = '';
+              if (bulaInput) bulaInput.value = '';
               sugestoes.style.display = 'none';
             };
             sugestoes.appendChild(addLi);

--- a/tests/test_racao_optional_fields.py
+++ b/tests/test_racao_optional_fields.py
@@ -95,3 +95,25 @@ def test_alterar_medicamento_principio_nulo(app):
         resp = client.put(f'/medicamento/{med.id}', json={'nome': 'MedX'})
         assert resp.status_code == 200
         assert Medicamento.query.get(med.id).nome == 'MedX'
+
+
+def test_criar_medicamento_campos_opcionais(app):
+    with app.app_context():
+        db.create_all()
+        vet = User(name="Vet", email="vet@example.com", worker="veterinario")
+        vet.set_password("x")
+        db.session.add(vet)
+        db.session.commit()
+        client = app.test_client()
+        _login(client, 'vet@example.com', 'x')
+        payload = {
+            'nome': 'Dipirona',
+            'classificacao': 'analgésico'
+        }
+        resp = client.post('/medicamento', json=payload)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        med = Medicamento.query.get(data['id'])
+        assert med.nome == 'Dipirona'
+        assert med.classificacao == 'analgésico'
+        assert med.principio_ativo is None


### PR DESCRIPTION
## Summary
- Let veterinarians record full medication details while only requiring the name
- Return medication frequency in lookups and show complete info in the prescription card
- Test that medication creation succeeds with only the name provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b81a7e6570832ebb4b45097a044fc1