### PR TITLE
Add clinic veterinarian creation form and route

### DIFF
--- a/templates/partials/clinic_veterinarios_tab.html
+++ b/templates/partials/clinic_veterinarios_tab.html
@@ -203,9 +203,10 @@
             </tbody>
           </table>
         </div>
-        {% if pode_editar and vets_form.veterinario_id.choices %}
+        {% if pode_editar %}
         <button class="btn btn-secondary mt-3" onclick="toggleAddVet()">Adicionar Veterinário</button>
         <div id="add-vet" class="mt-3" style="display:none;">
+          {% if vets_form.veterinario_id.choices %}
           <form method="post" class="mb-4">
             {{ vets_form.hidden_tag() }}
             <div class="mb-3">
@@ -213,6 +214,23 @@
               {{ vets_form.veterinario_id(class="form-select") }}
             </div>
             {{ vets_form.submit(class="btn btn-primary") }}
+          </form>
+          <hr>
+          {% endif %}
+          <form method="post" action="{{ url_for('create_clinic_veterinario', clinica_id=clinica.id) }}" class="mb-4">
+            <div class="mb-3">
+              <label for="vet-name" class="form-label">Nome</label>
+              <input type="text" id="vet-name" name="name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label for="vet-email" class="form-label">E-mail</label>
+              <input type="email" id="vet-email" name="email" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <label for="vet-crmv" class="form-label">CRMV</label>
+              <input type="text" id="vet-crmv" name="crmv" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary">Cadastrar</button>
           </form>
         </div>
         {% endif %}


### PR DESCRIPTION
## Summary
- allow clinic owners to create veterinarians by name, email, and CRMV
- render inline vet creation form in clinic veterinarians tab with duplicate validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec745a900832eb2bbeb438e367ac1