### PR TITLE
Enable collaborator appointment scheduling with type selection

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -408,6 +408,13 @@ class AppointmentForm(FlaskForm):
         validators=[DataRequired()],
     )
 
+    kind = SelectField(
+        'Tipo',
+        choices=[('consulta', 'Consulta'), ('retorno', 'Retorno'), ('exame', 'Exame')],
+        validators=[DataRequired()],
+        default='consulta',
+    )
+
     reason = TextAreaField(
         'Motivo',
         validators=[Optional(), Length(max=500)],
@@ -432,4 +439,6 @@ class AppointmentForm(FlaskForm):
         self.veterinario_id.choices = [
             (v.id, v.user.name if v.user else str(v.id)) for v in veterinarios
         ]
+        if not self.kind.data:
+            self.kind.data = 'consulta'
 

--- a/models.py
+++ b/models.py
@@ -731,6 +731,7 @@ class Appointment(db.Model):
     veterinario_id = db.Column(db.Integer, db.ForeignKey('veterinario.id'), nullable=False)
     scheduled_at = db.Column(db.DateTime, nullable=False)
     status = db.Column(db.String(20), nullable=False, default='scheduled')
+    kind = db.Column(db.String(20), nullable=False, default='consulta')
     notes = db.Column(db.Text, nullable=True)
     consulta_id = db.Column(db.Integer, db.ForeignKey('consulta.id'), nullable=True)
     clinica_id = db.Column(db.Integer, db.ForeignKey('clinica.id'), nullable=True)

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -55,6 +55,11 @@
           </div>
 
           <div class="mt-3">
+            {{ form.kind.label(class="form-label fw-semibold") }}
+            {{ form.kind(class="form-select") }}
+          </div>
+
+          <div class="mt-3">
             {{ form.reason.label(class="form-label fw-semibold") }}
             {{ form.reason(class="form-control", rows=3, placeholder="Motivo da consulta...") }}
           </div>

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -127,6 +127,10 @@
               </div>
             </div>
             <div class="mb-3">
+              {{ appointment_form.kind.label(class="form-label fw-bold") }}
+              {{ appointment_form.kind(class="form-select") }}
+            </div>
+            <div class="mb-3">
               {{ appointment_form.reason.label(class="form-label fw-bold") }}
               {{ appointment_form.reason(class="form-control", rows=3) }}
             </div>

--- a/templates/partials/consulta_form.html
+++ b/templates/partials/consulta_form.html
@@ -102,6 +102,10 @@
       {{ appointment_form.time(class='form-control', type='time', value=consulta.appointment.scheduled_at|format_datetime_brazil('%H:%M')) }}
     </div>
     <div class="col-12">
+      {{ appointment_form.kind.label(class='form-label') }}
+      {{ appointment_form.kind(class='form-select', value=consulta.appointment.kind) }}
+    </div>
+    <div class="col-12">
       {{ appointment_form.reason.label(class='form-label') }}
       {{ appointment_form.reason(class='form-control', rows=3, value=consulta.appointment.notes or '') }}
     </div>
@@ -128,6 +132,10 @@
     <div class="col-md-6">
       {{ appointment_form.time.label(class='form-label') }}
       {{ appointment_form.time(class='form-control', type='time') }}
+    </div>
+    <div class="col-12">
+      {{ appointment_form.kind.label(class='form-label') }}
+      {{ appointment_form.kind(class='form-select') }}
     </div>
     <div class="col-12">
       {{ appointment_form.reason.label(class='form-label') }}

--- a/tests/test_appointment_vet.py
+++ b/tests/test_appointment_vet.py
@@ -89,6 +89,7 @@ def test_veterinarian_can_schedule_for_other_users_animal(client, monkeypatch):
             'appointment-veterinario_id': vet_id,
             'appointment-date': '2024-05-01',
             'appointment-time': '10:00',
+            'appointment-kind': 'consulta',
             'appointment-reason': 'Checkup',
             'appointment-submit': True,
         },

--- a/tests/test_collaborator_appointment.py
+++ b/tests/test_collaborator_appointment.py
@@ -1,0 +1,66 @@
+import pytest
+import flask_login.utils as login_utils
+from app import app as flask_app, db
+from models import User, Clinica, Veterinario, Animal, VetSchedule, HealthPlan, HealthSubscription, Appointment
+from datetime import time, date
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+def login(monkeypatch, user):
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def setup_data():
+    clinic = Clinica(id=1, nome='Clinica')
+    tutor = User(id=1, name='Tutor', email='t@test')
+    tutor.set_password('x')
+    vet_user = User(id=2, name='Vet', email='v@test', worker='veterinario')
+    vet_user.set_password('x')
+    vet = Veterinario(id=1, user_id=vet_user.id, crmv='123', clinica_id=clinic.id)
+    animal = Animal(id=1, name='Rex', user_id=tutor.id, clinica_id=clinic.id)
+    schedule = VetSchedule(veterinario_id=vet.id, dia_semana='Segunda', hora_inicio=time(8,0), hora_fim=time(12,0))
+    plan = HealthPlan(id=1, name='Basic', price=10.0)
+    sub = HealthSubscription(animal_id=animal.id, plan_id=plan.id, user_id=tutor.id, active=True)
+    db.session.add_all([clinic, tutor, vet_user, vet, animal, schedule, plan, sub])
+    db.session.commit()
+    return clinic.id, animal.id, vet.id
+
+
+def test_collaborator_can_schedule_consulta(client, monkeypatch):
+    with flask_app.app_context():
+        clinic_id, animal_id, vet_id = setup_data()
+    collaborator = type('U', (), {
+        'id': 3,
+        'worker': 'colaborador',
+        'role': 'adotante',
+        'is_authenticated': True,
+        'clinica_id': clinic_id,
+    })()
+    login(monkeypatch, collaborator)
+    resp = client.post('/appointments', data={
+        'appointment-animal_id': str(animal_id),
+        'appointment-veterinario_id': str(vet_id),
+        'appointment-date': '2024-05-20',
+        'appointment-time': '09:00',
+        'appointment-kind': 'consulta',
+        'appointment-reason': 'Checkup',
+        'appointment-submit': True,
+    })
+    assert resp.status_code == 302
+    with flask_app.app_context():
+        appt = Appointment.query.first()
+        assert appt is not None
+        assert appt.kind == 'consulta'
+        assert appt.notes == 'Checkup'


### PR DESCRIPTION
## Summary
- Allow collaborators to schedule appointments for clinic pets and choose appointment type
- Add `kind` field to appointments and forms for exam/return/consultation
- Include new collaborator scheduling test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beb43833a8832e9c9a3964d7e87e77