### PR TITLE
Add client-side animal search for tutor page

### DIFF
--- a/static/js/tutor_detail.js
+++ b/static/js/tutor_detail.js
@@ -1,0 +1,18 @@
+// Filter animals list by name without page reload
+
+document.addEventListener('DOMContentLoaded', () => {
+  const searchInput = document.getElementById('animal-search');
+  const table = document.getElementById('animals-table');
+  if (!searchInput || !table) return;
+
+  const rows = table.querySelectorAll('tbody tr');
+
+  searchInput.addEventListener('input', () => {
+    const term = searchInput.value.toLowerCase();
+    rows.forEach(row => {
+      const nameCell = row.querySelector('.animal-name');
+      const name = nameCell ? nameCell.textContent.toLowerCase() : '';
+      row.style.display = name.includes(term) ? '' : 'none';
+    });
+  });
+});

--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -125,8 +125,9 @@
               ➕ Novo Animal
             </button>
           </div>
+          <input id="animal-search" type="search" class="form-control mb-3" placeholder="Buscar animal">
 
-    <table class="table table-hover align-middle">
+    <table id="animals-table" class="table table-hover align-middle">
       <thead>
         <tr>
           <th>Nome</th>
@@ -607,4 +608,9 @@ document.addEventListener('form-sync-success', function(ev) {
 </script>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/tutor_detail.js') }}"></script>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -862,6 +862,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/inputmask/5.0.8/inputmask.min.js"></script>
   <script src="{{ url_for('static', filename='masks.js') }}"></script>
   <script src="{{ url_for('static', filename='avatar_helper.js') }}"></script>
+  <!-- Page specific scripts -->
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add search input on tutor detail to filter animals
- load dedicated script via layout block
- implement JS filtering logic

## Testing
- `pytest`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68beb9c77058832e946bba83a3d11604