### PR TITLE
Fix DataTables column count warning in staff list

### DIFF
--- a/templates/partials/clinic_veterinarios_tab.html
+++ b/templates/partials/clinic_veterinarios_tab.html
@@ -89,6 +89,11 @@
         </div>
         <div class="table-responsive">
           <table id="staff-list" class="table table-striped">
+            <thead>
+              <tr>
+                <th>Veterinário</th>
+              </tr>
+            </thead>
             <tbody>
               {% for v in veterinarios %}
               <tr data-name="{{ v.user.name|lower }}" data-role="{{ v.user.worker or '' }}">


### PR DESCRIPTION
## Summary
- add explicit header to staff DataTable to align column count

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bed18f4014832eaeb33c62f9b3959f