### PR TITLE
Renomeia doses futuras para vacinas agendadas

### DIFF
--- a/app.py
+++ b/app.py
@@ -1783,7 +1783,7 @@ def ficha_animal(animal_id):
         .order_by(Vacina.aplicada_em.desc())
         .all()
     )
-    doses_futuras = (
+    vacinas_agendadas = (
         Vacina.query.filter_by(animal_id=animal.id, aplicada=False)
         .filter(Vacina.aplicada_em >= date.today())
         .order_by(Vacina.aplicada_em)
@@ -1821,7 +1821,7 @@ def ficha_animal(animal_id):
         blocos_prescricao=blocos_prescricao,
         blocos_exames=blocos_exames,
         vacinas_aplicadas=vacinas_aplicadas,
-        doses_futuras=doses_futuras,
+        vacinas_agendadas=vacinas_agendadas,
         doses_atrasadas=doses_atrasadas,
         retornos=retornos,
         exames_agendados=exames_agendados,

--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -94,6 +94,22 @@
           {% else %}
             <p class="text-muted">Nenhum exame agendado.</p>
           {% endif %}
+
+          <h6 class="mt-3 text-muted">💉 Vacinas Agendadas</h6>
+          {% if vacinas_agendadas %}
+            <ul class="list-group mb-3">
+              {% for v in vacinas_agendadas %}
+              <li class="list-group-item d-flex justify-content-between align-items-center">
+                <div>
+                  <strong>{{ v.nome }}</strong>
+                  {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
+                </div>
+              </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-muted">Nenhuma vacina agendada.</p>
+          {% endif %}
         </div>
       </div>
       <div class="tab-pane fade" id="historico" role="tabpanel" aria-labelledby="historico-tab">
@@ -160,22 +176,6 @@
           {% endif %}
 
           <!-- VACINAS -->
-          <h6 class="mt-4 text-muted">💉 Doses Futuras</h6>
-          {% if doses_futuras %}
-            <ul class="list-group mb-2">
-              {% for v in doses_futuras %}
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <div>
-                  <strong>{{ v.nome }}</strong>
-                  {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
-                </div>
-              </li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="text-muted">Nenhuma dose futura agendada.</p>
-          {% endif %}
-
           <h6 class="mt-4 text-muted">💉 Doses Atrasadas</h6>
           {% if doses_atrasadas %}
             <ul class="list-group mb-2">


### PR DESCRIPTION
## Summary
- Rename future vaccine doses to scheduled vaccines
- Move scheduled vaccines from medical history to upcoming events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8f093c048832e978c090577f23762