### PR TITLE
fix: ensure delete return form triggers async update

### DIFF
--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -81,7 +81,7 @@
         <a href="#" class="card-link editar-retorno">Editar</a>
         <form method="POST"
               action="{{ url_for('delete_appointment', appointment_id=consulta.appointment.id) }}"
-              class="d-inline data-sync delete-appointment-form">
+              class="d-inline delete-appointment-form" data-sync>
           <button type="submit" class="btn btn-link p-0 card-link">Excluir</button>
         </form>
         <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" class="card-link start-return-link">Iniciar retorno</a>


### PR DESCRIPTION
## Summary
- fix delete return form attributes to support async update

## Testing
- `pytest`
- `pytest tests/test_event_permissions.py::test_collaborator_can_delete_appointment -q`


------
https://chatgpt.com/codex/tasks/task_e_68b861e3ee98832e90029bac6cfbaa78