### PR TITLE
Add applied status tracking for vaccines

### DIFF
--- a/migrations/versions/7ac809e3c0a9_add_aplicada_fields.py
+++ b/migrations/versions/7ac809e3c0a9_add_aplicada_fields.py
@@ -1,0 +1,27 @@
+"""add aplicada fields to vacina
+
+Revision ID: 7ac809e3c0a9
+Revises: 93a8666ff562
+Create Date: 2025-09-03 21:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '7ac809e3c0a9'
+down_revision = '93a8666ff562'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('vacina') as batch_op:
+        batch_op.alter_column('data', new_column_name='aplicada_em')
+        batch_op.add_column(sa.Column('aplicada', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('vacina') as batch_op:
+        batch_op.drop_column('aplicada')
+        batch_op.alter_column('aplicada_em', new_column_name='data')

--- a/models.py
+++ b/models.py
@@ -245,7 +245,7 @@ class Animal(db.Model):
 
     @property
     def vacinas_ordenadas(self):
-        return sorted(self.vacinas, key=lambda v: v.data or date.min, reverse=True)
+        return sorted(self.vacinas, key=lambda v: v.aplicada_em or date.min, reverse=True)
 
     user_id = db.Column(
         db.Integer,
@@ -957,7 +957,8 @@ class Vacina(db.Model):
     doses_totais = db.Column(db.Integer)
     intervalo_dias = db.Column(db.Integer)
     frequencia = db.Column(db.String(50))
-    data = db.Column(db.Date)        # Data da aplicação
+    aplicada = db.Column(db.Boolean, default=False)
+    aplicada_em = db.Column(db.Date)        # Data da aplicação
     observacoes = db.Column(db.Text)
     criada_em = db.Column(db.DateTime, default=datetime.utcnow)
 

--- a/templates/orcamentos/imprimir_vacinas.html
+++ b/templates/orcamentos/imprimir_vacinas.html
@@ -65,7 +65,7 @@
     <tbody>
       {% for vacina in animal.vacinas_ordenadas %}
       <tr>
-        <td>{{ vacina.data.strftime('%d/%m/%Y') if vacina.data else '—' }}</td>
+        <td>{{ vacina.aplicada_em.strftime('%d/%m/%Y') if vacina.aplicada_em else '—' }}</td>
         <td>{{ vacina.nome }}</td>
         <td>{{ vacina.tipo or '—' }}</td>
         <td>{{ vacina.lote or '—' }}</td>

--- a/templates/partials/historico_vacinas.html
+++ b/templates/partials/historico_vacinas.html
@@ -9,7 +9,8 @@
           data-nome="{{ vacina.nome }}" data-tipo="{{ vacina.tipo or '' }}"
           data-fabricante="{{ vacina.fabricante or '' }}" data-doses="{{ vacina.doses_totais or '' }}"
           data-intervalo="{{ vacina.intervalo_dias or '' }}" data-frequencia="{{ vacina.frequencia or '' }}"
-          data-data="{% if vacina.data %}{{ vacina.data.strftime('%Y-%m-%d') }}{% endif %}"
+          data-aplicada="{{ '1' if vacina.aplicada else '0' }}"
+          data-aplicada_em="{% if vacina.aplicada_em %}{{ vacina.aplicada_em.strftime('%Y-%m-%d') }}{% endif %}"
           data-obs="{{ vacina.observacoes or '' }}">
         <div class="vacina-info">
           <strong class="vacina-nome">{{ vacina.nome }}</strong>
@@ -18,10 +19,12 @@
           {% if vacina.doses_totais %} — <span class="vacina-doses">{{ vacina.doses_totais }} doses</span>{% endif %}
           {% if vacina.intervalo_dias %} — <span class="vacina-intervalo">{{ vacina.intervalo_dias }} dias</span>{% endif %}
           {% if vacina.frequencia %} — <span class="vacina-frequencia">{{ vacina.frequencia }}</span>{% endif %}
-          {% if vacina.data %}
-            em <span class="vacina-data" data-date="{{ vacina.data.strftime('%Y-%m-%d') }}">
-              {{ vacina.data.strftime('%d/%m/%Y') }}
+          {% if vacina.aplicada %}
+            em <span class="vacina-data" data-date="{{ vacina.aplicada_em.strftime('%Y-%m-%d') if vacina.aplicada_em else '' }}">
+              {{ vacina.aplicada_em.strftime('%d/%m/%Y') if vacina.aplicada_em else '' }}
             </span>
+          {% else %}
+            <span class="text-muted">Não aplicada</span>
           {% endif %}
           {% if vacina.observacoes %}
             <br><em class="vacina-obs">{{ vacina.observacoes }}</em>
@@ -52,7 +55,8 @@ function editarVacina(id) {
     doses = '',
     intervalo = '',
     frequencia = '',
-    data = '',
+    aplicada = '0',
+    aplicada_em = '',
     obs = ''
   } = li.dataset;
 
@@ -83,9 +87,13 @@ function editarVacina(id) {
         <input class="form-control" id="edit-frequencia-${id}" value="${frequencia}">
       </div>
     </div>
+    <div class="form-check mb-2">
+      <input class="form-check-input" type="checkbox" id="edit-aplicada-${id}" ${aplicada === '1' ? 'checked' : ''}>
+      <label class="form-check-label" for="edit-aplicada-${id}">Aplicada?</label>
+    </div>
     <div class="mb-2">
       <label class="form-label">Data</label>
-      <input type="date" class="form-control" id="edit-data-${id}" value="${data}">
+      <input type="date" class="form-control" id="edit-aplicada-em-${id}" value="${aplicada_em}" ${aplicada === '1' ? '' : 'disabled'}>
     </div>
     <div class="mb-2">
       <label class="form-label">Observações</label>
@@ -94,6 +102,13 @@ function editarVacina(id) {
     <button class="btn btn-sm btn-success" onclick="salvarEdicaoVacina(${id})">💾 Salvar</button>
     <button class="btn btn-sm btn-secondary" onclick="location.reload()">Cancelar</button>
   `;
+
+  const chk = document.getElementById(`edit-aplicada-${id}`);
+  const dt = document.getElementById(`edit-aplicada-em-${id}`);
+  chk.addEventListener('change', () => {
+    dt.disabled = !chk.checked;
+    if (!chk.checked) dt.value = '';
+  });
 }
 
 function salvarEdicaoVacina(id) {
@@ -103,13 +118,14 @@ function salvarEdicaoVacina(id) {
   const doses_totais = document.getElementById(`edit-doses-${id}`).value;
   const intervalo_dias = document.getElementById(`edit-intervalo-${id}`).value;
   const frequencia = document.getElementById(`edit-frequencia-${id}`).value.trim();
-  const data = document.getElementById(`edit-data-${id}`).value.trim();
+  const aplicada = document.getElementById(`edit-aplicada-${id}`).checked;
+  const aplicada_em = document.getElementById(`edit-aplicada-em-${id}`).value.trim();
   const observacoes = document.getElementById(`edit-obs-${id}`).value.trim();
 
   fetch(`/vacina/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ nome, tipo, fabricante, doses_totais, intervalo_dias, frequencia, data, observacoes })
+    body: JSON.stringify({ nome, tipo, fabricante, doses_totais, intervalo_dias, frequencia, aplicada, aplicada_em, observacoes })
   })
   .then(res => res.json())
   .then(d => {

--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -53,7 +53,7 @@
 
     <!-- Tipo e data -->
     <div class="row mb-3">
-      <div class="col-md-6">
+      <div class="col-md-4">
         <label for="tipo-vacina" class="form-label">Tipo</label>
         <select id="tipo-vacina" class="form-select">
           <option value="">Selecione...</option>
@@ -63,9 +63,15 @@
           <option value="Opcional">Opcional</option>
         </select>
       </div>
-      <div class="col-md-6">
-        <label for="data-vacina" class="form-label">Data da Aplicação</label>
-        <input type="date" id="data-vacina" class="form-control">
+      <div class="col-md-4 d-flex align-items-end">
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" id="aplicada-vacina">
+          <label class="form-check-label" for="aplicada-vacina">Aplicada?</label>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <label for="aplicada-em" class="form-label">Data da Aplicação</label>
+        <input type="date" id="aplicada-em" class="form-control" disabled>
       </div>
     </div>
 
@@ -113,6 +119,7 @@
     let vacinas = [];
     let inputVacina, sugestoesVacinas, vacinaSelecionada = null;
     let buscaVacinaInput, sugestoesBuscaVacina;
+    let aplicadaCheckbox, aplicadaEmInput;
     function mostrarFeedback(msg, tipo = 'success') {
       const fb = document.getElementById('feedback-vacinas');
       fb.textContent = msg;
@@ -125,6 +132,13 @@
       sugestoesVacinas = document.getElementById('sugestoes-vacinas');
       buscaVacinaInput = document.getElementById('buscar-vacina-nova');
       sugestoesBuscaVacina = document.getElementById('sugestoes-busca-vacina');
+      aplicadaCheckbox = document.getElementById('aplicada-vacina');
+      aplicadaEmInput = document.getElementById('aplicada-em');
+
+      aplicadaCheckbox.addEventListener('change', () => {
+        aplicadaEmInput.disabled = !aplicadaCheckbox.checked;
+        if (!aplicadaCheckbox.checked) aplicadaEmInput.value = '';
+      });
 
       inputVacina.addEventListener('input', function () {
         const q = this.value.trim();
@@ -292,30 +306,37 @@
     function adicionarVacina() {
       const nome = document.getElementById('nome-vacina').value.trim();
       const tipo = document.getElementById('tipo-vacina').value.trim();
-      const data = document.getElementById('data-vacina').value;
+      const aplicada = document.getElementById('aplicada-vacina').checked;
+      const aplicada_em = document.getElementById('aplicada-em').value;
       const fabricante = document.getElementById('fabricante-vacina').value.trim();
       const doses_totais = parseInt(document.getElementById('doses-vacina').value) || 1;
       const intervalo_dias = parseInt(document.getElementById('intervalo-vacina').value) || 0;
       const frequencia = document.getElementById('frequencia-vacina').value.trim();
 
-      if (!nome || !tipo || !data) {
+      if (!nome || !tipo || (aplicada && !aplicada_em)) {
         alert('Preencha todos os campos obrigatórios.');
         return;
       }
 
-      const base = { nome, tipo, fabricante, doses_totais, intervalo_dias, frequencia };
-      const primeiraData = new Date(data);
-      for (let i = 0; i < doses_totais; i++) {
-        const d = new Date(primeiraData);
-        d.setDate(d.getDate() + i * intervalo_dias);
-        const dataStr = d.toISOString().split('T')[0];
-        vacinas.push({ ...base, data: dataStr, dose_numero: i + 1 });
+      const base = { nome, tipo, fabricante, doses_totais, intervalo_dias, frequencia, aplicada };
+      if (aplicada && aplicada_em) {
+        const primeiraData = new Date(aplicada_em);
+        for (let i = 0; i < doses_totais; i++) {
+          const d = new Date(primeiraData);
+          d.setDate(d.getDate() + i * intervalo_dias);
+          const dataStr = d.toISOString().split('T')[0];
+          vacinas.push({ ...base, aplicada_em: dataStr, dose_numero: i + 1 });
+        }
+      } else {
+        vacinas.push({ ...base, aplicada_em: null, dose_numero: 1 });
       }
       renderVacinasTemp();
 
       document.getElementById('nome-vacina').value = '';
       document.getElementById('tipo-vacina').value = '';
-      document.getElementById('data-vacina').value = '';
+      document.getElementById('aplicada-vacina').checked = false;
+      document.getElementById('aplicada-em').value = '';
+      document.getElementById('aplicada-em').disabled = true;
       document.getElementById('fabricante-vacina').value = '';
       document.getElementById('doses-vacina').value = '';
       document.getElementById('intervalo-vacina').value = '';
@@ -335,7 +356,7 @@
         const div = document.createElement('div');
         div.className = 'border p-2 mb-2 bg-light rounded shadow-sm';
         div.innerHTML = `
-          💉 <strong>${v.nome}</strong> — ${v.tipo} em ${v.data}
+          💉 <strong>${v.nome}</strong> — ${v.tipo} ${v.aplicada ? `em ${v.aplicada_em}` : '(não aplicada)'}
           ${v.fabricante ? ` - ${v.fabricante}` : ''}
           ${v.doses_totais ? ` - dose ${v.dose_numero}/${v.doses_totais}` : ''}
           ${v.intervalo_dias ? ` - intervalo ${v.intervalo_dias}d` : ''}

--- a/tests/test_vacinas.py
+++ b/tests/test_vacinas.py
@@ -42,7 +42,7 @@ def test_salvar_vacina_data_invalida(app):
         db.session.commit()
 
         client = app.test_client()
-        payload = {"vacinas": [{"nome": "Antirrabica", "tipo": "Teste", "data": "111111-11-11"}]}
+        payload = {"vacinas": [{"nome": "Antirrabica", "tipo": "Teste", "aplicada": True, "aplicada_em": "111111-11-11"}]}
         resp = client.post(f"/animal/{animal.id}/vacinas", json=payload)
 
         assert resp.status_code == 200
@@ -51,7 +51,8 @@ def test_salvar_vacina_data_invalida(app):
 
         vacina = Vacina.query.filter_by(animal_id=animal.id).first()
         assert vacina is not None
-        assert vacina.data is None
+        assert vacina.aplicada_em is None
+        assert vacina.aplicada is True
 
 
 def test_criar_vacina_modelo(app):
@@ -135,7 +136,8 @@ def test_fluxo_criacao_edicao_vacina(app):
                 {
                     'nome': 'V10',
                     'tipo': 'Obrigatória',
-                    'data': '2024-01-01',
+                    'aplicada': True,
+                    'aplicada_em': '2024-01-01',
                     'fabricante': 'ACME',
                     'doses_totais': 3,
                     'intervalo_dias': 30,
@@ -156,10 +158,13 @@ def test_fluxo_criacao_edicao_vacina(app):
             'doses_totais': 2,
             'intervalo_dias': 60,
             'frequencia': 'Bienal',
-            'data': '2024-02-01'
+            'aplicada': True,
+            'aplicada_em': '2024-02-01'
         })
         assert resp.status_code == 200
         assert resp.get_json()['success'] is True
         vac2 = Vacina.query.get(vac.id)
         assert vac2.nome == 'V10X'
         assert vac2.intervalo_dias == 60
+        assert vac2.aplicada_em.strftime('%Y-%m-%d') == '2024-02-01'
+        assert vac2.aplicada is True


### PR DESCRIPTION
## Summary
- allow marking vaccines as applied with application date
- show and edit applied status in vaccine history
- persist applied fields on save

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8c0fa2608832e8e9fb7de8b1202cb