### PR TITLE
Include vaccine model metadata in search results

### DIFF
--- a/app.py
+++ b/app.py
@@ -3716,7 +3716,15 @@ def buscar_vacinas():
         ).all()
 
         return jsonify([
-            {'nome': v.nome, 'tipo': v.tipo or ''}
+            {
+                'id': v.id,
+                'nome': v.nome,
+                'tipo': v.tipo or '',
+                'frequencia': v.frequencia or '',
+                'doses_totais': v.doses_totais,
+                'intervalo_dias': v.intervalo_dias,
+                'fabricante': v.fabricante or ''
+            }
             for v in resultados
         ])
     except Exception as e:

--- a/models.py
+++ b/models.py
@@ -927,6 +927,10 @@ class VacinaModelo(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     nome = db.Column(db.String(100), nullable=False)
     tipo = db.Column(db.String(50))  # Opcional, mas útil para o frontend
+    frequencia = db.Column(db.String(50))
+    doses_totais = db.Column(db.Integer)
+    intervalo_dias = db.Column(db.Integer)
+    fabricante = db.Column(db.String(100))
     created_by = db.Column(
         db.Integer,
         db.ForeignKey('user.id', ondelete='CASCADE'),

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -21,6 +21,11 @@
       <label for="nome-vacina" class="form-label">Vacina</label>
       <input type="text" id="nome-vacina" class="form-control" placeholder="Ex: Antirrábica, V10, V8..." autocomplete="off">
       <ul id="sugestoes-vacinas" class="list-group position-absolute w-100 bg-white shadow border rounded mt-1" style="z-index: 1050;"></ul>
+      <input type="hidden" id="vacina-id">
+      <input type="hidden" id="vacina-frequencia">
+      <input type="hidden" id="vacina-doses-totais">
+      <input type="hidden" id="vacina-intervalo-dias">
+      <input type="hidden" id="vacina-fabricante">
     </div>
 
     <!-- Tipo e data -->
@@ -102,6 +107,13 @@
               li.textContent = item.nome;
               li.onclick = () => {
                 inputVacina.value = item.nome;
+                const tipo = document.getElementById('tipo-vacina');
+                if (tipo) tipo.value = item.tipo || '';
+                document.getElementById('vacina-id').value = item.id || '';
+                document.getElementById('vacina-frequencia').value = item.frequencia || '';
+                document.getElementById('vacina-doses-totais').value = item.doses_totais || '';
+                document.getElementById('vacina-intervalo-dias').value = item.intervalo_dias || '';
+                document.getElementById('vacina-fabricante').value = item.fabricante || '';
                 sugestoesVacinas.innerHTML = '';
               };
               sugestoesVacinas.appendChild(li);

--- a/tests/test_vacinas.py
+++ b/tests/test_vacinas.py
@@ -70,3 +70,33 @@ def test_criar_vacina_modelo(app):
         assert data['success'] is True
         vm = VacinaModelo.query.filter_by(nome='V10').first()
         assert vm is not None and vm.created_by == user.id
+
+
+def test_buscar_vacinas_retorna_campos(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(name="Vet", email="vet@example.com")
+        user.set_password("x")
+        db.session.add(user)
+        db.session.commit()
+        vm = VacinaModelo(
+            nome="V8",
+            tipo="Obrigatória",
+            frequencia="Anual",
+            doses_totais=3,
+            intervalo_dias=30,
+            fabricante="PetVac",
+            created_by=user.id,
+        )
+        db.session.add(vm)
+        db.session.commit()
+        client = app.test_client()
+        resp = client.get('/buscar_vacinas?q=V8')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data[0]["id"] == vm.id
+        assert data[0]["frequencia"] == "Anual"
+        assert data[0]["doses_totais"] == 3
+        assert data[0]["intervalo_dias"] == 30
+        assert data[0]["fabricante"] == "PetVac"


### PR DESCRIPTION
## Summary
- expose vaccine model id, frequency, dose count, interval, and manufacturer via `/buscar_vacinas`
- prefill vaccine form fields with search result details
- add API test for new vaccine search fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8637dc73c832eb4f39ca8a3480ea5