### PR TITLE
Display veterinarian available times in appointment modal

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -119,11 +119,13 @@
             <div class="row">
               <div class="col-md-6 mb-3">
                 {{ appointment_form.date.label(class="form-label fw-bold") }}
-                {{ appointment_form.date(class="form-control", type="date") }}
+                {{ appointment_form.date(class="form-control", type="date", id="appointment-date") }}
               </div>
               <div class="col-md-6 mb-3">
                 {{ appointment_form.time.label(class="form-label fw-bold") }}
-                {{ appointment_form.time(class="form-control", type="time") }}
+                <select id="appointment-time" name="time" class="form-select">
+                  <option value="">Selecione...</option>
+                </select>
               </div>
             </div>
             <div class="mb-3">
@@ -489,7 +491,28 @@
   function toggleAppointmentForm() {
     const modal = new bootstrap.Modal(document.getElementById('appointmentModalForm'));
     modal.show();
+    updateAppointmentTimes();
   }
+
+  async function updateAppointmentTimes() {
+    const date = document.getElementById('appointment-date').value;
+    const select = document.getElementById('appointment-time');
+    if (!date) {
+      select.innerHTML = '<option value="">Selecione...</option>';
+      return;
+    }
+    const resp = await fetch(`/api/specialist/{{ veterinario.id }}/available_times?date=${date}`);
+    const times = await resp.json();
+    select.innerHTML = '<option value="">Selecione...</option>';
+    times.forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      opt.textContent = t;
+      select.appendChild(opt);
+    });
+  }
+
+  document.getElementById('appointment-date').addEventListener('change', updateAppointmentTimes);
 
   function toggleScheduleEdit() {
     document.querySelectorAll('.schedule-actions').forEach(el => {


### PR DESCRIPTION
## Summary
- Show only free slots when scheduling a consultation with a veterinarian
- Fetch available times via API and populate dropdown in appointment form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bec065cea0832e83b198b94c931f07