### PR TITLE
Adiciona breadcrumb e link do tutor na ficha do animal

### DIFF
--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -3,6 +3,14 @@
 
 <div class="container py-4">
 
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="{{ url_for('index') }}">Home</a></li>
+      <li class="breadcrumb-item"><a href="{{ url_for('tutores') }}">Tutores</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Ficha do animal</li>
+    </ol>
+  </nav>
+
   {% if animal.removido_em %}
     <div class="alert alert-warning">
       Este animal foi removido do sistema em {{ animal.removido_em|format_datetime_brazil('%d/%m/%Y') }}. Histórico preservado.
@@ -33,8 +41,9 @@
           {% if animal.sex %}<div class="col-md-4"><strong>Sexo:</strong> {{ animal.sex }}</div>{% endif %}
           {% if animal.date_of_birth %}<div class="col-md-4"><strong>Nascimento:</strong> {{ animal.date_of_birth.strftime('%d/%m/%Y') }}</div>{% endif %}
           {% if animal.age_display %}<div class="col-md-4"><strong>Idade:</strong> {{ animal.age_display }}</div>{% endif %}
+          {% if tutor %}<div class="col-md-4"><strong>Tutor:</strong> <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}">{{ tutor.name }}</a></div>{% endif %}
+          </div>
         </div>
-      </div>
     </div>
   </div>
 
@@ -204,13 +213,7 @@
 
 
 
-  <!-- VOLTAR -->
-  <h3>Ficha de {{ animal.name }}</h3>
-  <p><strong>Tutor:</strong>
-    <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}">{{ tutor.name }}</a>
-  </p>
-
-<!-- STATUS DE VIDA -->
+  <!-- STATUS DE VIDA -->
 {% if animal.is_alive and current_user.worker == 'veterinario' %}
   <div class="card border-dark p-3 mb-4">
     <div class="text-start">


### PR DESCRIPTION
## Summary
- Adiciona breadcrumb de navegação para Home, Tutores e Ficha do animal
- Torna o nome do tutor clicável na ficha do animal
- Remove bloco duplicado de cabeçalho e tutor

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8ee32048c832ebf2c3d33f6714ff1