### PR TITLE
Include vet workers without records in clinic staff list

### DIFF
--- a/app.py
+++ b/app.py
@@ -2542,7 +2542,7 @@ def clinic_detail(clinica_id):
     veterinarios = Veterinario.query.filter_by(clinica_id=clinica_id).all()
     staff_members = ClinicStaff.query.filter(
         ClinicStaff.clinic_id == clinica.id,
-        ClinicStaff.user.has(or_(User.worker != 'veterinario', User.worker.is_(None))),
+        ClinicStaff.user.has(User.veterinario == None),
     ).all()
 
     staff_permission_forms = {}


### PR DESCRIPTION
## Summary
- Show clinic staff members whose worker type is 'veterinario' when they lack a Veterinario record
- Add regression test for vet workers without Veterinario record

## Testing
- `pytest tests/test_clinic_staff_permissions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec5c2d5bc832e9b4172cbf435d59d