### PR TITLE
Adiciona breadcrumb e link para tutor na ficha do animal

### DIFF
--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -1,7 +1,14 @@
 {% extends "layout.html" %}
 {% block main %}
 
-<div class="container py-4">
+  <div class="container py-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('index') }}">Home</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('tutores') }}">Tutores</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Ficha do animal</li>
+      </ol>
+    </nav>
 
   {% if animal.removido_em %}
     <div class="alert alert-warning">
@@ -45,8 +52,9 @@
           {% if animal.breed %}<div class="col-md-4"><strong>Raça:</strong> {{ animal.breed }}</div>{% endif %}
           {% if animal.sex %}<div class="col-md-4"><strong>Sexo:</strong> {{ animal.sex }}</div>{% endif %}
           {% if animal.date_of_birth %}<div class="col-md-4"><strong>Nascimento:</strong> {{ animal.date_of_birth.strftime('%d/%m/%Y') }}</div>{% endif %}
-          {% if animal.age_display %}<div class="col-md-4"><strong>Idade:</strong> {{ animal.age_display }}</div>{% endif %}
-        </div>
+            {% if animal.age_display %}<div class="col-md-4"><strong>Idade:</strong> {{ animal.age_display }}</div>{% endif %}
+            {% if tutor %}<div class="col-md-4"><strong>Tutor:</strong> <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}">{{ tutor.name }}</a></div>{% endif %}
+          </div>
       </div>
     </div>
   </div>
@@ -193,22 +201,20 @@
           {% endif %}
 
           <h6 class="mt-4 text-muted">💉 Vacinas Aplicadas</h6>
-          {% if vacinas_aplicadas %}
-            <ul class="list-group mb-2">
-              {% for v in vacinas_aplicadas %}
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <div>
-                  <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') if v.aplicada_em else 'Data não registrada' }}
-                  {% if v.observacoes %}
-                    <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
-                  {% endif %}
-                </div>
-              </li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="text-muted">Nenhuma vacina registrada.</p>
-          {% endif %}
+            {% if vacinas_aplicadas %}
+              <ul class="list-group mb-2">
+                {% for v in vacinas_aplicadas %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <div>
+                    <strong>{{ v.nome }}</strong> — {{ v.tipo or "Tipo não informado" }} em {{ v.aplicada_em|format_datetime_brazil('%d/%m/%Y') if v.aplicada_em else 'Data não registrada' }}
+                    {% if v.observacoes %}
+                      <br><em class="text-muted">Obs: {{ v.observacoes }}</em>
+                    {% endif %}
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
 
           <!-- DOCUMENTOS -->
           <div class="mt-4">


### PR DESCRIPTION
## Resumo
- Remove bloco redundante da seção de vacinas aplicadas
- Adiciona breadcrumb "Home → Tutores → Ficha do animal"
- Torna o nome do tutor clicável para acesso rápido à sua ficha

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8f037a298832eb64e5583ba33c11a