### PR TITLE
Allow scheduling without health plan and show available times

### DIFF
--- a/app.py
+++ b/app.py
@@ -7102,7 +7102,12 @@ def appointments():
             else:
                 animal = get_animal_or_404(appointment_form.animal_id.data)
                 tutor_id = animal.user_id
-                if not Appointment.has_active_subscription(animal.id, tutor_id):
+                requires_plan = current_app.config.get(
+                    'REQUIRE_HEALTH_SUBSCRIPTION_FOR_APPOINTMENT', False
+                )
+                if requires_plan and not Appointment.has_active_subscription(
+                    animal.id, tutor_id
+                ):
                     flash(
                         'O animal não possui uma assinatura de plano de saúde ativa.',
                         'danger',
@@ -7287,7 +7292,12 @@ def appointments():
                     else:
                         animal = get_animal_or_404(appointment_form.animal_id.data)
                         tutor_id = animal.user_id
-                        if not Appointment.has_active_subscription(animal.id, tutor_id):
+                        requires_plan = current_app.config.get(
+                            'REQUIRE_HEALTH_SUBSCRIPTION_FOR_APPOINTMENT', False
+                        )
+                        if requires_plan and not Appointment.has_active_subscription(
+                            animal.id, tutor_id
+                        ):
                             flash(
                                 'O animal não possui uma assinatura de plano de saúde ativa.',
                                 'danger',

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -50,7 +50,8 @@
             </div>
             <div class="col-md-6">
               {{ form.time.label(class="form-label fw-semibold") }}
-              {{ form.time(class="form-control", type="time") }}
+              {{ form.time(class="form-control", type="time", list="available-times") }}
+              <datalist id="available-times"></datalist>
             </div>
           </div>
 
@@ -156,4 +157,29 @@
 {% block scripts %}
 {{ super() }}
 <script src="{{ url_for('static', filename='appointments_table.js') }}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const vetField = document.getElementById('veterinario_id');
+  const dateField = document.getElementById('date');
+  const datalist = document.getElementById('available-times');
+
+  async function updateTimes() {
+    if (!vetField || !dateField || !datalist) return;
+    const vetId = vetField.value;
+    const date = dateField.value;
+    if (!vetId || !date) return;
+    const resp = await fetch(`/api/specialist/${vetId}/available_times?date=${date}`);
+    const times = await resp.json();
+    datalist.innerHTML = '';
+    times.forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      datalist.appendChild(opt);
+    });
+  }
+
+  vetField && vetField.addEventListener('change', updateTimes);
+  dateField && dateField.addEventListener('change', updateTimes);
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Skip health plan check unless config flag requires it, allowing any animal to be scheduled
- Populate appointment form with veterinarian's available times for chosen date

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bec2a05aa0832ebb8ddc3fda216a7d