### PR TITLE
feat: add search filter to tutor detail animals

### DIFF
--- a/static/js/tutor_detail.js
+++ b/static/js/tutor_detail.js
@@ -1,0 +1,15 @@
+// Filter animal rows by name in tutor detail page
+window.addEventListener('DOMContentLoaded', () => {
+  const searchInput = document.getElementById('animal-search');
+  const table = document.getElementById('animais-table');
+  if (!searchInput || !table) return;
+  searchInput.addEventListener('input', () => {
+    const query = searchInput.value.toLowerCase();
+    table.querySelectorAll('tbody tr').forEach(row => {
+      const nameEl = row.querySelector('.animal-name');
+      if (!nameEl) return;
+      const matches = nameEl.textContent.toLowerCase().includes(query);
+      row.style.display = matches ? '' : 'none';
+    });
+  });
+});

--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -118,8 +118,9 @@
         ➕ Novo Animal
       </button>
     </div>
+    <input id="animal-search" type="search" class="form-control mb-3" placeholder="Buscar animal...">
 
-    <table class="table table-hover align-middle">
+    <table id="animais-table" class="table table-hover align-middle">
       <thead>
         <tr>
           <th>Nome</th>
@@ -607,4 +608,8 @@ document.addEventListener('form-sync-success', function(ev) {
 </script>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/tutor_detail.js') }}"></script>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -868,6 +868,7 @@
     });
   </script>
   <script src="{{ url_for('static', filename='avatar_helper.js') }}"></script>
+  {# Page-specific scripts #}
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add search input to tutor detail page
- filter animal rows on client side
- document page-specific script hook

## Testing
- `pytest`
- `node <script>`

------
https://chatgpt.com/codex/tasks/task_e_68beb45e1e50832e86ff9f1fbc3233e0