### PR TITLE
feat: mostrar listas de vacinas na ficha do animal

### DIFF
--- a/app.py
+++ b/app.py
@@ -1776,7 +1776,20 @@ def ficha_animal(animal_id):
 
     blocos_prescricao = BlocoPrescricao.query.filter_by(animal_id=animal.id).all()
     blocos_exames = BlocoExames.query.filter_by(animal_id=animal.id).all()
-    vacinas = Vacina.query.filter_by(animal_id=animal.id).all()
+
+    vacinas_aplicadas = Vacina.query.filter_by(
+        animal_id=animal.id, aplicada=True
+    ).all()
+    doses_futuras = (
+        Vacina.query.filter_by(animal_id=animal.id, aplicada=False)
+        .filter(Vacina.data >= date.today())
+        .all()
+    )
+    doses_atrasadas = (
+        Vacina.query.filter_by(animal_id=animal.id, aplicada=False)
+        .filter(Vacina.data < date.today())
+        .all()
+    )
 
     now = datetime.utcnow()
     retornos = (
@@ -1794,12 +1807,6 @@ def ficha_animal(animal_id):
         .order_by(ExamAppointment.scheduled_at)
         .all()
     )
-    doses_futuras = (
-        Vacina.query.filter_by(animal_id=animal.id)
-        .filter(Vacina.aplicada_em >= date.today())
-        .order_by(Vacina.aplicada_em)
-        .all()
-    )
 
     return render_template(
         'animais/ficha_animal.html',
@@ -1808,10 +1815,11 @@ def ficha_animal(animal_id):
         consultas=consultas,
         blocos_prescricao=blocos_prescricao,
         blocos_exames=blocos_exames,
-        vacinas=vacinas,
+        vacinas_aplicadas=vacinas_aplicadas,
+        doses_futuras=doses_futuras,
+        doses_atrasadas=doses_atrasadas,
         retornos=retornos,
         exames_agendados=exames_agendados,
-        doses_futuras=doses_futuras,
     )
 @app.route('/animal/<int:animal_id>/documentos', methods=['POST'])
 @login_required

--- a/models.py
+++ b/models.py
@@ -12,6 +12,7 @@ import enum
 from sqlalchemy import Enum, event
 from enum import Enum
 from sqlalchemy import Enum as PgEnum
+from sqlalchemy.orm import synonym
 
 
 
@@ -964,6 +965,7 @@ class Vacina(db.Model):
     aplicada_em = db.Column(db.Date)
     aplicada_por = db.Column(db.Integer, db.ForeignKey('user.id'))
     criada_em = db.Column(db.DateTime, default=datetime.utcnow)
+    data = synonym('aplicada_em')
 
     # Registro de quem cadastrou a vacina
     created_by = db.Column(

--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -78,19 +78,6 @@
       <p class="text-muted">Nenhum exame agendado.</p>
     {% endif %}
 
-    <h6 class="mt-3 text-muted">💉 Doses Futuras</h6>
-    {% if doses_futuras %}
-      <ul class="list-group mb-0">
-        {% for v in doses_futuras %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <span>{{ v.nome }}</span>
-          <span>{{ v.data|format_datetime_brazil('%d/%m/%Y') }}</span>
-        </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p class="text-muted mb-0">Nenhuma dose futura agendada.</p>
-    {% endif %}
   </div>
 
   <!-- HISTÓRICO MÉDICO -->
@@ -156,28 +143,60 @@
     {% endif %}
 
 
-<!-- VACINAS -->
-<h6 class="mt-4 text-muted">💉 Vacinas Aplicadas</h6>
-{% if animal.vacinas %}
-  <ul class="list-group mb-2">
-    {% for v in animal.vacinas_ordenadas %}
-    <li class="list-group-item d-flex justify-content-between align-items-center">
-      <div>
-        <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.data|format_datetime_brazil('%d/%m/%Y') if v.data else 'Data não registrada' }}
-        {% if v.observacoes %}
-          <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
-        {% endif %}
-      </div>
-    </li>
-    {% endfor %}
-  </ul>
-  {% else %}
-  <p class="text-muted">Nenhuma vacina registrada.</p>
-  {% endif %}
+    <!-- VACINAS -->
+    <h6 class="mt-4 text-muted">💉 Doses Futuras</h6>
+    {% if doses_futuras %}
+      <ul class="list-group mb-2">
+        {% for v in doses_futuras %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <div>
+            <strong>{{ v.nome }}</strong>
+            {% if v.data %} — {{ v.data|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-muted">Nenhuma dose futura agendada.</p>
+    {% endif %}
 
-  <!-- DOCUMENTOS -->
-  <div class="mt-4">
-    {% include 'partials/documentos.html' %}
+    <h6 class="mt-4 text-muted">💉 Doses Atrasadas</h6>
+    {% if doses_atrasadas %}
+      <ul class="list-group mb-2">
+        {% for v in doses_atrasadas %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <div>
+            <strong>{{ v.nome }}</strong>
+            {% if v.data %} — {{ v.data|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-muted">Nenhuma dose atrasada.</p>
+    {% endif %}
+
+    <h6 class="mt-4 text-muted">💉 Vacinas Aplicadas</h6>
+    {% if vacinas_aplicadas %}
+      <ul class="list-group mb-2">
+        {% for v in vacinas_aplicadas %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <div>
+            <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.data|format_datetime_brazil('%d/%m/%Y') if v.data else 'Data não registrada' }}
+            {% if v.observacoes %}
+              <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
+            {% endif %}
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-muted">Nenhuma vacina registrada.</p>
+    {% endif %}
+
+    <!-- DOCUMENTOS -->
+    <div class="mt-4">
+      {% include 'partials/documentos.html' %}
   </div>
 
   </div>


### PR DESCRIPTION
## Summary
- separar vacinas aplicadas, doses futuras e doses atrasadas na rota de ficha do animal
- exibir as três listas de vacinas na ficha do animal
- criar alias de data para campo `aplicada_em` no modelo de vacina

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c5c5e9fc832e816b9dadefa9b2e5