### PR TITLE
Add basic chat API and UI

### DIFF
--- a/models.py
+++ b/models.py
@@ -383,6 +383,7 @@ class Message(db.Model):
         nullable=False,
     )
     animal_id = db.Column(db.Integer, db.ForeignKey('animal.id'), nullable=True)
+    clinica_id = db.Column(db.Integer, db.ForeignKey('clinica.id'), nullable=True)
 
     content = db.Column(db.Text, nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
@@ -391,6 +392,7 @@ class Message(db.Model):
     sender = db.relationship('User', foreign_keys=[sender_id], back_populates='sent_messages')
     receiver = db.relationship('User', foreign_keys=[receiver_id], back_populates='received_messages')
     animal = db.relationship('Animal', backref=db.backref('messages', cascade='all, delete-orphan'))
+    clinica = db.relationship('Clinica', backref=db.backref('messages', cascade='all, delete-orphan'))
 
     lida = db.Column(db.Boolean, default=False)
 

--- a/templates/chat/conversa.html
+++ b/templates/chat/conversa.html
@@ -1,0 +1,45 @@
+{% extends "layout.html" %}
+{% block main %}
+<h2>Chat sobre {{ animal.name }}</h2>
+<div id="messages" class="border p-3 mb-3 rounded" style="max-height:400px; overflow-y:auto;"></div>
+<form id="chat-form" class="input-group">
+    <input type="text" id="content" class="form-control" placeholder="Digite sua mensagem..." required>
+    <button class="btn btn-primary" type="submit">Enviar</button>
+</form>
+<script>
+const animalId = {{ animal.id }};
+const currentUserId = {{ current_user.id }};
+const receiverId = {{ animal.owner.id }};
+async function loadMessages() {
+    const resp = await fetch(`/chat/${animalId}`);
+    const msgs = await resp.json();
+    const container = document.getElementById('messages');
+    container.innerHTML = '';
+    msgs.forEach(m => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'mb-2 ' + (m.sender_id === currentUserId ? 'text-end' : '');
+        wrapper.innerHTML = `<div class="p-2 rounded ${m.sender_id === currentUserId ? 'bg-info-subtle' : 'bg-light'}">
+            <small>${m.sender_id === currentUserId ? 'Você' : 'Eles'}:</small><br>
+            ${m.content}
+            <div class="text-muted small">${new Date(m.timestamp).toLocaleString()}</div>
+        </div>`;
+        container.appendChild(wrapper);
+    });
+    container.scrollTop = container.scrollHeight;
+}
+document.getElementById('chat-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const content = document.getElementById('content').value.trim();
+    if (!content) return;
+    await fetch(`/chat/${animalId}`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({sender_id: currentUserId, receiver_id: receiverId, content})
+    });
+    document.getElementById('content').value = '';
+    loadMessages();
+});
+loadMessages();
+setInterval(loadMessages, 3000);
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend Message model with clinic relationship
- add REST chat endpoints and simple template with periodic polling
- test chat API message flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8bac7a3b0832e8a0f3900899a7543