### PR TITLE
Handle empty vet schedule submissions

### DIFF
--- a/app.py
+++ b/app.py
@@ -7108,7 +7108,7 @@ def appointments():
                 ):
                     flash(f'Conflito de horário em {dia}.', 'danger')
                     return redirect(url_for('appointments'))
-
+            added = False
             for dia in schedule_form.dias_semana.data:
                 if has_schedule_conflict(
                     schedule_form.veterinario_id.data,
@@ -7131,6 +7131,8 @@ def appointments():
             if added:
                 db.session.commit()
                 flash('Horário salvo com sucesso.', 'success')
+            else:
+                flash('Nenhum novo horário foi salvo.', 'info')
             return redirect(url_for('appointments'))
         if appointment_form.submit.data and appointment_form.validate_on_submit():
             scheduled_at_local = datetime.combine(


### PR DESCRIPTION
## Summary
- Track whether vet schedule slots were actually saved
- Flash info message when no new schedule slots are created

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed71ba6d0832e8c3ae261fd8243e8