### PR TITLE
Send VetClinicInvite acceptance email notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -2538,7 +2538,33 @@ def clinic_detail(clinica_id):
                 )
                 db.session.add(invite)
                 db.session.commit()
-                flash('Convite enviado.', 'success')
+                acceptance_url = url_for('clinic_invites', _external=True)
+                inviter_name = getattr(current_user, 'name', None) or 'Um membro da clínica'
+                recipient_name = getattr(user, 'name', None) or 'veterinário(a)'
+                subject = f"Convite para ingressar na clínica {clinica.nome}"
+                body = (
+                    f"Olá {recipient_name},\n\n"
+                    f"{inviter_name} convidou você para ingressar na clínica {clinica.nome} na PetOrlândia.\n"
+                    f"Acesse {acceptance_url} para aceitar ou recusar o convite e concluir o processo.\n\n"
+                    "Se tiver dúvidas, responda a este e-mail ou entre em contato com a clínica.\n\n"
+                    "Equipe PetOrlândia"
+                )
+                msg = MailMessage(
+                    subject=subject,
+                    sender=app.config['MAIL_DEFAULT_SENDER'],
+                    recipients=[user.email],
+                    body=body,
+                )
+                try:
+                    mail.send(msg)
+                except Exception as exc:  # noqa: BLE001
+                    current_app.logger.exception('Falha ao enviar e-mail de convite da clínica: %s', exc)
+                    flash(
+                        'Convite criado, mas houve um problema ao enviar o e-mail para o veterinário.',
+                        'warning',
+                    )
+                else:
+                    flash('Convite enviado.', 'success')
         return redirect(url_for('clinic_detail', clinica_id=clinica.id) + '#veterinarios')
     if hours_form.submit.data and hours_form.validate_on_submit():
         if not pode_editar:

--- a/tests/test_clinic_vet.py
+++ b/tests/test_clinic_vet.py
@@ -5,6 +5,7 @@ os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import pytest
+from unittest.mock import MagicMock
 from app import app as flask_app, db
 from models import User, Clinica, Veterinario, VetClinicInvite
 
@@ -46,6 +47,51 @@ def test_accepting_invite_sets_clinic(app):
 
         assert vet.clinica_id == clinic.id
         assert invite.status == 'accepted'
+
+        db.session.remove()
+        db.drop_all()
+
+
+def test_creating_invite_sends_email(app, monkeypatch):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        owner = User(id=1, name='Owner', email='owner@test', password_hash='x')
+        clinic = Clinica(id=1, nome='Clinica', owner_id=owner.id)
+        owner.clinica_id = clinic.id
+        vet_user = User(
+            id=2,
+            name='Vet',
+            email='vet@example.com',
+            password_hash='x',
+            worker='veterinario',
+        )
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123')
+        db.session.add_all([owner, clinic, vet_user, vet])
+        db.session.commit()
+
+        mocked_send = MagicMock()
+        monkeypatch.setattr('app.mail.send', mocked_send)
+        monkeypatch.setattr('app.ClinicAddStaffForm.validate_on_submit', lambda self: False)
+
+        client = app.test_client()
+        login(client, owner.id)
+        response = client.post(
+            f'/clinica/{clinic.id}',
+            data={'email': vet_user.email, 'submit': 'Convidar', 'nome': ''},
+        )
+
+        assert response.status_code == 302
+        invite = VetClinicInvite.query.filter_by(
+            clinica_id=clinic.id,
+            veterinario_id=vet.id,
+            status='pending',
+        ).first()
+        assert invite is not None
+        mocked_send.assert_called_once()
+        sent_message = mocked_send.call_args[0][0]
+        assert vet_user.email in sent_message.recipients
 
         db.session.remove()
         db.drop_all()


### PR DESCRIPTION
## Summary
- send a VetClinicInvite email with an acceptance URL when clinics invite veterinarians
- log and surface email delivery failures while preserving invite creation feedback
- add a regression test that ensures the mail extension is called after creating an invite

## Testing
- pytest tests/test_clinic_vet.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9e5aa8cc832ebdc0dc47fe06f2f8