### PR TITLE
Remove duplicate schedule conflict helper

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -126,19 +126,6 @@ def is_slot_available(veterinario_id, scheduled_at):
     return conflict is None
 
 
-def has_schedule_conflict(veterinario_id, dia_semana, hora_inicio, hora_fim):
-    """Verifica se há conflito com horários existentes do veterinário."""
-    from models import VetSchedule
-
-    existentes = VetSchedule.query.filter_by(
-        veterinario_id=veterinario_id, dia_semana=dia_semana
-    ).all()
-    for s in existentes:
-        if hora_inicio < s.hora_fim and hora_fim > s.hora_inicio:
-            return True
-    return False
-
-
 def clinicas_do_usuario():
     """Retorna query de ``Clinica`` filtrada pelo usuário atual."""
     from models import Clinica


### PR DESCRIPTION
## Summary
- remove the legacy `has_schedule_conflict` helper overload so only the implementation supporting `exclude_id` remains

## Testing
- pytest tests/test_scheduling.py tests/test_schedule_interval.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9872bee0832eb0638b3b5033f6a8