### PR TITLE
Renomeia doses futuras e exibe vacinas agendadas nos próximos eventos

### DIFF
--- a/app.py
+++ b/app.py
@@ -1783,7 +1783,7 @@ def ficha_animal(animal_id):
         .order_by(Vacina.aplicada_em.desc())
         .all()
     )
-    doses_futuras = (
+    vacinas_agendadas = (
         Vacina.query.filter_by(animal_id=animal.id, aplicada=False)
         .filter(Vacina.aplicada_em >= date.today())
         .order_by(Vacina.aplicada_em)
@@ -1821,7 +1821,7 @@ def ficha_animal(animal_id):
         blocos_prescricao=blocos_prescricao,
         blocos_exames=blocos_exames,
         vacinas_aplicadas=vacinas_aplicadas,
-        doses_futuras=doses_futuras,
+        vacinas_agendadas=vacinas_agendadas,
         doses_atrasadas=doses_atrasadas,
         retornos=retornos,
         exames_agendados=exames_agendados,

--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -68,7 +68,23 @@
         <div class="card shadow-sm p-4 mb-4">
           <h4 class="mb-3"><i class="bi bi-calendar-event text-primary me-2"></i>Próximos eventos</h4>
 
-          <h6 class="text-muted">🔁 Retornos</h6>
+          <h6 class="text-muted">💉 Vacinas Agendadas</h6>
+          {% if vacinas_agendadas %}
+            <ul class="list-group mb-3">
+              {% for v in vacinas_agendadas %}
+              <li class="list-group-item d-flex justify-content-between align-items-center">
+                <div>
+                  <strong>{{ v.nome }}</strong>
+                  {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
+                </div>
+              </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-muted">Nenhuma vacina agendada.</p>
+          {% endif %}
+
+          <h6 class="mt-3 text-muted">🔁 Retornos</h6>
           {% if retornos %}
             <ul class="list-group mb-3">
               {% for r in retornos %}
@@ -204,23 +220,7 @@
               </h2>
               <div id="collapseVacinas" class="accordion-collapse collapse" aria-labelledby="headingVacinas" data-bs-parent="#historicoAccordion">
                 <div class="accordion-body">
-                  <h6 class="text-muted">💉 Doses Futuras</h6>
-                  {% if doses_futuras %}
-                    <ul class="list-group mb-2">
-                      {% for v in doses_futuras[:3] %}
-                      <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <div>
-                          <strong>{{ v.nome }}</strong>
-                          {% if v.aplicada_em %} — {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') }}{% endif %}
-                        </div>
-                      </li>
-                      {% endfor %}
-                    </ul>
-                  {% else %}
-                    <p class="text-muted">Nenhuma dose futura agendada.</p>
-                  {% endif %}
-
-                  <h6 class="mt-3 text-muted">💉 Doses Atrasadas</h6>
+                  <h6 class="text-muted">💉 Doses Atrasadas</h6>
                   {% if doses_atrasadas %}
                     <ul class="list-group mb-2">
                       {% for v in doses_atrasadas[:3] %}
@@ -254,7 +254,7 @@
                     <p class="text-muted">Nenhuma vacina registrada.</p>
                   {% endif %}
 
-                  {% if (doses_futuras|length > 3 or doses_atrasadas|length > 3 or vacinas_aplicadas|length > 3) and 'historico_vacinas' in current_app.view_functions %}
+                  {% if (vacinas_agendadas|length > 3 or doses_atrasadas|length > 3 or vacinas_aplicadas|length > 3) and 'historico_vacinas' in current_app.view_functions %}
                     <a href="{{ url_for('historico_vacinas', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark">🔍 Ver todas</a>
                   {% endif %}
                 </div>


### PR DESCRIPTION
## Summary
- Renomeia consultas de `doses_futuras` para `vacinas_agendadas` na ficha do animal
- Remove seção de doses futuras do histórico e mostra vacinas agendadas nos próximos eventos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8f3ea02e4832e840b6c4f6ed3a58a