### PR TITLE
Use accordions for animal history sections

### DIFF
--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -84,120 +84,172 @@
   <div class="card shadow-sm p-4 mb-4">
     <h4 class="mb-3"><i class="bi bi-journal-medical text-success me-2"></i>Histórico Médico</h4>
 
-    <!-- PRESCRIÇÕES -->
-    <h6 class="mt-4 text-muted">💊 Prescrições</h6>
-    {% if blocos_prescricao %}
-      {% for bloco in blocos_prescricao[:3] %}
-      <div class="card mb-2 shadow-sm">
-        <div class="card-body d-flex justify-content-between align-items-center">
-          <span class="text-dark">
-            {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y') }} — {{ bloco.prescricoes | length }} medicação(ões)
-          </span>
-          {% if current_user.worker == 'veterinario' %}
-            <a href="{{ url_for('imprimir_bloco_prescricao', bloco_id=bloco.id) }}"
-               class="btn btn-sm btn-outline-primary">🖨️ Imprimir</a>
-          {% endif %}
-        </div>
-      </div>
-      {% endfor %}
-    {% else %}
-      <p class="text-muted">Nenhuma prescrição encontrada.</p>
-    {% endif %}
+    <div class="accordion" id="historicoAccordion">
 
-    <!-- EXAMES -->
-    <h6 class="mt-4 text-muted">🧪 Exames Solicitados</h6>
-    {% if blocos_exames %}
-      {% for bloco in blocos_exames[:3] %}
-      <div class="card mb-2 shadow-sm">
-        <div class="card-body d-flex justify-content-between align-items-center">
-          <span class="text-dark">
-            {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y') }} — {{ bloco.exames | length }} exame(s)
-          </span>
-          {% if current_user.worker == 'veterinario' %}
-            <a href="{{ url_for('imprimir_bloco_exames', bloco_id=bloco.id) }}"
-               class="btn btn-sm btn-outline-primary">🖨️ Imprimir</a>
-          {% endif %}
-        </div>
-      </div>
-      {% endfor %}
-    {% else %}
-      <p class="text-muted">Nenhum exame solicitado.</p>
-    {% endif %}
-
-    <!-- CONSULTAS -->
-    <h6 class="mt-4 text-muted">📅 Consultas Veterinárias</h6>
-    {% if consultas %}
-      <ul class="list-group mb-2">
-        {% for c in consultas[:3] %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <span>{{ c.created_at|format_datetime_brazil('%d/%m/%Y') }}</span>
-          <span class="text-muted small">{{ c.veterinario.name }}</span>
-        </li>
-        {% endfor %}
-      </ul>
-      {% if consultas|length > 3 %}
-        <a href="{{ url_for('historico_consultas', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark">🔍 Ver todas</a>
-      {% endif %}
-    {% else %}
-      <p class="text-muted">Nenhuma consulta registrada.</p>
-    {% endif %}
-
-
-    <!-- VACINAS -->
-    <h6 class="mt-4 text-muted">💉 Doses Futuras</h6>
-    {% if doses_futuras %}
-      <ul class="list-group mb-2">
-        {% for v in doses_futuras %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <div>
-            <strong>{{ v.nome }}</strong>
-            {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
-          </div>
-        </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p class="text-muted">Nenhuma dose futura agendada.</p>
-    {% endif %}
-
-    <h6 class="mt-4 text-muted">💉 Doses Atrasadas</h6>
-    {% if doses_atrasadas %}
-      <ul class="list-group mb-2">
-        {% for v in doses_atrasadas %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <div>
-            <strong>{{ v.nome }}</strong>
-            {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
-          </div>
-        </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p class="text-muted">Nenhuma dose atrasada.</p>
-    {% endif %}
-
-    <h6 class="mt-4 text-muted">💉 Vacinas Aplicadas</h6>
-    {% if vacinas_aplicadas %}
-      <ul class="list-group mb-2">
-        {% for v in vacinas_aplicadas %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          <div>
-            <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') if v.aplicada_em else 'Data não registrada' }}
-            {% if v.observacoes %}
-              <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
+      <!-- PRESCRIÇÕES -->
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingPrescricoes">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePrescricoes" aria-expanded="false" aria-controls="collapsePrescricoes">
+            💊 Prescrições
+          </button>
+        </h2>
+        <div id="collapsePrescricoes" class="accordion-collapse collapse" data-bs-parent="#historicoAccordion">
+          <div class="accordion-body">
+            {% if blocos_prescricao %}
+              {% for bloco in blocos_prescricao[:3] %}
+              <div class="card mb-2 shadow-sm">
+                <div class="card-body d-flex justify-content-between align-items-center">
+                  <span class="text-dark">
+                    {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y') }} — {{ bloco.prescricoes | length }} medicação(ões)
+                  </span>
+                  {% if current_user.worker == 'veterinario' %}
+                    <a href="{{ url_for('imprimir_bloco_prescricao', bloco_id=bloco.id) }}" class="btn btn-sm btn-outline-primary">🖨️ Imprimir</a>
+                  {% endif %}
+                </div>
+              </div>
+              {% endfor %}
+              {% if blocos_prescricao|length > 3 %}
+                <a href="{{ url_for('historico_prescricoes', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark">🔍 Ver todas</a>
+              {% endif %}
+            {% else %}
+              <p class="text-muted">Nenhuma prescrição encontrada.</p>
             {% endif %}
           </div>
-        </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p class="text-muted">Nenhuma vacina registrada.</p>
-    {% endif %}
+        </div>
+      </div>
+
+      <!-- EXAMES -->
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingExames">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseExames" aria-expanded="false" aria-controls="collapseExames">
+            🧪 Exames Solicitados
+          </button>
+        </h2>
+        <div id="collapseExames" class="accordion-collapse collapse" data-bs-parent="#historicoAccordion">
+          <div class="accordion-body">
+            {% if blocos_exames %}
+              {% for bloco in blocos_exames[:3] %}
+              <div class="card mb-2 shadow-sm">
+                <div class="card-body d-flex justify-content-between align-items-center">
+                  <span class="text-dark">
+                    {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y') }} — {{ bloco.exames | length }} exame(s)
+                  </span>
+                  {% if current_user.worker == 'veterinario' %}
+                    <a href="{{ url_for('imprimir_bloco_exames', bloco_id=bloco.id) }}" class="btn btn-sm btn-outline-primary">🖨️ Imprimir</a>
+                  {% endif %}
+                </div>
+              </div>
+              {% endfor %}
+              {% if blocos_exames|length > 3 %}
+                <a href="{{ url_for('historico_exames', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark">🔍 Ver todas</a>
+              {% endif %}
+            {% else %}
+              <p class="text-muted">Nenhum exame solicitado.</p>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+      <!-- CONSULTAS -->
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingConsultas">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseConsultas" aria-expanded="false" aria-controls="collapseConsultas">
+            📅 Consultas Veterinárias
+          </button>
+        </h2>
+        <div id="collapseConsultas" class="accordion-collapse collapse" data-bs-parent="#historicoAccordion">
+          <div class="accordion-body">
+            {% if consultas %}
+              <ul class="list-group mb-2">
+                {% for c in consultas[:3] %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <span>{{ c.created_at|format_datetime_brazil('%d/%m/%Y') }}</span>
+                  <span class="text-muted small">{{ c.veterinario.name }}</span>
+                </li>
+                {% endfor %}
+              </ul>
+              {% if consultas|length > 3 %}
+                <a href="{{ url_for('historico_consultas', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark">🔍 Ver todas</a>
+              {% endif %}
+            {% else %}
+              <p class="text-muted">Nenhuma consulta registrada.</p>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+      <!-- VACINAS -->
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingVacinas">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseVacinas" aria-expanded="false" aria-controls="collapseVacinas">
+            💉 Vacinas
+          </button>
+        </h2>
+        <div id="collapseVacinas" class="accordion-collapse collapse" data-bs-parent="#historicoAccordion">
+          <div class="accordion-body">
+            <h6 class="text-muted">Doses Futuras</h6>
+            {% if doses_futuras %}
+              <ul class="list-group mb-2">
+                {% for v in doses_futuras[:3] %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <div>
+                    <strong>{{ v.nome }}</strong>
+                    {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="text-muted">Nenhuma dose futura agendada.</p>
+            {% endif %}
+
+            <h6 class="mt-3 text-muted">Doses Atrasadas</h6>
+            {% if doses_atrasadas %}
+              <ul class="list-group mb-2">
+                {% for v in doses_atrasadas[:3] %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <div>
+                    <strong>{{ v.nome }}</strong>
+                    {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="text-muted">Nenhuma dose atrasada.</p>
+            {% endif %}
+
+            <h6 class="mt-3 text-muted">Vacinas Aplicadas</h6>
+            {% if vacinas_aplicadas %}
+              <ul class="list-group mb-2">
+                {% for v in vacinas_aplicadas[:3] %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <div>
+                    <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') if v.aplicada_em else 'Data não registrada' }}
+                    {% if v.observacoes %}
+                      <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
+                    {% endif %}
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="text-muted">Nenhuma vacina registrada.</p>
+            {% endif %}
+
+            {% if animal.vacinas|length > 3 %}
+              <a href="{{ url_for('historico_vacinas', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark">🔍 Ver todas</a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+    </div>
 
     <!-- DOCUMENTOS -->
     <div class="mt-4">
       {% include 'partials/documentos.html' %}
-  </div>
+    </div>
 
   </div>
 


### PR DESCRIPTION
## Summary
- Wrap prescription, exam, consultation and vaccine sections in a Bootstrap accordion on the animal record
- Limit each section to three recent entries and provide “Ver todas” links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8ee443a74832ebb26f154dde36a10