### PR TITLE
Fix vaccine dose application flag for future scheduling

### DIFF
--- a/templates/partials/vacinas_form.html
+++ b/templates/partials/vacinas_form.html
@@ -318,17 +318,18 @@
         return;
       }
 
-      const base = { nome, tipo, fabricante, doses_totais, intervalo_dias, frequencia, aplicada };
+      const base = { nome, tipo, fabricante, doses_totais, intervalo_dias, frequencia };
       if (aplicada && aplicada_em) {
         const primeiraData = new Date(aplicada_em);
         for (let i = 0; i < doses_totais; i++) {
           const d = new Date(primeiraData);
           d.setDate(d.getDate() + i * intervalo_dias);
           const dataStr = d.toISOString().split('T')[0];
-          vacinas.push({ ...base, aplicada_em: dataStr, dose_numero: i + 1 });
+          const aplicadaDose = i === 0;
+          vacinas.push({ ...base, aplicada: aplicadaDose, aplicada_em: dataStr, dose_numero: i + 1 });
         }
       } else {
-        vacinas.push({ ...base, aplicada_em: null, dose_numero: 1 });
+        vacinas.push({ ...base, aplicada: false, aplicada_em: null, dose_numero: 1 });
       }
       renderVacinasTemp();
 


### PR DESCRIPTION
## Summary
- Adjust vaccine form to mark only first generated dose as applied and leave subsequent doses pending

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8d3b27b58832eb081f370230fc484