### PR TITLE
Permite escolher outro veterinário no retorno

### DIFF
--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -117,7 +117,10 @@
     <h5 class="mb-3">Agendar Retorno</h5>
     {{ appointment_form.hidden_tag() }}
     <input type="hidden" name="animal_id" value="{{ animal.id }}">
-    <input type="hidden" name="veterinario_id" value="{{ consulta.veterinario.veterinario.id }}">
+    <div class="col-md-6">
+      {{ appointment_form.veterinario_id.label(class='form-label') }}
+      {{ appointment_form.veterinario_id(class='form-select') }}
+    </div>
     <div class="col-md-6">
       {{ appointment_form.date.label(class='form-label') }}
       {{ appointment_form.date(class='form-control', type='date') }}


### PR DESCRIPTION
## Resumo
- Permite selecionar qualquer veterinário da clínica ao agendar retorno
- Evita solicitar confirmação ao finalizar consulta com retorno já agendado
- Adiciona teste para finalizar consulta sem confirmação quando há retorno

## Testes
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b1008988832ebe132adcc07e4b23