### PR TITLE
Add input masks for tutor detail form

### DIFF
--- a/static/masks.js
+++ b/static/masks.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-mask]').forEach(el => {
+    const mask = el.dataset.mask;
+    if (mask) {
+      Inputmask({ mask }).mask(el);
+    }
+  });
+});

--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -48,16 +48,19 @@
         </div>
         <div class="col-md-6">
           <label class="form-label">Telefone</label>
-          <input name="phone" class="form-control" value="{{ tutor.phone or '' }}">
+          <input name="phone" class="form-control" value="{{ tutor.phone or '' }}"
+                 data-mask="(99) 99999-9999" pattern="\(\d{2}\) \d{5}-\d{4}">
         </div>
 
         <div class="col-md-4">
           <label class="form-label">CPF</label>
-          <input name="cpf" class="form-control" value="{{ tutor.cpf or '' }}">
+          <input name="cpf" class="form-control" value="{{ tutor.cpf or '' }}"
+                 data-mask="999.999.999-99" pattern="\d{3}\.\d{3}\.\d{3}-\d{2}">
         </div>
         <div class="col-md-4">
           <label class="form-label">RG</label>
-          <input name="rg" class="form-control" value="{{ tutor.rg or '' }}">
+          <input name="rg" class="form-control" value="{{ tutor.rg or '' }}"
+                 data-mask="99.999.999-9" pattern="\d{2}\.\d{3}\.\d{3}-\d">
         </div>
         <div class="col-md-4">
           <label class="form-label">Data de Nascimento</label>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -867,6 +867,8 @@
       });
     });
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/inputmask/5.0.8/inputmask.min.js"></script>
+  <script src="{{ url_for('static', filename='masks.js') }}"></script>
   <script src="{{ url_for('static', filename='avatar_helper.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- add phone, CPF, and RG masks to tutor detail inputs
- load Inputmask library and initialize masks automatically

## Testing
- `pytest`
- `python - <<'PY'
import re
patterns = {
    'phone': r"\\(\\d{2}\\) \\d{5}-\\d{4}",
    'cpf': r"\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}",
    'rg': r"\\d{2}\\.\\d{3}\\.\\d{3}-\\d",
}
examples = {
    'phone': '(12) 34567-8901',
    'cpf': '123.456.789-01',
    'rg': '12.345.678-9'
}
for key, pat in patterns.items():
    print(key, bool(re.fullmatch(pat, examples[key])))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68beb45d68b8832e9cf157ead0d92252