### PR TITLE
Add API for tutor pets and integrate with calendar

### DIFF
--- a/app.py
+++ b/app.py
@@ -7729,6 +7729,28 @@ def delete_appointment(appointment_id):
     return redirect(request.referrer or url_for('manage_appointments'))
 
 
+@app.route('/api/my_pets')
+@login_required
+def api_my_pets():
+    """Return the authenticated tutor's pets."""
+    pets = (
+        Animal.query
+        .filter_by(user_id=current_user.id)
+        .filter(Animal.removido_em.is_(None))
+        .order_by(Animal.name)
+        .all()
+    )
+    return jsonify([
+        {
+            "id": p.id,
+            "name": p.name,
+            "species": p.species.name if getattr(p, "species", None) else "",
+            "breed": p.breed.name if getattr(p, "breed", None) else "",
+        }
+        for p in pets
+    ])
+
+
 @app.route('/api/my_appointments')
 @login_required
 def api_my_appointments():

--- a/templates/agendamentos/appointments_calendar.html
+++ b/templates/agendamentos/appointments_calendar.html
@@ -158,7 +158,7 @@
   <script>
     // -- Dados e armazenamento local (localStorage)
     const STORAGE_KEYS = { PETS: 'vet_pets_v1', EVENTS: 'vet_events_v1' }
-    let pets = JSON.parse(localStorage.getItem(STORAGE_KEYS.PETS) || '[]')
+    let pets = []
     let events = JSON.parse(localStorage.getItem(STORAGE_KEYS.EVENTS) || '[]')
 
     // -- Estado do calendário
@@ -191,9 +191,20 @@
     }
 
     // -- Pets
-    function renderPets(){
+    async function renderPets(){
       petListEl.innerHTML = ''
       eventPetSelect.innerHTML = ''
+      try {
+        const resp = await fetch('/api/my_pets')
+        if (resp.ok) {
+          pets = await resp.json()
+        } else {
+          pets = []
+        }
+      } catch (err) {
+        console.error('Erro ao carregar pets', err)
+        pets = []
+      }
       if(pets.length===0){
         petListEl.innerHTML = '<div class="small">Nenhum pet cadastrado. Clique em + Novo Pet</div>'
       }


### PR DESCRIPTION
## Summary
- add `/api/my_pets` endpoint returning pets for the logged in tutor
- load pets from `/api/my_pets` in appointment calendar and populate pet selector

## Testing
- `pytest` *(fails: tests/test_collaborator_appointment.py::test_collaborator_can_schedule_consulta)*

------
https://chatgpt.com/codex/tasks/task_e_68c20c9077b4832e807e064b80ee1e3a