### PR TITLE
Padroniza logs de console para português

### DIFF
--- a/static/admin/js/form.js
+++ b/static/admin/js/form.js
@@ -74,11 +74,11 @@
        */
       function processLeafletWidget($el, name) {
         if (!window.MAPBOX_MAP_ID) {
-          console.error("You must set MAPBOX_MAP_ID in your Flask settings to use the map widget");
+          console.error("Você deve definir MAPBOX_MAP_ID nas configurações do Flask para usar o widget de mapa");
           return false;
         }
         if (!window.DEFAULT_CENTER_LAT || !window.DEFAULT_CENTER_LONG) {
-          console.error("You must set DEFAULT_CENTER_LAT and DEFAULT_CENTER_LONG in your Flask settings to use the map widget");
+          console.error("Você deve definir DEFAULT_CENTER_LAT e DEFAULT_CENTER_LONG nas configurações do Flask para usar o widget de mapa");
           return false;
         }
 

--- a/templates/clinica/clinic_detail.html
+++ b/templates/clinica/clinic_detail.html
@@ -224,7 +224,7 @@ document.addEventListener('DOMContentLoaded', function() {
           window.history.replaceState({}, '', url);
         }
       })
-      .catch(err => console.error(err));
+      .catch(err => console.error('Erro:', err));
   }
 
   form.addEventListener('submit', function(e) {

--- a/templates/entregas/delivery_requests.html
+++ b/templates/entregas/delivery_requests.html
@@ -169,7 +169,7 @@
         document.getElementById('done-count').textContent = data.done;
         document.getElementById('canceled-count').textContent = data.canceled;
       } catch (err) {
-        console.error('Failed to update counts', err);
+        console.error('Falha ao atualizar contadores', err);
       }
     }
     refreshCounts();

--- a/templates/partials/food_form.html
+++ b/templates/partials/food_form.html
@@ -224,7 +224,7 @@ function salvarTipoRacao() {
   })
   .catch(error => {
     alert('Erro técnico ao salvar tipo de ração.');
-    console.error(error);
+    console.error('Erro:', error);
   });
 }
 
@@ -255,7 +255,7 @@ function salvarRacaoAnimal() {
   })
   .catch(error => {
     alert('Erro técnico ao salvar ração.');
-    console.error(error);
+    console.error('Erro:', error);
   });
 }
 

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -270,7 +270,7 @@ function salvarBlocoExames(blocoId, consultaId) {
     }
   })
   .catch(err => {
-    console.error(err);
+    console.error('Erro:', err);
     alert('Erro na requisição.');
   });
 }

--- a/templates/partials/historico_vacinas.html
+++ b/templates/partials/historico_vacinas.html
@@ -93,7 +93,7 @@ function salvarEdicaoVacina(id) {
     }
   })
   .catch(err => {
-    console.error(err);
+    console.error('Erro:', err);
     alert("Erro na requisição.");
   });
 }


### PR DESCRIPTION
## Resumo
- Traduz mensagens de erro no painel de entregas e no script de mapas do admin
- Padroniza logs `console.error` em formulários e históricos para exibirem textos em português

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b823614cb0832eacd5589a245ab014