### PR TITLE
feat: add weekly veterinarian schedule overview

### DIFF
--- a/app.py
+++ b/app.py
@@ -260,6 +260,7 @@ from helpers import (
     group_vet_schedules_by_day,
     appointments_to_events,
     get_available_times,
+    get_weekly_schedule,
 )
 
 
@@ -7688,6 +7689,15 @@ def api_specialist_available_times(veterinario_id):
     date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
     times = get_available_times(veterinario_id, date_obj)
     return jsonify(times)
+
+
+@app.route('/api/specialist/<int:veterinario_id>/weekly_schedule')
+def api_specialist_weekly_schedule(veterinario_id):
+    start_str = request.args.get('start')
+    days = int(request.args.get('days', 7))
+    start_date = datetime.strptime(start_str, '%Y-%m-%d').date() if start_str else date.today()
+    data = get_weekly_schedule(veterinario_id, start_date, days)
+    return jsonify(data)
 
 
 @app.route('/animal/<int:animal_id>/schedule_exam', methods=['POST'])

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -69,6 +69,15 @@
             {{ form.submit(class="btn btn-success btn-lg rounded-pill") }}
           </div>
         </form>
+        <div class="mt-4">
+          <h6 class="fw-bold"><i class="bi bi-calendar3 me-2"></i>Disponibilidade do Veterinário</h6>
+          <div id="schedule-overview" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 small"></div>
+          <div class="mt-2 small">
+            <span class="badge bg-success me-1">&nbsp;</span> Disponível
+            <span class="badge bg-danger ms-2 me-1">&nbsp;</span> Ocupado
+            <span class="badge bg-secondary ms-2 me-1">&nbsp;</span> Não trabalha
+          </div>
+        </div>
         {% endif %}
       </div>
     </div>
@@ -162,6 +171,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const vetField = document.getElementById('veterinario_id');
   const dateField = document.getElementById('date');
   const datalist = document.getElementById('available-times');
+  const scheduleContainer = document.getElementById('schedule-overview');
 
   async function updateTimes() {
     if (!vetField || !dateField || !datalist) return;
@@ -178,8 +188,52 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  vetField && vetField.addEventListener('change', updateTimes);
-  dateField && dateField.addEventListener('change', updateTimes);
+  function badge(text, cls) {
+    const span = document.createElement('span');
+    span.className = `badge ${cls} me-1 mb-1`;
+    span.textContent = text;
+    return span;
+  }
+
+  async function loadSchedule() {
+    if (!vetField || !scheduleContainer) return;
+    const vetId = vetField.value;
+    if (!vetId) { scheduleContainer.innerHTML = ''; return; }
+    const start = dateField && dateField.value ? dateField.value : new Date().toISOString().split('T')[0];
+    const resp = await fetch(`/api/specialist/${vetId}/weekly_schedule?start=${start}`);
+    const days = await resp.json();
+    scheduleContainer.innerHTML = '';
+    days.forEach(day => {
+      const col = document.createElement('div');
+      col.className = 'col';
+      const card = document.createElement('div');
+      card.className = 'card h-100';
+      const body = document.createElement('div');
+      body.className = 'card-body';
+      const title = document.createElement('h6');
+      title.className = 'card-title fw-bold';
+      title.textContent = new Date(day.date).toLocaleDateString('pt-BR', { weekday: 'short', day: '2-digit', month: '2-digit' });
+      body.appendChild(title);
+      const slots = document.createElement('div');
+      day.available.forEach(t => slots.appendChild(badge(t, 'bg-success')));
+      day.booked.forEach(t => slots.appendChild(badge(t, 'bg-danger')));
+      day.not_working.forEach(t => slots.appendChild(badge(t, 'bg-secondary')));
+      if (!slots.children.length) {
+        const span = document.createElement('span');
+        span.className = 'text-muted small';
+        span.textContent = 'Folga';
+        slots.appendChild(span);
+      }
+      body.appendChild(slots);
+      card.appendChild(body);
+      col.appendChild(card);
+      scheduleContainer.appendChild(col);
+    });
+  }
+
+  vetField && vetField.addEventListener('change', () => { updateTimes(); loadSchedule(); });
+  dateField && dateField.addEventListener('change', () => { updateTimes(); loadSchedule(); });
+  loadSchedule();
 });
 </script>
 {% endblock %}

--- a/tests/test_weekly_schedule_api.py
+++ b/tests/test_weekly_schedule_api.py
@@ -1,0 +1,65 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from datetime import datetime, time, date
+from zoneinfo import ZoneInfo
+from app import app as flask_app, db
+from models import User, Animal, Veterinario, Clinica, VetSchedule, Appointment
+from helpers import BR_TZ
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def test_weekly_schedule_api_returns_slots(client):
+    with flask_app.app_context():
+        clinic = Clinica(id=1, nome="Clinica")
+        tutor = User(id=1, name="Tutor", email="tutor@test")
+        tutor.set_password("x")
+        animal = Animal(id=1, name="Rex", user_id=tutor.id, clinica_id=clinic.id)
+        vet_user = User(id=2, name="Vet", email="vet@test", worker="veterinario")
+        vet_user.set_password("x")
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv="123", clinica_id=clinic.id)
+        schedule = VetSchedule(
+            id=1,
+            veterinario_id=1,
+            dia_semana="Segunda",
+            hora_inicio=time(9, 0),
+            hora_fim=time(11, 0),
+        )
+        appt_time_local = datetime(2024, 5, 6, 9, 30, tzinfo=BR_TZ)
+        appt_time = appt_time_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+        appt = Appointment(
+            id=1,
+            veterinario_id=1,
+            tutor_id=tutor.id,
+            animal_id=animal.id,
+            clinica_id=clinic.id,
+            scheduled_at=appt_time,
+            status="scheduled",
+        )
+        db.session.add_all([clinic, tutor, animal, vet_user, vet, schedule, appt])
+        db.session.commit()
+
+    resp = client.get("/api/specialist/1/weekly_schedule?start=2024-05-06&days=1")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data[0]["date"] == "2024-05-06"
+    assert "09:00" in data[0]["available"]
+    assert "09:30" in data[0]["booked"]
+    assert "08:00" in data[0]["not_working"]


### PR DESCRIPTION
## Summary
- expose weekly schedule API for veterinarians
- display available, booked and off slots when scheduling appointments
- cover weekly schedule endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed222b5ec832e98fc1d4c1f61ccba