### PR TITLE
Align clinic appointment buttons with site-wide style

### DIFF
--- a/templates/partials/appointments_table.html
+++ b/templates/partials/appointments_table.html
@@ -67,16 +67,6 @@
         .status-completed { background-color: #e6faf3; color: var(--success-color); }
         .status-canceled { background-color: #fce8e6; color: var(--danger-color); }
         
-        .btn-icon {
-            width: 36px;
-            height: 36px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 50%;
-            margin: 0 3px;
-        }
-        
         .time-display {
             font-size: 1.1rem;
             font-weight: 600;
@@ -172,49 +162,45 @@
                                 </div>
                                 <div class="col-md-3">
                                     <div class="actions-container">
-                                        <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-icon btn-primary" title="Ficha do Animal">
-                                            <i class="fa-solid fa-file-medical"></i>
+                                        <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary" title="Ficha do Animal">
+                                            <i class="fa-solid fa-file-medical me-1"></i>Ficha do Animal
                                         </a>
-                                        <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-icon btn-secondary" title="Ficha do Tutor">
-                                            <i class="fa-solid fa-user"></i>
+                                        <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary" title="Ficha do Tutor">
+                                            <i class="fa-solid fa-user me-1"></i>Ficha do Tutor
                                         </a>
                                         {% if current_user.worker in ['veterinario', 'colaborador'] %}
-                                        <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-icon btn-success" title="Iniciar Consulta">
-                                            <i class="fa-solid fa-stethoscope"></i>
+                                        <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success" title="Iniciar Consulta">
+                                            <i class="fa-solid fa-stethoscope me-1"></i>Iniciar Consulta
                                         </a>
                                         {% endif %}
-                                        <a href="{{ url_for('edit_appointment', appointment_id=appt.id) }}" class="btn btn-icon btn-info" title="Propor novo horário">
-                                            <i class="fa-solid fa-arrows-rotate"></i>
+                                        <a href="{{ url_for('edit_appointment', appointment_id=appt.id) }}" class="btn btn-sm btn-outline-info" title="Propor novo horário">
+                                            <i class="fa-solid fa-arrows-rotate me-1"></i>Propor novo horário
                                         </a>
-                                        
                                         <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
                                             {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
                                             <input type="hidden" name="status" value="completed">
-                                            <button class="btn btn-icon btn-success" title="Marcar como realizada">
-                                                <i class="fa-solid fa-check"></i>
+                                            <button class="btn btn-sm btn-outline-success" title="Marcar como realizada">
+                                                <i class="fa-solid fa-check me-1"></i>Realizada
                                             </button>
                                         </form>
-                                        
                                         <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
                                             {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
                                             <input type="hidden" name="status" value="canceled">
-                                            <button class="btn btn-icon btn-warning" title="Cancelar">
-                                                <i class="fa-solid fa-xmark"></i>
+                                            <button class="btn btn-sm btn-outline-warning" title="Cancelar">
+                                                <i class="fa-solid fa-xmark me-1"></i>Cancelar
                                             </button>
                                         </form>
-                                        
                                         <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
                                             {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
                                             <input type="hidden" name="status" value="scheduled">
-                                            <button class="btn btn-icon btn-secondary" title="Marcar como a fazer">
-                                                <i class="fa-solid fa-clock"></i>
+                                            <button class="btn btn-sm btn-outline-secondary" title="Marcar como a fazer">
+                                                <i class="fa-solid fa-clock me-1"></i>A fazer
                                             </button>
                                         </form>
-                                        
                                         <form method="POST" action="{{ url_for('delete_appointment', appointment_id=appt.id) }}" class="form-confirm" data-confirm="Excluir este agendamento?">
                                             {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
-                                            <button class="btn btn-icon btn-danger" title="Excluir">
-                                                <i class="fa-solid fa-trash"></i>
+                                            <button class="btn btn-sm btn-outline-danger" title="Excluir">
+                                                <i class="fa-solid fa-trash me-1"></i>Excluir
                                             </button>
                                         </form>
                                     </div>


### PR DESCRIPTION
## Summary
- replace circular icon buttons in clinic appointment tab with standard outline buttons
- remove custom `btn-icon` styling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec0fe07b8832e838e469ba1abd728