### PR TITLE
fix: remove DataTable from employee list

### DIFF
--- a/templates/partials/clinic_veterinarios_tab.html
+++ b/templates/partials/clinic_veterinarios_tab.html
@@ -239,11 +239,6 @@
         <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
         <script>
           $(document).ready(function() {
-            $('#employee-list').DataTable({
-              paging: false,
-              searching: false,
-              info: false
-            });
             $('#staff-list').DataTable();
           });
         </script>


### PR DESCRIPTION
## Summary
- avoid DataTable initialization on employee list to prevent column count warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68becf11b6b4832ea987b68429b7c197