### PR TITLE
Add tabbed navigation to tutor details

### DIFF
--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -6,9 +6,21 @@
   <!-- Navegação -->
   <a href="{{ url_for('tutores') }}" class="btn btn-secondary mb-3">← Voltar à Busca de Tutores</a>
 
-  <!-- =========================  FICHA DO TUTOR  ========================= -->
-  <div class="card mb-4">
-    <div class="card-body position-relative">
+  <ul class="nav nav-tabs" id="tutorTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="dados-tab" data-bs-toggle="tab" data-bs-target="#dados" type="button" role="tab" aria-controls="dados" aria-selected="true">Dados do Tutor</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="animais-tab" data-bs-toggle="tab" data-bs-target="#animais" type="button" role="tab" aria-controls="animais" aria-selected="false">Lista de Animais</button>
+    </li>
+  </ul>
+
+  <div class="tab-content mt-3">
+
+    <div class="tab-pane fade show active" id="dados" role="tabpanel" aria-labelledby="dados-tab">
+      <!-- =========================  FICHA DO TUTOR  ========================= -->
+      <div class="card mb-4">
+        <div class="card-body position-relative">
       <!-- Botão de excluir tutor no topo direito -->
       <form method="POST" action="{{ url_for('deletar_tutor', tutor_id=tutor.id) }}"
             onsubmit="return confirm('Tem certeza que deseja excluir este tutor e todos os seus dados permanentemente?');"
@@ -98,26 +110,18 @@
       </form>
     </div>
   </div>
-
-
-
-
-
-
-
-
-
-
-
-<!-- ========================= LISTA DE ANIMAIS ========================= -->
-<div class="card">
-  <div class="card-body">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h3 class="card-title mb-0" id="animais-heading">🐾 Animais de {{ tutor.name.split(' ')[0] }}</h3>
-      <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#modalNovoAnimal">
-        ➕ Novo Animal
-      </button>
     </div>
+
+    <div class="tab-pane fade" id="animais" role="tabpanel" aria-labelledby="animais-tab">
+      <!-- ========================= LISTA DE ANIMAIS ========================= -->
+      <div class="card">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h3 class="card-title mb-0" id="animais-heading">🐾 Animais de {{ tutor.name.split(' ')[0] }}</h3>
+            <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#modalNovoAnimal">
+              ➕ Novo Animal
+            </button>
+          </div>
 
     <table class="table table-hover align-middle">
       <thead>
@@ -196,12 +200,14 @@
         </ul>
       </div>
     </div>
-    {% endif %}
+      {% endif %}
+    </div>
   </div>
-</div>
+    </div>
+  </div>
 
 
-<!-- =========================  MODAIS DE EDIÇÃO  ========================= -->
+  <!-- =========================  MODAIS DE EDIÇÃO  ========================= -->
 {% for a in animais %}
 <div class="modal fade" id="modalEditarAnimal{{ a.id }}" tabindex="-1" aria-hidden="true">
 <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">


### PR DESCRIPTION
## Summary
- Add Bootstrap nav-tabs to switch between tutor data and animal list
- Wrap tutor data and animal list in tab panes with proper IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb45c14bc832ea64f78f5950759f9