### PR TITLE
Show agenda on collaborator home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -91,7 +91,7 @@
                     👥 Tutores
                 </a>
 
-                {% if current_user.worker == 'veterinario' and current_user.veterinario %}
+                {% if (current_user.worker == 'veterinario' and current_user.veterinario) or current_user.worker == 'colaborador' %}
                 <a href="{{ url_for('appointments') }}"
                    class="btn btn-outline-warning rounded-pill shadow-sm px-4 py-2"
                    data-bs-toggle="tooltip" title="Administre sua agenda de atendimentos.">


### PR DESCRIPTION
## Summary
- Allow collaborators to access agenda from home page professional section

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bebcf13fb4832e94b070325a7c8438