### PR TITLE
Add unified edit/delete endpoints for feed, vaccine, and exam

### DIFF
--- a/templates/partials/food_form.html
+++ b/templates/partials/food_form.html
@@ -286,7 +286,7 @@ function confirmarEdicaoRacao() {
   const recomendacao = parseFloat(document.getElementById('edit-recomendacao').value) || null;
   const preco = parseFloat(document.getElementById('edit-preco').value) || null;
 
-  fetch(`/racao/${racaoId}/editar`, {
+  fetch(`/racao/${racaoId}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -313,7 +313,7 @@ function confirmarEdicaoRacao() {
 function excluirRacao(racaoId) {
   if (!confirm('Tem certeza que deseja excluir esta ração?')) return;
 
-  fetch(`/racao/${racaoId}/excluir`, {
+  fetch(`/racao/${racaoId}`, {
     method: 'DELETE'
   })
   .then(resp => resp.json())

--- a/templates/partials/historico_exames.html
+++ b/templates/partials/historico_exames.html
@@ -52,7 +52,7 @@
     <div id="exames-edit-{{ bloco.id }}" class="d-none">
       <div id="exames-container-{{ bloco.id }}">
         {% for exame in bloco.exames %}
-        <div class="card mb-3 exame-card">
+        <div class="card mb-3 exame-card" data-id="{{ exame.id }}">
           <div class="card-body">
             <div class="mb-2 position-relative">
               <label class="form-label">Nome do Exame</label>
@@ -164,17 +164,27 @@ function adicionarExame(blocoId) {
 
 
 function removerExame(button) {
+  if (!confirm('Deseja remover este exame?')) return;
   const card = button.closest('.exame-card');
-  card.remove();
-}
-
-document.addEventListener('click', function (e) {
-  if (e.target.classList.contains('btn-remover')) {
-    if (confirm('Deseja remover este exame?')) {
-      e.target.closest('.exame-card')?.remove();
-    }
+  const exameId = card.dataset.id;
+  if (exameId) {
+    fetch(`/exame/${exameId}`, { method: 'DELETE' })
+      .then(r => r.json())
+      .then(data => {
+        if (data.success) {
+          card.remove();
+        } else {
+          alert(data.error || 'Erro ao excluir exame.');
+        }
+      })
+      .catch(err => {
+        console.error('Erro ao excluir exame:', err);
+        alert('Erro ao excluir exame.');
+      });
+  } else {
+    card.remove();
   }
-});
+}
 
 function sugerirExames(input) {
   const lista = input.nextElementSibling;

--- a/templates/partials/historico_vacinas.html
+++ b/templates/partials/historico_vacinas.html
@@ -20,18 +20,9 @@
         </div>
 
       <div class="mt-2 d-flex gap-2">
-        <form method="POST" action="{{ url_for('deletar_vacina', vacina_id=vacina.id) }}"
-              class="delete-history-form" data-sync data-target="historico-vacinas"
-              data-confirm="Deseja mesmo remover esta vacina?">
-          <button class="btn btn-sm btn-danger">🗑️ Remover</button>
-        </form>
-
-        <button class="btn btn-sm btn-outline-primary" onclick="editarVacina({{ vacina.id }})">
-          ✏️ Editar
-        </button>
-        <a href="{{ url_for('imprimir_vacinas', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark" target="_blank">
-          🖨️ Imprimir
-        </a>
+        <button class="btn btn-sm btn-danger" onclick="excluirVacina({{ vacina.id }})">🗑️ Remover</button>
+        <button class="btn btn-sm btn-outline-primary" onclick="editarVacina({{ vacina.id }})">✏️ Editar</button>
+        <a href="{{ url_for('imprimir_vacinas', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark" target="_blank">🖨️ Imprimir</a>
       </div>
       </li>
       {% endfor %}
@@ -78,23 +69,41 @@ function salvarEdicaoVacina(id) {
   const data = document.getElementById(`edit-data-${id}`).value.trim();
   const observacoes = document.getElementById(`edit-obs-${id}`).value.trim();
 
-  fetch(`/vacina/${id}/editar`, {
-    method: 'POST',
+  fetch(`/vacina/${id}`, {
+    method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ nome, tipo, data, observacoes })
   })
   .then(res => res.json())
   .then(d => {
     if (d.success) {
-      alert("Vacina atualizada!");
+      alert('Vacina atualizada!');
       location.reload();
     } else {
-      alert("Erro ao salvar.");
+      alert('Erro ao salvar.');
     }
   })
   .catch(err => {
     console.error('Erro:', err);
-    alert("Erro na requisição.");
+    alert('Erro na requisição.');
   });
+}
+
+function excluirVacina(id) {
+  if (!confirm('Deseja mesmo remover esta vacina?')) return;
+  fetch(`/vacina/${id}`, { method: 'DELETE' })
+    .then(res => res.json())
+    .then(d => {
+      if (d.success) {
+        const li = document.querySelector(`[data-vacina-id='${id}']`);
+        li?.remove();
+      } else {
+        alert(d.error || 'Erro ao excluir vacina.');
+      }
+    })
+    .catch(err => {
+      console.error('Erro ao excluir vacina:', err);
+      alert('Erro ao excluir vacina.');
+    });
 }
 </script>


### PR DESCRIPTION
## Summary
- Add unified PUT/DELETE routes for rations, vaccines and exams
- Wire templates to new endpoints to allow editing and deletion from UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8282a1f8c832e98af9b30f472a362