### PR TITLE
Render flash messages with responsive alert fallback

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -170,23 +170,33 @@
 
         /* Alert Styles */
         .alert-container {
+            width: 90%;
+            max-width: 600px;
+            margin: 1rem auto;
             overflow: hidden;
             transition: max-height 0.6s ease, opacity 0.6s ease, margin 0.6s ease;
             max-height: 200px;
             opacity: 1;
-            margin-bottom: 1rem;
         }
 
         .alert-container.shrink {
             max-height: 0;
             opacity: 0;
-            margin-bottom: 0;
+            margin: 0 auto;
         }
 
         .alert {
+            position: relative;
             border-radius: 8px;
             padding: 15px 20px;
+            padding-right: 2.5rem;
             box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+        }
+
+        .alert .btn-close {
+            position: absolute;
+            top: 10px;
+            right: 10px;
         }
 
         /* Button Styles */
@@ -511,6 +521,17 @@
             </div>
         </div>
     </nav>
+
+    {% if flash_messages %}
+        {% for category, message in flash_messages %}
+            <div class="alert-container">
+                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                    {{ message }}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+            </div>
+        {% endfor %}
+    {% endif %}
 
     <!-- Main Content -->
     <main class="container">


### PR DESCRIPTION
## Summary
- show flash messages in dismissible Bootstrap alerts as a visible fallback to notifications
- keep Notification API script as optional enhancement
- adjust alert styles for responsiveness and close button positioning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec5ca14c4832eb034ee0c2f1ee32e