### PR TITLE
feat: add responsive form and table components

### DIFF
--- a/static/js/mobile.js
+++ b/static/js/mobile.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('table').forEach(table => {
+    if (!table.closest('.table-responsive')) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'table-responsive';
+      table.parentNode.insertBefore(wrapper, table);
+      wrapper.appendChild(table);
+    }
+  });
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,14 @@
+/* Estilos adicionais para responsividade */
+@media (max-width: 576px) {
+  .form-control, .form-select {
+    font-size: 1rem;
+  }
+  .btn {
+    font-size: 1rem;
+  }
+}
+
+/* Garante que tabelas sempre possam rolar em telas pequenas */
+.table-responsive {
+  overflow-x: auto;
+}

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% from 'components/form_macros.html' import render_field, render_checkbox, render_submit %}
 
 {% block main %}
 <div class="container d-flex justify-content-center align-items-center mt-5">
@@ -6,35 +7,13 @@
         <h3 class="mb-4 text-center">🔐 Entrar na PetOrlândia</h3>
         <form method="POST" class="js-auth-form">
             {{ form.hidden_tag() }}
-
-            <div class="mb-3">
-                {{ form.email.label(class="form-label") }}
-                {{ form.email(class="form-control rounded-pill") }}
-                {% for error in form.email.errors %}
-                    <div class="text-danger">{{ error }}</div>
-                {% endfor %}
-            </div>
-
-            <div class="mb-3">
-                {{ form.password.label(class="form-label") }}
-                {{ form.password(class="form-control rounded-pill") }}
-                {% for error in form.password.errors %}
-                    <div class="text-danger">{{ error }}</div>
-                {% endfor %}
-            </div>
-
-            <div class="mb-3 form-check">
-                {{ form.remember(class="form-check-input") }}
-                {{ form.remember.label(class="form-check-label") }}
-            </div>
-
-            <div class="d-grid">
-                {{ form.submit(class="btn btn-primary rounded-pill py-2") }}
-            </div>
+            {{ render_field(form.email, classes='form-control rounded-pill') }}
+            {{ render_field(form.password, classes='form-control rounded-pill') }}
+            {{ render_checkbox(form.remember) }}
+            {{ render_submit(form.submit, classes='btn btn-primary rounded-pill py-2') }}
             <div class="text-center mt-3">
                 <a href="{{ url_for('reset_password_request') }}" class="text-decoration-none">Esqueceu sua senha?</a>
             </div>
-
         </form>
     </div>
 </div>

--- a/templates/components/form_macros.html
+++ b/templates/components/form_macros.html
@@ -1,0 +1,22 @@
+{% macro render_field(field, type='text', label=None, placeholder='', classes='form-control') %}
+<div class="mb-3">
+  <label for="{{ field.id }}" class="form-label">{{ label if label is not none else field.label.text }}</label>
+  {{ field(class=classes, id=field.id, placeholder=placeholder, type=type) }}
+  {% for error in field.errors %}
+  <div class="text-danger">{{ error }}</div>
+  {% endfor %}
+</div>
+{% endmacro %}
+
+{% macro render_checkbox(field, label=None, classes='form-check-input') %}
+<div class="mb-3 form-check">
+  {{ field(class=classes, id=field.id) }}
+  <label for="{{ field.id }}" class="form-check-label">{{ label if label is not none else field.label.text }}</label>
+</div>
+{% endmacro %}
+
+{% macro render_submit(field, classes='btn btn-primary w-100') %}
+<div class="d-grid">
+  {{ field(class=classes) }}
+</div>
+{% endmacro %}

--- a/templates/components/table_macros.html
+++ b/templates/components/table_macros.html
@@ -1,0 +1,14 @@
+{% macro render_table(headers) %}
+<div class="table-responsive">
+  <table class="table table-striped align-middle">
+    <thead>
+      <tr>
+        {% for h in headers %}<th>{{ h }}</th>{% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {{ caller() }}
+    </tbody>
+  </table>
+</div>
+{% endmacro %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -25,6 +25,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
     <link href="{{ url_for('static', filename='images.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='styles.css') }}" rel="stylesheet">
 
     <style>
         :root {
@@ -891,6 +892,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/inputmask/5.0.8/inputmask.min.js"></script>
   <script src="{{ url_for('static', filename='masks.js') }}"></script>
   <script src="{{ url_for('static', filename='avatar_helper.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/mobile.js') }}"></script>
   <!-- Page specific scripts -->
   {% block scripts %}{% endblock %}
 </body>

--- a/templates/partials/exam_appointments_table.html
+++ b/templates/partials/exam_appointments_table.html
@@ -1,29 +1,20 @@
-<table class="table">
-  <thead>
-    <tr>
-      <th>Hora</th>
-      <th>Animal</th>
-      <th>Especialista</th>
-      <th>Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% if exam_appointments_grouped %}
-      {% for day, items in exam_appointments_grouped %}
-        <tr class="table-light">
-          <th colspan="4">{{ day|format_datetime_brazil('%d/%m/%Y') }}</th>
-        </tr>
-        {% for appt in items %}
-          <tr>
-            <td>{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}</td>
-            <td>{{ appt.animal.name }}</td>
-            <td>{{ appt.specialist.user.name }}</td>
-            <td>{{ appt.status_display }}</td>
-          </tr>
-        {% endfor %}
+{% from 'components/table_macros.html' import render_table %}
+{% call render_table(['Hora', 'Animal', 'Especialista', 'Status']) %}
+  {% if exam_appointments_grouped %}
+    {% for day, items in exam_appointments_grouped %}
+      <tr class="table-light">
+        <th colspan="4">{{ day|format_datetime_brazil('%d/%m/%Y') }}</th>
+      </tr>
+      {% for appt in items %}
+      <tr>
+        <td>{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}</td>
+        <td>{{ appt.animal.name }}</td>
+        <td>{{ appt.specialist.user.name }}</td>
+        <td>{{ appt.status_display }}</td>
+      </tr>
       {% endfor %}
-    {% else %}
-      <tr><td colspan="4">Nenhum exame agendado.</td></tr>
-    {% endif %}
-  </tbody>
-</table>
+    {% endfor %}
+  {% else %}
+    <tr><td colspan="4">Nenhum exame agendado.</td></tr>
+  {% endif %}
+{% endcall %}

--- a/templates/partials/vaccine_appointments_table.html
+++ b/templates/partials/vaccine_appointments_table.html
@@ -1,25 +1,18 @@
-<table class="table">
-  <thead>
-    <tr>
-      <th>Animal</th>
-      <th>Vacina</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% if vaccine_appointments_grouped %}
-      {% for day, items in vaccine_appointments_grouped %}
-        <tr class="table-light">
-          <th colspan="2">{{ day|format_datetime_brazil('%d/%m/%Y') }}</th>
-        </tr>
-        {% for vac in items %}
-          <tr>
-            <td>{{ vac.animal.name }}</td>
-            <td>{{ vac.nome }}</td>
-          </tr>
-        {% endfor %}
+{% from 'components/table_macros.html' import render_table %}
+{% call render_table(['Animal', 'Vacina']) %}
+  {% if vaccine_appointments_grouped %}
+    {% for day, items in vaccine_appointments_grouped %}
+      <tr class="table-light">
+        <th colspan="2">{{ day|format_datetime_brazil('%d/%m/%Y') }}</th>
+      </tr>
+      {% for vac in items %}
+      <tr>
+        <td>{{ vac.animal.name }}</td>
+        <td>{{ vac.nome }}</td>
+      </tr>
       {% endfor %}
-    {% else %}
-      <tr><td colspan="2">Nenhuma vacina agendada.</td></tr>
-    {% endif %}
-  </tbody>
-</table>
+    {% endfor %}
+  {% else %}
+    <tr><td colspan="2">Nenhuma vacina agendada.</td></tr>
+  {% endif %}
+{% endcall %}


### PR DESCRIPTION
## Summary
- add reusable macros for forms and tables
- apply macros to login and appointment templates
- add mobile-friendly styles and JS wrappers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bee5996398832eaa37ba54f0d24930