### PR TITLE
Allow long medication instructions and fix collaborator booking

### DIFF
--- a/app.py
+++ b/app.py
@@ -7439,18 +7439,19 @@ def appointments():
                                 'danger',
                             )
                             return redirect(url_for('appointments'))
-                            appt = Appointment(
-                                animal_id=animal.id,
-                                tutor_id=tutor_id,
-                                veterinario_id=appointment_form.veterinario_id.data,
-                                scheduled_at=scheduled_at,
-                                clinica_id=clinica_id,
-                                notes=appointment_form.reason.data,
-                                kind=appointment_form.kind.data,
-                            )
-                            db.session.add(appt)
-                            db.session.commit()
-                            flash('Agendamento criado com sucesso.', 'success')
+
+                        appt = Appointment(
+                            animal_id=animal.id,
+                            tutor_id=tutor_id,
+                            veterinario_id=appointment_form.veterinario_id.data,
+                            scheduled_at=scheduled_at,
+                            clinica_id=clinica_id,
+                            notes=appointment_form.reason.data,
+                            kind=appointment_form.kind.data,
+                        )
+                        db.session.add(appt)
+                        db.session.commit()
+                        flash('Agendamento criado com sucesso.', 'success')
                 return redirect(url_for('appointments'))
             appointments = (
                 Appointment.query

--- a/migrations/versions/2f9a0dc93f25_expand_medicamento_text_fields.py
+++ b/migrations/versions/2f9a0dc93f25_expand_medicamento_text_fields.py
@@ -1,0 +1,59 @@
+"""expand medicamento text fields"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2f9a0dc93f25'
+down_revision = 'b1db1e768d50'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        'medicamento',
+        'dosagem_recomendada',
+        existing_type=sa.String(length=100),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'medicamento',
+        'frequencia',
+        existing_type=sa.String(length=50),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'medicamento',
+        'duracao_tratamento',
+        existing_type=sa.String(length=100),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'medicamento',
+        'duracao_tratamento',
+        existing_type=sa.Text(),
+        type_=sa.String(length=100),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'medicamento',
+        'frequencia',
+        existing_type=sa.Text(),
+        type_=sa.String(length=50),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'medicamento',
+        'dosagem_recomendada',
+        existing_type=sa.Text(),
+        type_=sa.String(length=100),
+        existing_nullable=True,
+    )

--- a/models.py
+++ b/models.py
@@ -896,9 +896,9 @@ class Medicamento(db.Model):
     classificacao = db.Column(db.String(100))  # 🆕 antibiótico, anti-inflamatório, etc.
     principio_ativo = db.Column(db.String(100))  # opcional
     via_administracao = db.Column(db.String(50))  # oral, IM, IV...
-    dosagem_recomendada = db.Column(db.String(100))  # Ex: 5 mg/kg SID
-    frequencia = db.Column(db.String(50))  # Ex: SID, BID, TID
-    duracao_tratamento = db.Column(db.String(100))  # Ex: 7 dias
+    dosagem_recomendada = db.Column(db.Text)  # Ex: 5 mg/kg SID
+    frequencia = db.Column(db.Text)  # Ex: SID, BID, TID
+    duracao_tratamento = db.Column(db.Text)  # Ex: 7 dias
     observacoes = db.Column(db.Text)  # para contraindicações, interações, etc.
     bula = db.Column(db.Text)  # 🆕 Texto completo da bula, opcional
 


### PR DESCRIPTION
## Summary
- store medication dosage, frequency and treatment duration as unrestricted text fields
- add an Alembic migration that alters the `medicamento` table to use the new types
- fix collaborator scheduling so successful bookings are persisted when no health-plan check is required

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd71cbc46c832ebce8196734396a10