### PR TITLE
Show update results with Bootstrap toasts

### DIFF
--- a/app.py
+++ b/app.py
@@ -2756,7 +2756,10 @@ def update_inventory_item(item_id):
         qty = item.quantity
     item.quantity = max(0, qty)
     db.session.commit()
-    flash('Quantidade atualizada.', 'success')
+    message = 'Quantidade atualizada.'
+    flash(message, 'success')
+    if 'application/json' in request.headers.get('Accept', ''):
+        return jsonify(success=True, message=message, category='success', quantity=item.quantity)
     return redirect(url_for('clinic_detail', clinica_id=clinica.id) + '#estoque')
 
 
@@ -3333,9 +3336,9 @@ def update_tutor(user_id):
     # 🔐 Permissão: veterinários ou colaboradores
     if current_user.worker not in ['veterinario', 'colaborador']:
         message = 'Apenas veterinários ou colaboradores podem editar dados do tutor.'
-        if wants_json:
-            return jsonify(success=False, message=message), 403
         flash(message, 'danger')
+        if wants_json:
+            return jsonify(success=False, message=message, category='danger'), 403
         return redirect(request.referrer or url_for('index'))
 
     # 📋 Campos básicos (exceto CPF)
@@ -3352,9 +3355,9 @@ def update_tutor(user_id):
             existing = User.query.filter(User.cpf == cpf_val, User.id != user.id).first()
             if existing:
                 message = 'CPF já cadastrado para outro tutor.'
-                if wants_json:
-                    return jsonify(success=False, message=message), 400
                 flash(message, 'danger')
+                if wants_json:
+                    return jsonify(success=False, message=message, category='danger'), 400
                 return redirect(request.referrer or url_for('index'))
         user.cpf = cpf_val
 
@@ -3365,9 +3368,9 @@ def update_tutor(user_id):
             user.date_of_birth = datetime.strptime(date_str, '%Y-%m-%d').date()
         except ValueError:
             message = 'Data de nascimento inválida. Use o formato correto.'
-            if wants_json:
-                return jsonify(success=False, message=message), 400
             flash(message, 'danger')
+            if wants_json:
+                return jsonify(success=False, message=message, category='danger'), 400
             return redirect(request.referrer or url_for('index'))
 
     # 📸 Foto de perfil
@@ -3414,9 +3417,9 @@ def update_tutor(user_id):
             user.endereco_id = endereco.id
     elif any(addr_fields.values()):
         message = 'Por favor, informe CEP, rua, cidade e estado.'
-        if wants_json:
-            return jsonify(success=False, message=message), 400
         flash(message, 'warning')
+        if wants_json:
+            return jsonify(success=False, message=message, category='warning'), 400
         return redirect(request.referrer or url_for('index'))
 
     # 💾 Commit final
@@ -3426,15 +3429,15 @@ def update_tutor(user_id):
         db.session.rollback()
         print(f"❌ ERRO ao salvar tutor: {e}")
         message = f'Ocorreu um erro ao salvar: {str(e)}'
-        if wants_json:
-            return jsonify(success=False, message=message), 500
         flash(message, 'danger')
+        if wants_json:
+            return jsonify(success=False, message=message, category='danger'), 500
         return redirect(request.referrer or url_for('index'))
 
     message = 'Dados do tutor atualizados com sucesso!'
-    if wants_json:
-        return jsonify(success=True, message=message, tutor_name=user.name)
     flash(message, 'success')
+    if wants_json:
+        return jsonify(success=True, message=message, tutor_name=user.name, category='success')
     return redirect(request.referrer or url_for('index'))
 
 
@@ -3507,9 +3510,9 @@ def update_animal(animal_id):
 
     if current_user.worker != 'veterinario':
         message = 'Apenas veterinários podem editar dados do animal.'
-        if wants_json:
-            return jsonify(success=False, message=message), 403
         flash(message, 'danger')
+        if wants_json:
+            return jsonify(success=False, message=message, category='danger'), 403
         return redirect(request.referrer or url_for('index'))
 
     # Campos básicos
@@ -3593,15 +3596,15 @@ def update_animal(animal_id):
     except Exception as e:
         db.session.rollback()
         message = f'Ocorreu um erro ao salvar: {str(e)}'
-        if wants_json:
-            return jsonify(success=False, message=message), 500
         flash(message, 'danger')
+        if wants_json:
+            return jsonify(success=False, message=message, category='danger'), 500
         return redirect(request.referrer or url_for('index'))
 
     message = 'Dados do animal atualizados com sucesso!'
-    if wants_json:
-        return jsonify(success=True, message=message, animal_name=animal.name)
     flash(message, 'success')
+    if wants_json:
+        return jsonify(success=True, message=message, animal_name=animal.name, category='success')
     return redirect(request.referrer or url_for('index'))
 
 
@@ -3612,8 +3615,13 @@ def update_animal(animal_id):
 def update_consulta(consulta_id):
     consulta = get_consulta_or_404(consulta_id)
 
+    wants_json = 'application/json' in request.headers.get('Accept', '')
+
     if current_user.worker != 'veterinario':
-        flash('Apenas veterinários podem editar a consulta.', 'danger')
+        message = 'Apenas veterinários podem editar a consulta.'
+        flash(message, 'danger')
+        if wants_json:
+            return jsonify(success=False, message=message, category='danger'), 403
         return redirect(url_for('index'))
 
     # Atualiza os campos
@@ -3645,7 +3653,7 @@ def update_consulta(consulta_id):
         message = 'Consulta salva e movida para o histórico!'
         flash(message, 'success')
 
-    if 'application/json' in request.headers.get('Accept', ''):
+    if wants_json:
         historico = (
             Consulta.query
             .filter_by(
@@ -3661,7 +3669,7 @@ def update_consulta(consulta_id):
             animal=consulta.animal,
             historico_consultas=historico,
         )
-        return jsonify(success=True, message=message, html=html)
+        return jsonify(success=True, message=message, category='success', html=html)
 
     return redirect(url_for('consulta_direct', animal_id=consulta.animal_id))
 

--- a/static/offline.js
+++ b/static/offline.js
@@ -109,6 +109,10 @@
     if (resp) {
       let json = null;
       try { json = await resp.json(); } catch(e) {}
+      if (json && json.message) {
+        const category = json.category || (json.success === false || !resp.ok ? 'danger' : 'success');
+        showToast(json.message, category);
+      }
       const evt = new CustomEvent('form-sync-success', {detail: {form, data: json, response: resp}, cancelable: true});
       document.dispatchEvent(evt);
       if (!evt.defaultPrevented) {
@@ -129,7 +133,6 @@
         const cont=document.getElementById('tutores-adicionados');
         if(cont) cont.innerHTML=data.html;
       }
-      showToast(data.message || 'Tutor criado com sucesso', data.category || 'success');
       form.reset();
       const btn=form.querySelector('button[type="submit"]');
       if(btn && btn.dataset.original){
@@ -142,7 +145,6 @@
         const cont=document.getElementById('animais-adicionados');
         if(cont) cont.innerHTML=data.html;
       }
-      showToast(data.message || 'Animal cadastrado com sucesso', data.category || 'success');
       form.reset();
       const btn=form.querySelector('button[type="submit"]');
       if(btn && btn.dataset.original){

--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -559,15 +559,6 @@ document.addEventListener('form-sync-success', function(ev) {
     btn.disabled = false;
   }
 
-  const toastEl = document.getElementById('actionToast');
-  if (toastEl) {
-    const success = !(data && data.success === false);
-    const msg = (data && (data.message || data.error)) || (success ? 'Dados salvos!' : 'Erro ao salvar');
-    toastEl.querySelector('.toast-body').textContent = msg;
-    toastEl.classList.remove('bg-danger', 'bg-info', 'bg-success');
-    toastEl.classList.add(success ? 'bg-success' : 'bg-danger');
-    bootstrap.Toast.getOrCreateInstance(toastEl).show();
-  }
 
   if (form.id === 'tutor-form') {
     ev.preventDefault();

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -514,16 +514,6 @@
 
     <!-- Main Content -->
     <main class="container">
-        {% for category, message in flash_messages %}
-            <div class="alert-container">
-                <div class="alert alert-{{ category }} alert-dismissible fade show mt-3" role="alert">
-                    <i class="fas fa-{% if category == 'success' %}check-circle{% elif category == 'danger' %}exclamation-circle{% elif category == 'warning' %}exclamation-triangle{% else %}info-circle{% endif %} me-2"></i>
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-                </div>
-            </div>
-        {% endfor %}
-
         {% block main %}
         {% endblock %}
     </main>
@@ -548,14 +538,16 @@
         </div>
     </div>
 
-    <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
+    {% block messages %}
+    <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11" aria-live="polite" aria-atomic="true">
         <div id="actionToast" class="toast text-white border-0" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="d-flex">
                 <div class="toast-body"></div>
-                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Fechar"></button>
             </div>
         </div>
     </div>
+    {% endblock %}
 
     <!-- Script para desaparecer com transição suave -->
     <script>


### PR DESCRIPTION
## Summary
- use flash messages in update handlers and include categories in JSON replies
- add reusable toast block to layout with accessibility attributes
- display server feedback after AJAX data-sync submits via global toast

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beb45efa44832eaa2b897584f0794f