### PR TITLE
fix: sync forms outside tab-pane

### DIFF
--- a/templates/consulta_qr.html
+++ b/templates/consulta_qr.html
@@ -270,7 +270,7 @@
 
 <script>
 function bindSyncForms(root) {
-  root.querySelectorAll('.tab-pane form[data-sync]').forEach(form => {
+  root.querySelectorAll('form[data-sync]').forEach(form => {
     if (form.dataset.syncBound) return;
     form.dataset.syncBound = '1';
     form.addEventListener('submit', async ev => {


### PR DESCRIPTION
## Summary
- Bind sync forms without restricting to `.tab-pane`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b861d6aa8c832eb8609b7f6ac4b74e