### PR TITLE
Adicionar justificativa ao criar exame modelo

### DIFF
--- a/app.py
+++ b/app.py
@@ -4356,12 +4356,13 @@ def buscar_exames():
 def criar_exame_modelo():
     data = request.get_json(silent=True) or {}
     nome = (data.get('nome') or '').strip()
+    justificativa = (data.get('justificativa') or '').strip() or None
     if not nome:
         return jsonify({'error': 'Nome é obrigatório'}), 400
-    exame = ExameModelo(nome=nome, created_by=current_user.id)
+    exame = ExameModelo(nome=nome, justificativa=justificativa, created_by=current_user.id)
     db.session.add(exame)
     db.session.commit()
-    return jsonify({'id': exame.id, 'nome': exame.nome})
+    return jsonify({'id': exame.id, 'nome': exame.nome, 'justificativa': exame.justificativa})
 
 
 @app.route('/exame_modelo/<int:exame_id>', methods=['PUT', 'DELETE'])

--- a/static/admin/modelos.js
+++ b/static/admin/modelos.js
@@ -1,6 +1,8 @@
 async function criarExameModelo(modalId){
   const nomeInput = document.getElementById(`${modalId}-nome`);
   const nome = nomeInput ? nomeInput.value.trim() : '';
+  const justificativaInput = document.getElementById(`${modalId}-justificativa`);
+  const justificativa = justificativaInput ? justificativaInput.value.trim() : '';
   if(!nome){
     if(typeof mostrarFeedback === 'function') mostrarFeedback('Informe o nome do exame.', 'danger');
     return;
@@ -9,7 +11,7 @@ async function criarExameModelo(modalId){
     const resp = await fetch('/exame_modelo', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-      body: JSON.stringify({ nome })
+      body: JSON.stringify({ nome, justificativa })
     });
     if(!resp.ok) throw new Error();
     const data = await resp.json();
@@ -22,7 +24,7 @@ async function criarExameModelo(modalId){
       li.onclick = () => {
         inputExame.value = data.nome;
         const just = document.getElementById('justificativa-exame');
-        if(just) just.value = '';
+        if(just) just.value = data.justificativa || '';
         const sug = document.getElementById('sugestoes-exames');
         if(sug) sug.innerHTML = '';
       };
@@ -33,6 +35,8 @@ async function criarExameModelo(modalId){
       }
       li.click();
     }
+    if(nomeInput) nomeInput.value = '';
+    if(justificativaInput) justificativaInput.value = '';
   }catch(e){
     if(typeof mostrarFeedback === 'function') mostrarFeedback('Erro ao criar exame.', 'danger');
   }

--- a/templates/partials/exames_form.html
+++ b/templates/partials/exames_form.html
@@ -9,6 +9,10 @@
       <label for="novo-exame-nome" class="form-label">Nome do exame</label>
       <input type="text" id="novo-exame-nome" class="form-control">
     </div>
+    <div class="mb-2">
+      <label for="novo-exame-justificativa" class="form-label">Justificativa</label>
+      <textarea id="novo-exame-justificativa" class="form-control" rows="2"></textarea>
+    </div>
     <button type="button" class="btn btn-primary" onclick="salvarExameModelo()">💾 Salvar Exame</button>
   </div>
 
@@ -97,6 +101,7 @@
 
   async function salvarExameModelo() {
     const nome = document.getElementById('novo-exame-nome').value.trim();
+    const justificativa = document.getElementById('novo-exame-justificativa').value.trim();
     if (!nome) {
       mostrarFeedback('Informe o nome do exame.', 'warning');
       return;
@@ -105,13 +110,15 @@
       const resp = await fetch('/exame_modelo', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-        body: JSON.stringify({ nome })
+        body: JSON.stringify({ nome, justificativa })
       });
       const data = await resp.json();
       if (resp.ok && data.id) {
         mostrarFeedback('Exame cadastrado com sucesso!');
         document.getElementById('nome-exame').value = nome;
+        document.getElementById('justificativa-exame').value = justificativa;
         document.getElementById('novo-exame-nome').value = '';
+        document.getElementById('novo-exame-justificativa').value = '';
         document.getElementById('novo-exame-container').classList.add('d-none');
       } else {
         mostrarFeedback(data.message || 'Erro ao cadastrar exame.', 'danger');

--- a/tests/test_exame_modelo.py
+++ b/tests/test_exame_modelo.py
@@ -28,14 +28,16 @@ def test_criar_exame_modelo(app):
     client = app.test_client()
     with client:
         client.post('/login', data={'email': 'vet@example.com', 'password': 'x'}, follow_redirects=True)
-        resp = client.post('/exame_modelo', json={'nome': 'Hemograma'})
+        resp = client.post('/exame_modelo', json={'nome': 'Hemograma', 'justificativa': 'Exame de rotina'})
         assert resp.status_code == 200
         data = resp.get_json()
         assert data['nome'] == 'Hemograma'
+        assert data['justificativa'] == 'Exame de rotina'
         with app.app_context():
             exame = ExameModelo.query.first()
             user_db = User.query.filter_by(email='vet@example.com').first()
             assert exame and exame.nome == 'Hemograma'
+            assert exame.justificativa == 'Exame de rotina'
             assert user_db and exame.created_by == user_db.id
 
 


### PR DESCRIPTION
## Summary
- Permite informar uma justificativa ao criar um modelo de exame
- Exibe campo de justificativa no formulário de novo exame e preenche automaticamente
- Ajusta testes de criação de exame modelo

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81be57790832e9787da7ba65bf258