### PR TITLE
Manage clinic invites

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -284,6 +284,10 @@ class ClinicInviteResponseForm(FlaskForm):
     submit = SubmitField('Enviar')
 
 
+class ClinicInviteActionForm(FlaskForm):
+    submit = SubmitField('Confirmar')
+
+
 class ClinicAddStaffForm(FlaskForm):
     """Simple form to add an existing user as clinic staff."""
     email = StringField('Email do usuário', validators=[DataRequired(), Email()])

--- a/templates/partials/clinic_veterinarios_tab.html
+++ b/templates/partials/clinic_veterinarios_tab.html
@@ -209,6 +209,63 @@
           </table>
         </div>
         {% if pode_editar %}
+        <div class="mt-4">
+          <h5 class="mb-2">Convites enviados</h5>
+          {% set status_meta = {
+            'pending': ('Pendente', 'warning'),
+            'accepted': ('Aceito', 'success'),
+            'declined': ('Recusado', 'danger'),
+            'cancelled': ('Cancelado', 'secondary')
+          } %}
+          {% set status_order = ['pending', 'accepted', 'declined', 'cancelled'] %}
+          {% if clinic_invite_counts %}
+          <div class="mb-3">
+            {% for status in status_order %}
+            {% if clinic_invite_counts.get(status) %}
+            {% set meta = status_meta.get(status, (status|capitalize, 'secondary')) %}
+            <span class="badge text-bg-{{ meta[1] }} me-2">{{ meta[0] }}: {{ clinic_invite_counts.get(status) }}</span>
+            {% endif %}
+            {% endfor %}
+          </div>
+          {% endif %}
+          {% if clinic_invites %}
+          <div class="list-group">
+            {% for invite in clinic_invites %}
+            {% set meta = status_meta.get(invite.status, (invite.status|capitalize, 'secondary')) %}
+            {% set vet_user = invite.veterinario.user if invite.veterinario and invite.veterinario.user else None %}
+            <div class="list-group-item d-flex justify-content-between align-items-start">
+              <div>
+                <strong>{{ vet_user.name if vet_user else 'Veterinário removido' }}</strong>
+                {% if vet_user %}
+                <div class="text-muted small">{{ vet_user.email }}</div>
+                {% endif %}
+                {% if invite.created_at %}
+                <div class="text-muted small">Enviado em {{ invite.created_at|datetime_brazil }}</div>
+                {% endif %}
+              </div>
+              <div class="text-end">
+                <div class="mb-2">
+                  <span class="badge text-bg-{{ meta[1] }}">{{ meta[0] }}</span>
+                </div>
+                {% if invite.status == 'pending' %}
+                <form method="post" action="{{ url_for('cancel_clinic_invite', clinica_id=clinica.id, invite_id=invite.id) }}" class="d-inline">
+                  {{ invite_action_form.hidden_tag() }}
+                  <button type="submit" class="btn btn-sm btn-outline-danger">Cancelar</button>
+                </form>
+                {% elif invite.status in ['declined', 'cancelled'] %}
+                <form method="post" action="{{ url_for('resend_clinic_invite', clinica_id=clinica.id, invite_id=invite.id) }}" class="d-inline">
+                  {{ invite_action_form.hidden_tag() }}
+                  <button type="submit" class="btn btn-sm btn-outline-secondary">Reenviar</button>
+                </form>
+                {% endif %}
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+          {% else %}
+          <p class="text-muted">Nenhum convite enviado.</p>
+          {% endif %}
+        </div>
         <button class="btn btn-secondary mt-3" onclick="toggleAddVet()">Adicionar Veterinário</button>
         <div id="add-vet" class="mt-3" style="display:none;">
           <form method="post" class="mb-4">

--- a/tests/test_clinic_vet.py
+++ b/tests/test_clinic_vet.py
@@ -49,3 +49,86 @@ def test_accepting_invite_sets_clinic(app):
 
         db.session.remove()
         db.drop_all()
+
+
+def test_owner_can_cancel_invite(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        owner = User(id=1, name='Owner', email='o@test', password_hash='x')
+        clinic = Clinica(id=1, nome='Clinica', owner_id=owner.id)
+        vet_user = User(id=2, name='Vet', email='vet@test', password_hash='x', worker='veterinario')
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123')
+        db.session.add_all([owner, clinic, vet_user, vet])
+        db.session.commit()
+
+        invite = VetClinicInvite(clinica_id=clinic.id, veterinario_id=vet.id)
+        db.session.add(invite)
+        db.session.commit()
+
+        client = app.test_client()
+        login(client, owner.id)
+        response = client.post(f'/clinica/{clinic.id}/convites/{invite.id}/cancel')
+
+        assert response.status_code == 302
+        db.session.refresh(invite)
+        assert invite.status == 'cancelled'
+
+        db.session.remove()
+        db.drop_all()
+
+
+def test_admin_can_resend_declined_invite(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        owner = User(id=1, name='Owner', email='o@test', password_hash='x')
+        clinic = Clinica(id=1, nome='Clinica', owner_id=owner.id)
+        admin = User(id=99, name='Admin', email='admin@test', password_hash='x', role='admin')
+        vet_user = User(id=2, name='Vet', email='vet@test', password_hash='x', worker='veterinario')
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123')
+        db.session.add_all([owner, clinic, admin, vet_user, vet])
+        db.session.commit()
+
+        invite = VetClinicInvite(clinica_id=clinic.id, veterinario_id=vet.id, status='declined')
+        db.session.add(invite)
+        db.session.commit()
+
+        client = app.test_client()
+        login(client, admin.id)
+        response = client.post(f'/clinica/{clinic.id}/convites/{invite.id}/resend')
+
+        assert response.status_code == 302
+        db.session.refresh(invite)
+        assert invite.status == 'pending'
+
+        db.session.remove()
+        db.drop_all()
+
+
+def test_non_owner_cannot_manage_invite(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        owner = User(id=1, name='Owner', email='o@test', password_hash='x')
+        clinic = Clinica(id=1, nome='Clinica', owner_id=owner.id)
+        other_user = User(id=2, name='User', email='user@test', password_hash='x')
+        vet_user = User(id=3, name='Vet', email='vet@test', password_hash='x', worker='veterinario')
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123')
+        db.session.add_all([owner, clinic, other_user, vet_user, vet])
+        db.session.commit()
+
+        invite = VetClinicInvite(clinica_id=clinic.id, veterinario_id=vet.id)
+        db.session.add(invite)
+        db.session.commit()
+
+        client = app.test_client()
+        login(client, other_user.id)
+        response = client.post(f'/clinica/{clinic.id}/convites/{invite.id}/cancel')
+
+        assert response.status_code == 403
+        db.session.refresh(invite)
+        assert invite.status == 'pending'
+
+        db.session.remove()
+        db.drop_all()


### PR DESCRIPTION
## Summary
- surface veterinarian invite counts and listings in the clinic detail view
- render clinic invite management UI with status badges plus cancel/resend actions
- add invite management routes and tests ensuring only authorized users can update invites

## Testing
- pytest tests/test_clinic_vet.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9e4e2dc4832e8be7d877b3839ae6