### PR TITLE
Display upcoming exams and vaccines for tutors and animals

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -121,6 +121,10 @@
   <h5 class="fw-bold mt-5 mb-3"><i class="bi bi-flask me-2"></i> Agenda de Exames</h5>
   {% include 'partials/exam_appointments_table.html' %}
 
+  <!-- Agenda de Vacinas -->
+  <h5 class="fw-bold mt-5 mb-3"><i class="bi bi-syringe me-2"></i> Agenda de Vacinas</h5>
+  {% include 'partials/vaccine_appointments_table.html' %}
+
 </div>
 
 <!-- Modal Editar Consulta -->

--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -47,6 +47,52 @@
   </div>
   {% endif %}
 
+  <!-- PRÓXIMOS EVENTOS -->
+  <div class="card shadow-sm p-4 mb-4">
+    <h4 class="mb-3"><i class="bi bi-calendar-event text-primary me-2"></i>Próximos eventos</h4>
+
+    <h6 class="text-muted">🔁 Retornos</h6>
+    {% if retornos %}
+      <ul class="list-group mb-3">
+        {% for r in retornos %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <span>{{ r.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-muted">Nenhum retorno agendado.</p>
+    {% endif %}
+
+    <h6 class="mt-3 text-muted">🧪 Exames</h6>
+    {% if exames_agendados %}
+      <ul class="list-group mb-3">
+        {% for ex in exames_agendados %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <span>{{ ex.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</span>
+          <span class="text-muted small">{{ ex.specialist.user.name }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-muted">Nenhum exame agendado.</p>
+    {% endif %}
+
+    <h6 class="mt-3 text-muted">💉 Doses Futuras</h6>
+    {% if doses_futuras %}
+      <ul class="list-group mb-0">
+        {% for v in doses_futuras %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <span>{{ v.nome }}</span>
+          <span>{{ v.data|format_datetime_brazil('%d/%m/%Y') }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-muted mb-0">Nenhuma dose futura agendada.</p>
+    {% endif %}
+  </div>
+
   <!-- HISTÓRICO MÉDICO -->
   <div class="card shadow-sm p-4 mb-4">
     <h4 class="mb-3"><i class="bi bi-journal-medical text-success me-2"></i>Histórico Médico</h4>

--- a/templates/partials/vaccine_appointments_table.html
+++ b/templates/partials/vaccine_appointments_table.html
@@ -1,0 +1,25 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>Animal</th>
+      <th>Vacina</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% if vaccine_appointments_grouped %}
+      {% for day, items in vaccine_appointments_grouped %}
+        <tr class="table-light">
+          <th colspan="2">{{ day|format_datetime_brazil('%d/%m/%Y') }}</th>
+        </tr>
+        {% for vac in items %}
+          <tr>
+            <td>{{ vac.animal.name }}</td>
+            <td>{{ vac.nome }}</td>
+          </tr>
+        {% endfor %}
+      {% endfor %}
+    {% else %}
+      <tr><td colspan="2">Nenhuma vacina agendada.</td></tr>
+    {% endif %}
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- Show scheduled exams and vaccine doses on appointments page
- Add "Próximos eventos" to animal profile with upcoming returns, exams and vaccines
- Provide vaccine appointments table partial

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8baca2a28832e9842c5201c944d0a