### PR TITLE
Fix vaccine schedule display on animal record

### DIFF
--- a/app.py
+++ b/app.py
@@ -1777,17 +1777,21 @@ def ficha_animal(animal_id):
     blocos_prescricao = BlocoPrescricao.query.filter_by(animal_id=animal.id).all()
     blocos_exames = BlocoExames.query.filter_by(animal_id=animal.id).all()
 
-    vacinas_aplicadas = Vacina.query.filter_by(
-        animal_id=animal.id, aplicada=True
-    ).all()
+    vacinas_aplicadas = (
+        Vacina.query.filter_by(animal_id=animal.id, aplicada=True)
+        .order_by(Vacina.aplicada_em.desc())
+        .all()
+    )
     doses_futuras = (
         Vacina.query.filter_by(animal_id=animal.id, aplicada=False)
-        .filter(Vacina.data >= date.today())
+        .filter(Vacina.aplicada_em >= date.today())
+        .order_by(Vacina.aplicada_em)
         .all()
     )
     doses_atrasadas = (
         Vacina.query.filter_by(animal_id=animal.id, aplicada=False)
-        .filter(Vacina.data < date.today())
+        .filter(Vacina.aplicada_em < date.today())
+        .order_by(Vacina.aplicada_em)
         .all()
     )
 

--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -151,7 +151,7 @@
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <div>
             <strong>{{ v.nome }}</strong>
-            {% if v.data %} — {{ v.data|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
+            {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
           </div>
         </li>
         {% endfor %}
@@ -167,7 +167,7 @@
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <div>
             <strong>{{ v.nome }}</strong>
-            {% if v.data %} — {{ v.data|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
+            {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
           </div>
         </li>
         {% endfor %}
@@ -182,7 +182,7 @@
         {% for v in vacinas_aplicadas %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <div>
-            <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.data|format_datetime_brazil('%d/%m/%Y') if v.data else 'Data não registrada' }}
+            <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') if v.aplicada_em else 'Data não registrada' }}
             {% if v.observacoes %}
               <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
             {% endif %}


### PR DESCRIPTION
## Summary
- use `aplicada_em` to pull applied and scheduled vaccines and order results
- render vaccine dates from `aplicada_em` field in animal record template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c96c56d8832e9bb37295e06deebb