### PR TITLE
Add vaccine metadata to search and prefill form

### DIFF
--- a/app.py
+++ b/app.py
@@ -3717,6 +3717,7 @@ def buscar_vacinas():
 
         return jsonify([
             {
+                'id': v.id,
                 'nome': v.nome,
                 'tipo': v.tipo or '',
                 'fabricante': v.fabricante or '',

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -38,6 +38,7 @@
     <div class="mb-3 position-relative">
       <label for="nome-vacina" class="form-label">Vacina</label>
       <input type="text" id="nome-vacina" class="form-control" placeholder="Ex: Antirrábica, V10, V8..." autocomplete="off">
+      <input type="hidden" id="vacina-id">
       <ul id="sugestoes-vacinas" class="list-group position-absolute w-100 bg-white shadow border rounded mt-1" style="z-index: 1050;"></ul>
     </div>
 
@@ -133,16 +134,22 @@
               return;
             }
 
-            data.forEach(item => {
-              const li = document.createElement('li');
-              li.className = 'list-group-item list-group-item-action';
-              li.textContent = item.nome;
-              li.onclick = () => {
-                inputVacina.value = item.nome;
-                sugestoesVacinas.innerHTML = '';
-              };
-              sugestoesVacinas.appendChild(li);
-            });
+              data.forEach(item => {
+                const li = document.createElement('li');
+                li.className = 'list-group-item list-group-item-action';
+                li.textContent = item.nome;
+                li.onclick = () => {
+                  document.getElementById('vacina-id').value = item.id || '';
+                  inputVacina.value = item.nome;
+                  document.getElementById('tipo-vacina').value = item.tipo || '';
+                  document.getElementById('fabricante-vacina').value = item.fabricante || '';
+                  document.getElementById('doses-vacina').value = item.doses_totais || '';
+                  document.getElementById('intervalo-vacina').value = item.intervalo_dias || '';
+                  document.getElementById('frequencia-vacina').value = item.frequencia || '';
+                  sugestoesVacinas.innerHTML = '';
+                };
+                sugestoesVacinas.appendChild(li);
+              });
           })
           .catch(err => {
             console.error("❌ Erro no autocomplete:", err);

--- a/tests/test_vacinas.py
+++ b/tests/test_vacinas.py
@@ -81,3 +81,36 @@ def test_criar_vacina_modelo(app):
         assert vm.doses_totais == 3
         assert vm.intervalo_dias == 30
         assert vm.frequencia == 'Anual'
+
+
+def test_buscar_vacinas_campos(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(name="Vet", email="vet@example.com", password_hash="x")
+        db.session.add(user)
+        db.session.commit()
+
+        vm = VacinaModelo(
+            nome="V8",
+            tipo="Obrigatória",
+            fabricante="ACME",
+            doses_totais=3,
+            intervalo_dias=30,
+            frequencia="Anual",
+            created_by=user.id,
+        )
+        db.session.add(vm)
+        db.session.commit()
+
+        client = app.test_client()
+        resp = client.get('/buscar_vacinas?q=V8')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list) and len(data) == 1
+        item = data[0]
+        assert item['id'] == vm.id
+        assert item['fabricante'] == 'ACME'
+        assert item['doses_totais'] == 3
+        assert item['intervalo_dias'] == 30
+        assert item['frequencia'] == 'Anual'


### PR DESCRIPTION
## Summary
- include vaccine id and metadata fields in `/buscar_vacinas`
- prefill vaccine form fields from autocomplete results
- test vaccine search returns expected fields

## Testing
- `pytest tests/test_vacinas.py::test_buscar_vacinas_campos -q`


------
https://chatgpt.com/codex/tasks/task_e_68b865c2b8e4832eac6d907c84aace87