### PR TITLE
Add vaccine scheduling fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -3716,7 +3716,14 @@ def buscar_vacinas():
         ).all()
 
         return jsonify([
-            {'nome': v.nome, 'tipo': v.tipo or ''}
+            {
+                'nome': v.nome,
+                'tipo': v.tipo or '',
+                'fabricante': v.fabricante or '',
+                'doses_totais': v.doses_totais,
+                'intervalo_dias': v.intervalo_dias,
+                'frequencia': v.frequencia or '',
+            }
             for v in resultados
         ])
     except Exception as e:
@@ -3729,16 +3736,39 @@ def criar_vacina_modelo():
     data = request.get_json(silent=True) or {}
     nome = (data.get('nome') or '').strip()
     tipo = (data.get('tipo') or '').strip()
+    fabricante = (data.get('fabricante') or '').strip() or None
+    doses_totais = data.get('doses_totais')
+    intervalo_dias = data.get('intervalo_dias')
+    frequencia = (data.get('frequencia') or '').strip() or None
     if not nome or not tipo:
         return jsonify({'success': False, 'message': 'Nome e tipo são obrigatórios.'}), 400
     try:
         existente = VacinaModelo.query.filter(func.lower(VacinaModelo.nome) == nome.lower()).first()
         if existente:
             return jsonify({'success': False, 'message': 'Vacina já cadastrada.'}), 400
-        vacina = VacinaModelo(nome=nome, tipo=tipo, created_by=current_user.id)
+        vacina = VacinaModelo(
+            nome=nome,
+            tipo=tipo,
+            fabricante=fabricante,
+            doses_totais=doses_totais,
+            intervalo_dias=intervalo_dias,
+            frequencia=frequencia,
+            created_by=current_user.id,
+        )
         db.session.add(vacina)
         db.session.commit()
-        return jsonify({'success': True, 'vacina': {'id': vacina.id, 'nome': vacina.nome, 'tipo': vacina.tipo}})
+        return jsonify({
+            'success': True,
+            'vacina': {
+                'id': vacina.id,
+                'nome': vacina.nome,
+                'tipo': vacina.tipo,
+                'fabricante': vacina.fabricante,
+                'doses_totais': vacina.doses_totais,
+                'intervalo_dias': vacina.intervalo_dias,
+                'frequencia': vacina.frequencia,
+            },
+        })
     except Exception as e:
         db.session.rollback()
         print('Erro ao salvar vacina modelo:', e)
@@ -3766,6 +3796,10 @@ def alterar_vacina_modelo(vacina_id):
     if tipo_val is not None:
         tipo_val = tipo_val.strip()
     vacina.tipo = tipo_val or None
+    vacina.fabricante = (data.get('fabricante', vacina.fabricante) or '').strip() or None
+    vacina.doses_totais = data.get('doses_totais', vacina.doses_totais)
+    vacina.intervalo_dias = data.get('intervalo_dias', vacina.intervalo_dias)
+    vacina.frequencia = (data.get('frequencia', vacina.frequencia) or '').strip() or None
     db.session.commit()
     return jsonify({'success': True})
 
@@ -3793,6 +3827,10 @@ def salvar_vacinas(animal_id):
                 animal_id=animal_id,
                 nome=v.get("nome"),
                 tipo=v.get("tipo"),
+                fabricante=v.get("fabricante"),
+                doses_totais=v.get("doses_totais"),
+                intervalo_dias=v.get("intervalo_dias"),
+                frequencia=v.get("frequencia"),
                 data=data_formatada,
                 observacoes=v.get("observacoes")
             )
@@ -3858,6 +3896,10 @@ def alterar_vacina(vacina_id):
     data = request.get_json(silent=True) or {}
     vacina.nome = data.get('nome', vacina.nome)
     vacina.tipo = data.get('tipo', vacina.tipo)
+    vacina.fabricante = data.get('fabricante', vacina.fabricante)
+    vacina.doses_totais = data.get('doses_totais', vacina.doses_totais)
+    vacina.intervalo_dias = data.get('intervalo_dias', vacina.intervalo_dias)
+    vacina.frequencia = data.get('frequencia', vacina.frequencia)
     vacina.observacoes = data.get('observacoes', vacina.observacoes)
 
     data_str = data.get('data')

--- a/migrations/versions/93a8666ff562_add_vaccine_fields.py
+++ b/migrations/versions/93a8666ff562_add_vaccine_fields.py
@@ -1,0 +1,44 @@
+"""add vaccine fields
+
+Revision ID: 93a8666ff562
+Revises: d3f98e045e2b
+Create Date: 2025-09-03 15:53:25.992133
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '93a8666ff562'
+down_revision = 'd3f98e045e2b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('vacina_modelo') as batch_op:
+        batch_op.add_column(sa.Column('fabricante', sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column('doses_totais', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('intervalo_dias', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('frequencia', sa.String(length=50), nullable=True))
+
+    with op.batch_alter_table('vacina') as batch_op:
+        batch_op.add_column(sa.Column('fabricante', sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column('doses_totais', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('intervalo_dias', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('frequencia', sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('vacina') as batch_op:
+        batch_op.drop_column('frequencia')
+        batch_op.drop_column('intervalo_dias')
+        batch_op.drop_column('doses_totais')
+        batch_op.drop_column('fabricante')
+
+    with op.batch_alter_table('vacina_modelo') as batch_op:
+        batch_op.drop_column('frequencia')
+        batch_op.drop_column('intervalo_dias')
+        batch_op.drop_column('doses_totais')
+        batch_op.drop_column('fabricante')

--- a/models.py
+++ b/models.py
@@ -927,6 +927,10 @@ class VacinaModelo(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     nome = db.Column(db.String(100), nullable=False)
     tipo = db.Column(db.String(50))  # Opcional, mas útil para o frontend
+    fabricante = db.Column(db.String(100))
+    doses_totais = db.Column(db.Integer)
+    intervalo_dias = db.Column(db.Integer)
+    frequencia = db.Column(db.String(50))
     created_by = db.Column(
         db.Integer,
         db.ForeignKey('user.id', ondelete='CASCADE'),
@@ -934,7 +938,11 @@ class VacinaModelo(db.Model):
     )
 
     def __repr__(self):
-        return f'<VacinaModelo {self.nome}>'
+        return (
+            f"<VacinaModelo {self.nome} fabricante={self.fabricante} "
+            f"doses={self.doses_totais} intervalo={self.intervalo_dias} "
+            f"frequencia={self.frequencia}>"
+        )
 
 
 class Vacina(db.Model):
@@ -943,6 +951,10 @@ class Vacina(db.Model):
 
     nome = db.Column(db.String(100), nullable=False)
     tipo = db.Column(db.String(50))  # Campanha, Obrigatória, Reforço
+    fabricante = db.Column(db.String(100))
+    doses_totais = db.Column(db.Integer)
+    intervalo_dias = db.Column(db.Integer)
+    frequencia = db.Column(db.String(50))
     data = db.Column(db.Date)        # Data da aplicação
     observacoes = db.Column(db.Text)
     criada_em = db.Column(db.DateTime, default=datetime.utcnow)

--- a/templates/partials/historico_vacinas.html
+++ b/templates/partials/historico_vacinas.html
@@ -9,6 +9,10 @@
         <div class="vacina-info">
           <strong class="vacina-nome">{{ vacina.nome }}</strong>
           {% if vacina.tipo %} — <span class="vacina-tipo">{{ vacina.tipo }}</span>{% endif %}
+          {% if vacina.fabricante %} — <span class="vacina-fabricante">{{ vacina.fabricante }}</span>{% endif %}
+          {% if vacina.doses_totais %} — <span class="vacina-doses">{{ vacina.doses_totais }} doses</span>{% endif %}
+          {% if vacina.intervalo_dias %} — <span class="vacina-intervalo">{{ vacina.intervalo_dias }} dias</span>{% endif %}
+          {% if vacina.frequencia %} — <span class="vacina-frequencia">{{ vacina.frequencia }}</span>{% endif %}
           {% if vacina.data %}
             em <span class="vacina-data" data-date="{{ vacina.data.strftime('%Y-%m-%d') }}">
               {{ vacina.data.strftime('%d/%m/%Y') }}
@@ -38,6 +42,10 @@ function editarVacina(id) {
   const li = document.querySelector(`[data-vacina-id='${id}']`);
   const nome = li.querySelector('.vacina-nome')?.textContent.trim() || '';
   const tipo = li.querySelector('.vacina-tipo')?.textContent.trim() || '';
+  const fabricante = li.querySelector('.vacina-fabricante')?.textContent.trim() || '';
+  const doses = li.querySelector('.vacina-doses')?.textContent.replace(' doses','').trim() || '';
+  const intervalo = li.querySelector('.vacina-intervalo')?.textContent.replace(' dias','').trim() || '';
+  const freq = li.querySelector('.vacina-frequencia')?.textContent.trim() || '';
   const data = li.querySelector('.vacina-data')?.dataset.date || '';
   const obs = li.querySelector('.vacina-obs')?.textContent.trim() || '';
 
@@ -49,6 +57,24 @@ function editarVacina(id) {
     <div class="mb-2">
       <label class="form-label">Tipo</label>
       <input class="form-control" id="edit-tipo-${id}" value="${tipo}">
+    </div>
+    <div class="mb-2">
+      <label class="form-label">Fabricante</label>
+      <input class="form-control" id="edit-fabricante-${id}" value="${fabricante}">
+    </div>
+    <div class="row">
+      <div class="col-md-4 mb-2">
+        <label class="form-label">Doses Totais</label>
+        <input type="number" class="form-control" id="edit-doses-${id}" value="${doses}">
+      </div>
+      <div class="col-md-4 mb-2">
+        <label class="form-label">Intervalo (dias)</label>
+        <input type="number" class="form-control" id="edit-intervalo-${id}" value="${intervalo}">
+      </div>
+      <div class="col-md-4 mb-2">
+        <label class="form-label">Frequência</label>
+        <input class="form-control" id="edit-frequencia-${id}" value="${freq}">
+      </div>
     </div>
     <div class="mb-2">
       <label class="form-label">Data</label>
@@ -66,13 +92,17 @@ function editarVacina(id) {
 function salvarEdicaoVacina(id) {
   const nome = document.getElementById(`edit-nome-${id}`).value.trim();
   const tipo = document.getElementById(`edit-tipo-${id}`).value.trim();
+  const fabricante = document.getElementById(`edit-fabricante-${id}`).value.trim();
+  const doses_totais = document.getElementById(`edit-doses-${id}`).value;
+  const intervalo_dias = document.getElementById(`edit-intervalo-${id}`).value;
+  const frequencia = document.getElementById(`edit-frequencia-${id}`).value.trim();
   const data = document.getElementById(`edit-data-${id}`).value.trim();
   const observacoes = document.getElementById(`edit-obs-${id}`).value.trim();
 
   fetch(`/vacina/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ nome, tipo, data, observacoes })
+    body: JSON.stringify({ nome, tipo, fabricante, doses_totais, intervalo_dias, frequencia, data, observacoes })
   })
   .then(res => res.json())
   .then(d => {

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -13,6 +13,24 @@
         <label for="nova-vacina-tipo" class="form-label">Tipo</label>
         <input type="text" id="nova-vacina-tipo" class="form-control" placeholder="Campanha, Reforço...">
       </div>
+      <div class="row mb-2">
+        <div class="col-md-3">
+          <label for="nova-vacina-fabricante" class="form-label">Fabricante</label>
+          <input type="text" id="nova-vacina-fabricante" class="form-control">
+        </div>
+        <div class="col-md-3">
+          <label for="nova-vacina-doses" class="form-label">Doses Totais</label>
+          <input type="number" id="nova-vacina-doses" class="form-control">
+        </div>
+        <div class="col-md-3">
+          <label for="nova-vacina-intervalo" class="form-label">Intervalo (dias)</label>
+          <input type="number" id="nova-vacina-intervalo" class="form-control">
+        </div>
+        <div class="col-md-3">
+          <label for="nova-vacina-frequencia" class="form-label">Frequência</label>
+          <input type="text" id="nova-vacina-frequencia" class="form-control">
+        </div>
+      </div>
       <button type="button" class="btn btn-primary" onclick="salvarVacinaModelo()">💾 Salvar Vacina</button>
     </div>
 
@@ -38,6 +56,25 @@
       <div class="col-md-6">
         <label for="data-vacina" class="form-label">Data da Aplicação</label>
         <input type="date" id="data-vacina" class="form-control">
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-md-3">
+        <label for="fabricante-vacina" class="form-label">Fabricante</label>
+        <input type="text" id="fabricante-vacina" class="form-control">
+      </div>
+      <div class="col-md-3">
+        <label for="doses-vacina" class="form-label">Doses Totais</label>
+        <input type="number" id="doses-vacina" class="form-control">
+      </div>
+      <div class="col-md-3">
+        <label for="intervalo-vacina" class="form-label">Intervalo (dias)</label>
+        <input type="number" id="intervalo-vacina" class="form-control">
+      </div>
+      <div class="col-md-3">
+        <label for="frequencia-vacina" class="form-label">Frequência</label>
+        <input type="text" id="frequencia-vacina" class="form-control">
       </div>
     </div>
 
@@ -130,6 +167,10 @@
     async function salvarVacinaModelo() {
       const nome = document.getElementById('nova-vacina-nome').value.trim();
       const tipo = document.getElementById('nova-vacina-tipo').value.trim();
+      const fabricante = document.getElementById('nova-vacina-fabricante').value.trim();
+      const doses_totais = document.getElementById('nova-vacina-doses').value;
+      const intervalo_dias = document.getElementById('nova-vacina-intervalo').value;
+      const frequencia = document.getElementById('nova-vacina-frequencia').value.trim();
       if (!nome || !tipo) {
         mostrarFeedback('Preencha nome e tipo da vacina.', 'warning');
         return;
@@ -138,7 +179,7 @@
         const resp = await fetch('/vacina_modelo', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-          body: JSON.stringify({ nome, tipo })
+          body: JSON.stringify({ nome, tipo, fabricante, doses_totais: doses_totais || null, intervalo_dias: intervalo_dias || null, frequencia })
         });
         const data = await resp.json();
         if (data.success) {
@@ -151,6 +192,10 @@
           inputVacina.value = nome;
           document.getElementById('nova-vacina-nome').value = '';
           document.getElementById('nova-vacina-tipo').value = '';
+          document.getElementById('nova-vacina-fabricante').value = '';
+          document.getElementById('nova-vacina-doses').value = '';
+          document.getElementById('nova-vacina-intervalo').value = '';
+          document.getElementById('nova-vacina-frequencia').value = '';
           document.getElementById('nova-vacina-container').classList.add('d-none');
         } else {
           mostrarFeedback(data.message || 'Erro ao cadastrar vacina.', 'danger');
@@ -165,18 +210,26 @@
       const nome = document.getElementById('nome-vacina').value.trim();
       const tipo = document.getElementById('tipo-vacina').value.trim();
       const data = document.getElementById('data-vacina').value;
+      const fabricante = document.getElementById('fabricante-vacina').value.trim();
+      const doses_totais = document.getElementById('doses-vacina').value;
+      const intervalo_dias = document.getElementById('intervalo-vacina').value;
+      const frequencia = document.getElementById('frequencia-vacina').value.trim();
 
       if (!nome || !tipo || !data) {
-        alert('Preencha todos os campos.');
+        alert('Preencha todos os campos obrigatórios.');
         return;
       }
 
-      vacinas.push({ nome, tipo, data });
+      vacinas.push({ nome, tipo, data, fabricante, doses_totais: doses_totais || null, intervalo_dias: intervalo_dias || null, frequencia });
       renderVacinasTemp();
 
       document.getElementById('nome-vacina').value = '';
       document.getElementById('tipo-vacina').value = '';
       document.getElementById('data-vacina').value = '';
+      document.getElementById('fabricante-vacina').value = '';
+      document.getElementById('doses-vacina').value = '';
+      document.getElementById('intervalo-vacina').value = '';
+      document.getElementById('frequencia-vacina').value = '';
     }
 
     function removerVacina(index) {
@@ -193,6 +246,10 @@
         div.className = 'border p-2 mb-2 bg-light rounded shadow-sm';
         div.innerHTML = `
           💉 <strong>${v.nome}</strong> — ${v.tipo} em ${v.data}
+          ${v.fabricante ? ` - ${v.fabricante}` : ''}
+          ${v.doses_totais ? ` - ${v.doses_totais} doses` : ''}
+          ${v.intervalo_dias ? ` - intervalo ${v.intervalo_dias}d` : ''}
+          ${v.frequencia ? ` - ${v.frequencia}` : ''}
           <button class="btn btn-sm btn-danger ms-2" onclick="removerVacina(${i})">🗑️ Remover</button>
         `;
         lista.appendChild(div);

--- a/tests/test_vacinas.py
+++ b/tests/test_vacinas.py
@@ -64,9 +64,20 @@ def test_criar_vacina_modelo(app):
         db.session.commit()
         client = app.test_client()
         client.post('/login', data={'email': 'vet@example.com', 'password': 'x'}, follow_redirects=True)
-        resp = client.post('/vacina_modelo', json={'nome': 'V10', 'tipo': 'Obrigatória'})
+        resp = client.post('/vacina_modelo', json={
+            'nome': 'V10',
+            'tipo': 'Obrigatória',
+            'fabricante': 'ACME',
+            'doses_totais': 3,
+            'intervalo_dias': 30,
+            'frequencia': 'Anual'
+        })
         assert resp.status_code == 200
         data = resp.get_json()
         assert data['success'] is True
         vm = VacinaModelo.query.filter_by(nome='V10').first()
         assert vm is not None and vm.created_by == user.id
+        assert vm.fabricante == 'ACME'
+        assert vm.doses_totais == 3
+        assert vm.intervalo_dias == 30
+        assert vm.frequencia == 'Anual'


### PR DESCRIPTION
## Summary
- extend VacinaModelo and Vacina with manufacturer, total doses, interval and frequency fields
- update API endpoints and templates to manage the new vaccine data
- create Alembic migration for the new columns and adjust tests

## Testing
- `pytest`
- `flask db upgrade heads` *(fails: no such table: exame_modelo)*

------
https://chatgpt.com/codex/tasks/task_e_68b8637084d4832e9ca1c0f647ca6a07