### PR TITLE
Handle exam conflicts when checking slot availability

### DIFF
--- a/app.py
+++ b/app.py
@@ -7230,7 +7230,10 @@ def appointments():
             if not is_slot_available(
                 appointment_form.veterinario_id.data, scheduled_at_local
             ):
-                flash('Horário indisponível para o veterinário selecionado.', 'danger')
+                flash(
+                    'Horário indisponível para o veterinário selecionado. Já existe uma consulta ou exame nesse intervalo.',
+                    'danger'
+                )
             else:
                 animal = get_animal_or_404(appointment_form.animal_id.data)
                 tutor_id = animal.user_id
@@ -7396,7 +7399,10 @@ def appointments():
                 if not is_slot_available(
                     appointment_form.veterinario_id.data, scheduled_at_local
                 ):
-                    flash('Horário indisponível para o veterinário selecionado.', 'danger')
+                    flash(
+                        'Horário indisponível para o veterinário selecionado. Já existe uma consulta ou exame nesse intervalo.',
+                        'danger'
+                    )
                 else:
                     scheduled_at = (
                         scheduled_at_local
@@ -7413,7 +7419,10 @@ def appointments():
                             ExamAppointment.scheduled_at > scheduled_at - duration,
                         ).first()
                         if conflict:
-                            flash('Horário indisponível para o veterinário selecionado.', 'danger')
+                            flash(
+                                'Horário indisponível para o veterinário selecionado. Já existe uma consulta ou exame nesse intervalo.',
+                                'danger'
+                            )
                         else:
                             appt = ExamAppointment(
                                 animal_id=appointment_form.animal_id.data,
@@ -7652,7 +7661,10 @@ def edit_appointment(appointment_id):
         if not is_slot_available(vet_id, scheduled_at_local) and not (
             vet_id == appointment.veterinario_id and scheduled_at_local == existing_local
         ):
-            return jsonify({'success': False, 'message': 'Horário indisponível.'}), 400
+            return jsonify({
+                'success': False,
+                'message': 'Horário indisponível. Já existe uma consulta ou exame nesse intervalo.'
+            }), 400
         appointment.veterinario_id = vet_id
         appointment.scheduled_at = (
             scheduled_at_local
@@ -7871,7 +7883,10 @@ def schedule_exam(animal_id):
         ).first()
     )
     if conflict:
-        return jsonify({'success': False, 'message': 'Horário indisponível.'}), 400
+        return jsonify({
+            'success': False,
+            'message': 'Horário indisponível. Já existe uma consulta ou exame nesse intervalo.'
+        }), 400
     vet = Veterinario.query.get(specialist_id)
     animal = Animal.query.get(animal_id)
     same_user = vet and vet.user_id == current_user.id
@@ -7981,7 +7996,10 @@ def update_exam_appointment(appointment_id):
         ).first()
     )
     if conflict:
-        return jsonify({'success': False, 'message': 'Horário indisponível.'}), 400
+        return jsonify({
+            'success': False,
+            'message': 'Horário indisponível. Já existe uma consulta ou exame nesse intervalo.'
+        }), 400
     appt.specialist_id = specialist_id
     appt.scheduled_at = scheduled_at
     db.session.commit()

--- a/helpers.py
+++ b/helpers.py
@@ -85,9 +85,10 @@ def is_slot_available(veterinario_id, scheduled_at):
 
     A slot is available when it falls inside the veterinarian's schedule
     (``VetSchedule``) for the corresponding weekday and there is no
-    existing ``Appointment`` at the exact datetime.
+    overlapping ``Appointment`` or ``ExamAppointment`` within the
+    30-minute window used for bookings.
     """
-    from models import VetSchedule, Appointment
+    from models import VetSchedule, Appointment, ExamAppointment
 
     weekday_map = {
         0: 'Segunda',
@@ -105,23 +106,42 @@ def is_slot_available(veterinario_id, scheduled_at):
 
     # Se não houver horários cadastrados para o dia, assume-se disponibilidade.
     if schedules:
-        time = scheduled_at.time()
+        slot_time = scheduled_at.time()
         available = any(
-            s.hora_inicio <= time < s.hora_fim
+            s.hora_inicio <= slot_time < s.hora_fim
             and not (
                 s.intervalo_inicio
                 and s.intervalo_fim
-                and s.intervalo_inicio <= time < s.intervalo_fim
+                and s.intervalo_inicio <= slot_time < s.intervalo_fim
             )
             for s in schedules
         )
         if not available:
             return False
 
+    if scheduled_at.tzinfo is None:
+        scheduled_at_with_tz = scheduled_at.replace(tzinfo=BR_TZ)
+    else:
+        scheduled_at_with_tz = scheduled_at.astimezone(BR_TZ)
+    scheduled_at_utc = (
+        scheduled_at_with_tz
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
+    duration = timedelta(minutes=30)
+    start_window = scheduled_at_utc - duration
+    end_window = scheduled_at_utc + duration
     conflict = (
-        Appointment.query
-        .filter_by(veterinario_id=veterinario_id, scheduled_at=scheduled_at)
-        .first()
+        Appointment.query.filter(
+            Appointment.veterinario_id == veterinario_id,
+            Appointment.scheduled_at < end_window,
+            Appointment.scheduled_at > start_window,
+        ).first()
+        or ExamAppointment.query.filter(
+            ExamAppointment.specialist_id == veterinario_id,
+            ExamAppointment.scheduled_at < end_window,
+            ExamAppointment.scheduled_at > start_window,
+        ).first()
     )
     return conflict is None
 

--- a/tests/test_schedule_interval.py
+++ b/tests/test_schedule_interval.py
@@ -3,13 +3,13 @@ os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from datetime import datetime, time
+from datetime import datetime, time, timedelta, timezone
 
 import pytest
 
 from app import app as flask_app, db
-from models import User, Veterinario, VetSchedule
-from helpers import is_slot_available, has_schedule_conflict
+from models import User, Veterinario, VetSchedule, Animal, ExamAppointment
+from helpers import is_slot_available, has_schedule_conflict, BR_TZ
 
 
 @pytest.fixture
@@ -42,6 +42,51 @@ def test_interval_blocks_slot(app_context):
 
     assert is_slot_available(vet.id, datetime(2024, 5, 1, 11, 0)) is True
     assert is_slot_available(vet.id, datetime(2024, 5, 1, 12, 30)) is False
+
+
+def test_slot_unavailable_when_exam_conflicts(app_context):
+    vet_user = User(name="Vet", email="vet_exam@test", worker="veterinario")
+    vet_user.set_password("x")
+    tutor = User(name="Tutor", email="tutor_exam@test")
+    tutor.set_password("x")
+    db.session.add_all([vet_user, tutor])
+    db.session.commit()
+
+    vet = Veterinario(user_id=vet_user.id, crmv="789")
+    db.session.add(vet)
+    db.session.commit()
+
+    schedule = VetSchedule(
+        veterinario_id=vet.id,
+        dia_semana="Quarta",
+        hora_inicio=time(9, 0),
+        hora_fim=time(17, 0),
+    )
+    db.session.add(schedule)
+    db.session.commit()
+
+    animal = Animal(name="Rex", owner=tutor)
+    db.session.add(animal)
+    db.session.commit()
+
+    scheduled_at_local = datetime(2024, 5, 1, 11, 0)
+    scheduled_at_utc = (
+        scheduled_at_local.replace(tzinfo=BR_TZ)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
+    exam = ExamAppointment(
+        animal_id=animal.id,
+        specialist_id=vet.id,
+        requester_id=tutor.id,
+        scheduled_at=scheduled_at_utc,
+        status='confirmed',
+    )
+    db.session.add(exam)
+    db.session.commit()
+
+    assert is_slot_available(vet.id, scheduled_at_local) is False
+    assert is_slot_available(vet.id, scheduled_at_local + timedelta(minutes=30)) is True
 
 
 def test_has_schedule_conflict(app_context):


### PR DESCRIPTION
## Summary
- expand `helpers.is_slot_available` to consider overlapping appointments and exams within the 30-minute booking window
- update scheduling flows to surface the new unavailability reason in user-facing messages
- add regression coverage ensuring exam bookings block conflicting appointment slots

## Testing
- `pytest tests/test_schedule_interval.py`
- `pytest tests/test_schedule_exam.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd9891a5a0832ea6e681627295f004