### PR TITLE
Add applied status fields to Vacina model

### DIFF
--- a/migrations/versions/762f0e69f93c_add_aplicada_fields_to_vacina.py
+++ b/migrations/versions/762f0e69f93c_add_aplicada_fields_to_vacina.py
@@ -1,0 +1,32 @@
+"""add aplicada fields to vacina
+
+Revision ID: 762f0e69f93c
+Revises: 93a8666ff562
+Create Date: 2025-09-03 22:31:08.666721
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '762f0e69f93c'
+down_revision = '93a8666ff562'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('vacina', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('aplicada', sa.Boolean(), server_default='0', nullable=True))
+        batch_op.add_column(sa.Column('aplicada_em', sa.Date(), nullable=True))
+        batch_op.add_column(sa.Column('aplicada_por', sa.Integer(), nullable=True))
+        batch_op.create_foreign_key('fk_vacina_aplicada_por_user', 'user', ['aplicada_por'], ['id'])
+
+
+def downgrade():
+    with op.batch_alter_table('vacina', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_vacina_aplicada_por_user', type_='foreignkey')
+        batch_op.drop_column('aplicada_por')
+        batch_op.drop_column('aplicada_em')
+        batch_op.drop_column('aplicada')

--- a/models.py
+++ b/models.py
@@ -959,6 +959,9 @@ class Vacina(db.Model):
     frequencia = db.Column(db.String(50))
     data = db.Column(db.Date)        # Data da aplicação
     observacoes = db.Column(db.Text)
+    aplicada = db.Column(db.Boolean, default=False)
+    aplicada_em = db.Column(db.Date)
+    aplicada_por = db.Column(db.Integer, db.ForeignKey('user.id'))
     criada_em = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Registro de quem cadastrou a vacina


### PR DESCRIPTION
## Summary
- track vaccine application state with `aplicada`, `aplicada_em` and `aplicada_por` fields
- add Alembic migration to create new columns and foreign key

## Testing
- `flask db upgrade 762f0e69f93c`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8c0f94798832e9126385a33288963