### PR TITLE
feat: support veterinarians in multiple clinics

### DIFF
--- a/models.py
+++ b/models.py
@@ -600,6 +600,11 @@ class Clinica(db.Model):
     owner = db.relationship('User', backref=db.backref('clinicas', foreign_keys='Clinica.owner_id'), foreign_keys=[owner_id])
 
     veterinarios = db.relationship('Veterinario', backref='clinica', lazy=True)
+    veterinarios_associados = db.relationship(
+        'Veterinario',
+        secondary='veterinario_clinica',
+        back_populates='clinicas',
+    )
     eventos = db.relationship(
         'AgendaEvento',
         back_populates='clinica',
@@ -687,6 +692,13 @@ veterinario_especialidade = db.Table(
     db.Column('specialty_id', db.Integer, db.ForeignKey('specialty.id'), primary_key=True)
 )
 
+# Associação many-to-many entre veterinário e clínica
+veterinario_clinica = db.Table(
+    'veterinario_clinica',
+    db.Column('veterinario_id', db.Integer, db.ForeignKey('veterinario.id'), primary_key=True),
+    db.Column('clinica_id', db.Integer, db.ForeignKey('clinica.id'), primary_key=True),
+)
+
 
 class Specialty(db.Model):
     __tablename__ = 'specialty'
@@ -708,6 +720,11 @@ class Veterinario(db.Model):
 
     user = db.relationship('User', back_populates='veterinario', uselist=False)
     specialties = db.relationship('Specialty', secondary='veterinario_especialidade', backref='veterinarios')
+    clinicas = db.relationship(
+        'Clinica',
+        secondary='veterinario_clinica',
+        back_populates='veterinarios_associados',
+    )
 
     @property
     def specialty_list(self):

--- a/tests/test_vet_multi_clinic.py
+++ b/tests/test_vet_multi_clinic.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import pytest
+
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import app as flask_app, db
+from models import User, Veterinario, Clinica
+
+
+@pytest.fixture
+def app_context():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.app_context():
+        db.session.remove()
+        db.create_all()
+        yield
+        db.session.remove()
+        db.drop_all()
+
+
+def test_veterinario_pode_participar_de_multiplas_clinicas(app_context):
+    user = User(name="Vet", email="vet@example.com", password_hash="x", worker="veterinario")
+    vet = Veterinario(user=user, crmv="123")
+    c1 = Clinica(nome="Clinica 1")
+    c2 = Clinica(nome="Clinica 2")
+    vet.clinicas.extend([c1, c2])
+    db.session.add_all([user, vet, c1, c2])
+    db.session.commit()
+
+    assert {c.nome for c in vet.clinicas} == {"Clinica 1", "Clinica 2"}
+    assert vet in c1.veterinarios_associados
+    assert vet in c2.veterinarios_associados


### PR DESCRIPTION
## Summary
- allow clinics to maintain many-to-many associations with veterinarians
- add regression test for veterinarians linked to more than one clinic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bedeb3af00832e9c719aef79706580