### PR TITLE
Tradução de status de pagamento para português

### DIFF
--- a/app.py
+++ b/app.py
@@ -222,6 +222,20 @@ def digits_only(value):
     """Return only the digits from a string."""
     return "".join(filter(str.isdigit, value)) if value else ""
 
+
+@app.template_filter("payment_status_label")
+def payment_status_label(value):
+    """Translate payment status codes to Portuguese labels."""
+    mapping = {
+        "pending": "Pendente",
+        "success": "Aprovado",
+        "completed": "Aprovado",
+        "approved": "Aprovado",
+        "failure": "Falha no pagamento",
+        "failed": "Falha no pagamento",
+    }
+    return mapping.get(value.lower(), value) if value else ""
+
 # ----------------------------------------------------------------
 # 6)  Forms e helpers
 # ----------------------------------------------------------------

--- a/templates/loja/payment_status.html
+++ b/templates/loja/payment_status.html
@@ -4,19 +4,28 @@
   <div class="col-lg-8 bg-white shadow rounded-4 p-5 border">
 
     <h2 class="fw-bold mb-3 text-center">Status do pagamento</h2>
+    {% set status_map = {
+      'pending': 'Pendente',
+      'success': 'Aprovado',
+      'completed': 'Aprovado',
+      'approved': 'Aprovado',
+      'failure': 'Falha no pagamento',
+      'failed': 'Falha no pagamento'
+    } %}
+    {% set status = status_map.get(result, result) %}
 
-    <div id="loading" class="text-center my-4"{% if result != 'pending' %} style="display:none"{% endif %}>
+    <div id="loading" class="text-center my-4"{% if status != 'Pendente' %} style="display:none"{% endif %}>
       <div class="spinner-border text-primary" role="status" aria-label="Carregando"></div>
       <p class="mt-3">Aguardando a confirmação do pagamento...</p>
     </div>
 
-    <div id="status-banner"{% if result == 'pending' %} style="display:none"{% endif %}>
-      {% if result in ['success', 'completed', 'approved'] %}
+    <div id="status-banner"{% if status == 'Pendente' %} style="display:none"{% endif %}>
+      {% if status == 'Aprovado' %}
         <div class="alert alert-success text-center" role="alert">
           <i class="bi bi-check-circle-fill me-2"></i>
           Compra aprovada!
         </div>
-      {% elif result in ['failure', 'failed'] %}
+      {% elif status == 'Falha no pagamento' %}
         <div class="alert alert-danger text-center" role="alert">
           <i class="bi bi-x-circle-fill me-2"></i>
           Falha no pagamento.
@@ -30,7 +39,7 @@
       <dd class="col-sm-8">{{ payment.transaction_id }}</dd>
 
       <dt class="col-sm-4">Status interno:</dt>
-      <dd class="col-sm-8">{{ payment.status.name }}</dd>
+      <dd class="col-sm-8">{{ payment.status.name|payment_status_label }}</dd>
     </dl>
 
     {% if order %}
@@ -51,7 +60,7 @@
 
     <div class="d-flex justify-content-center flex-wrap gap-3">
 
-{% if result in ['failure', 'failed'] %}
+{% if status == 'Falha no pagamento' %}
   <form action="{{ url_for('checkout') }}" method="post" class="m-0">
     {{ form.hidden_tag() }}
     <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
## Summary
- Adiciona filtro Jinja para traduzir status de pagamento para rótulos em português
- Atualiza template de status de pagamento com mapeamento e lógica baseada nos rótulos traduzidos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b823550060832ea65004ef51c18845