### PR TITLE
refactor: use partial for appointments table

### DIFF
--- a/templates/partials/appointments_table.html
+++ b/templates/partials/appointments_table.html
@@ -1,134 +1,4 @@
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Agendamentos Veterinários</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <style>
-        :root {
-            --primary-color: #4e73df;
-            --success-color: #1cc88a;
-            --info-color: #36b9cc;
-            --warning-color: #f6c23e;
-            --danger-color: #e74a3b;
-            --light-bg: #f8f9fc;
-        }
-        
-        body {
-            background-color: #f5f7fb;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        }
-        
-        .page-header {
-            border-bottom: 1px solid #e3e6f0;
-            padding-bottom: 1rem;
-            margin-bottom: 2rem;
-        }
-        
-        .day-header {
-            background: linear-gradient(135deg, var(--primary-color) 0%, #2a3e9d 100%);
-            color: white;
-            border-radius: 8px;
-            padding: 12px 20px;
-            margin: 25px 0 15px 0;
-            font-weight: 600;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-        }
-        
-        .appointment-card {
-            background: white;
-            border-radius: 10px;
-            box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
-            margin-bottom: 15px;
-            transition: all 0.3s ease;
-            border-left: 4px solid var(--primary-color);
-        }
-        
-        .appointment-card:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-            cursor: pointer;
-        }
-        
-        .appointment-card.scheduled { border-left-color: var(--primary-color); }
-        .appointment-card.completed { border-left-color: var(--success-color); }
-        .appointment-card.canceled { border-left-color: var(--danger-color); }
-        
-        .status-badge {
-            padding: 6px 12px;
-            border-radius: 20px;
-            font-weight: 500;
-            font-size: 0.85rem;
-        }
-        
-        .status-scheduled { background-color: #e8eeff; color: var(--primary-color); }
-        .status-completed { background-color: #e6faf3; color: var(--success-color); }
-        .status-canceled { background-color: #fce8e6; color: var(--danger-color); }
-        
-        .btn-icon {
-            width: 36px;
-            height: 36px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 50%;
-            margin: 0 3px;
-        }
-        
-        .time-display {
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: #4e5b6a;
-        }
-        
-        .animal-name {
-            font-weight: 600;
-            color: #2e3a4b;
-            font-size: 1.1rem;
-        }
-        
-        .vet-name {
-            color: #656f7d;
-        }
-        
-        .actions-container {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 8px;
-            justify-content: flex-end;
-        }
-        
-        .empty-state {
-            text-align: center;
-            padding: 40px 20px;
-            color: #6c757d;
-        }
-        
-        .empty-state i {
-            font-size: 5rem;
-            margin-bottom: 20px;
-            color: #dee2e6;
-        }
-        
-        @media (max-width: 992px) {
-            .appointment-card .col-md-3 {
-                margin-bottom: 15px;
-            }
-            
-            .actions-container {
-                justify-content: flex-start;
-            }
-        }
-        
-        .form-confirm {
-            display: inline;
-        }
-    </style>
-</head>
-<body>
-    <div class="container py-4">
+<div class="container py-4">
         <div class="page-header">
             <h1 class="h3 mb-0 text-gray-800"><i class="fas fa-calendar-alt me-2"></i>Agendamentos</h1>
         </div>
@@ -227,38 +97,35 @@
                 <p>Não há agendamentos para exibir no momento.</p>
             </div>
         {% endif %}
-    </div>
+</div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script>
-        // Adiciona confirmação para exclusão
-        document.addEventListener('DOMContentLoaded', function() {
-            const deleteForms = document.querySelectorAll('form[data-confirm]');
-            
-            deleteForms.forEach(form => {
-                form.addEventListener('submit', function(e) {
-                    const message = this.getAttribute('data-confirm');
-                    if (!confirm(message)) {
-                        e.preventDefault();
-                    }
-                });
-            });
-            
-            // Adiciona classes de status aos cards
-            const appointmentCards = document.querySelectorAll('.appointment-card');
-            appointmentCards.forEach(card => {
-                const statusBadge = card.querySelector('.status-badge');
-                if (statusBadge) {
-                    if (statusBadge.classList.contains('status-scheduled')) {
-                        card.classList.add('scheduled');
-                    } else if (statusBadge.classList.contains('status-completed')) {
-                        card.classList.add('completed');
-                    } else if (statusBadge.classList.contains('status-canceled')) {
-                        card.classList.add('canceled');
-                    }
+<script>
+    // Adiciona confirmação para exclusão
+    document.addEventListener('DOMContentLoaded', function() {
+        const deleteForms = document.querySelectorAll('form[data-confirm]');
+
+        deleteForms.forEach(form => {
+            form.addEventListener('submit', function(e) {
+                const message = this.getAttribute('data-confirm');
+                if (!confirm(message)) {
+                    e.preventDefault();
                 }
             });
         });
-    </script>
-</body>
-</html>
+
+        // Adiciona classes de status aos cards
+        const appointmentCards = document.querySelectorAll('.appointment-card');
+        appointmentCards.forEach(card => {
+            const statusBadge = card.querySelector('.status-badge');
+            if (statusBadge) {
+                if (statusBadge.classList.contains('status-scheduled')) {
+                    card.classList.add('scheduled');
+                } else if (statusBadge.classList.contains('status-completed')) {
+                    card.classList.add('completed');
+                } else if (statusBadge.classList.contains('status-canceled')) {
+                    card.classList.add('canceled');
+                }
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- remove standalone HTML from appointments table partial so it can be included in other templates without extra `<head>` or `<body>`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81c857098832ea39fd2961b49aae3