### PR TITLE
Improve clinic invite cards UI and add template test

### DIFF
--- a/templates/clinica/clinic_invites.html
+++ b/templates/clinica/clinic_invites.html
@@ -1,27 +1,89 @@
 {% extends 'layout.html' %}
-{% block content %}
-<div class="container py-4">
-  <h2>Convites de Clínicas</h2>
-  {% if invites %}
-  <ul class="list-group">
-    {% for invite in invites %}
-    <li class="list-group-item d-flex justify-content-between align-items-center">
-      {{ invite.clinica.nome }}
-      <div>
-        <form method="post" action="{{ url_for('respond_clinic_invite', invite_id=invite.id, action='accept') }}" class="d-inline">
-          {{ form.csrf_token }}
-          <button type="submit" class="btn btn-sm btn-success">Aceitar</button>
-        </form>
-        <form method="post" action="{{ url_for('respond_clinic_invite', invite_id=invite.id, action='decline') }}" class="d-inline">
-          {{ form.csrf_token }}
-          <button type="submit" class="btn btn-sm btn-danger">Recusar</button>
-        </form>
+{% block main %}
+<div class="py-4">
+  <div class="row justify-content-center">
+    <div class="col-12 col-lg-10 col-xl-8">
+      <h1 class="h3 mb-4">Convites de Clínicas</h1>
+      {% if invites %}
+      <div class="row gy-4">
+        {% for invite in invites %}
+        <div class="col-12">
+          <article class="card shadow-sm h-100" aria-labelledby="invite-title-{{ invite.id }}">
+            <div class="card-body">
+              <div class="d-flex flex-column flex-md-row align-items-start gap-3">
+                <div class="flex-shrink-0">
+                  {% if invite.clinica.logo_url %}
+                  <img src="{{ invite.clinica.logo_url }}"
+                       alt="Logo da clínica {{ invite.clinica.nome }}"
+                       class="rounded border"
+                       style="width: 96px; height: 96px; object-fit: cover;">
+                  {% else %}
+                  <div class="bg-light border rounded d-flex align-items-center justify-content-center"
+                       style="width: 96px; height: 96px;">
+                    <span class="text-muted fw-semibold small text-center">Sem logo</span>
+                  </div>
+                  {% endif %}
+                </div>
+                <div class="flex-grow-1 w-100">
+                  <header class="mb-2">
+                    <h2 id="invite-title-{{ invite.id }}" class="h5 mb-2">{{ invite.clinica.nome }}</h2>
+                    {% if invite.clinica.endereco %}
+                    <p class="mb-1 text-muted">
+                      <span class="me-1" aria-hidden="true">📍</span>
+                      <span>{{ invite.clinica.endereco }}</span>
+                    </p>
+                    {% endif %}
+                    {% if invite.clinica.owner %}
+                    <p class="mb-0 text-muted">
+                      <span class="me-1" aria-hidden="true">👤</span>
+                      Proprietário: <span class="fw-semibold">{{ invite.clinica.owner.name }}</span>
+                    </p>
+                    {% endif %}
+                  </header>
+                  <p class="text-muted mb-3">
+                    A clínica convidou você para integrar a equipe e atender pacientes pela plataforma.
+                    {% if invite.created_at %}
+                    Convite enviado em <span class="fw-semibold">{{ invite.created_at|datetime_brazil }}</span>.
+                    {% endif %}
+                  </p>
+                  <div class="mt-auto">
+                    <div class="d-flex flex-column flex-sm-row gap-2" role="group" aria-label="Ações para o convite da clínica {{ invite.clinica.nome }}">
+                      <form method="post"
+                            action="{{ url_for('respond_clinic_invite', invite_id=invite.id, action='accept') }}"
+                            class="d-inline"
+                            aria-label="Aceitar convite da clínica {{ invite.clinica.nome }}">
+                        {{ form.hidden_tag() }}
+                        <button type="submit" class="btn btn-primary w-100">Aceitar</button>
+                      </form>
+                      <form method="post"
+                            action="{{ url_for('respond_clinic_invite', invite_id=invite.id, action='decline') }}"
+                            class="d-inline"
+                            aria-label="Recusar convite da clínica {{ invite.clinica.nome }}">
+                        {{ form.hidden_tag() }}
+                        <button type="submit" class="btn btn-outline-secondary w-100">Recusar</button>
+                      </form>
+                    </div>
+                    <p class="text-muted small mt-3 mb-0">
+                      Aceitar adiciona esta clínica ao seu perfil e libera os recursos dela. Recusar mantém tudo como está.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+        {% endfor %}
       </div>
-    </li>
-    {% endfor %}
-  </ul>
-  {% else %}
-  <p>Não há convites pendentes.</p>
-  {% endif %}
+      {% else %}
+      <div class="card shadow-sm border-0">
+        <div class="card-body text-center py-5" role="status" aria-live="polite">
+          <h2 class="h5">Nenhum convite por aqui</h2>
+          <p class="text-muted mb-2">Quando uma clínica cadastrar seu e-mail para colaboração, você receberá um convite por e-mail e ele aparecerá aqui.</p>
+          <p class="text-muted mb-0">Combine com a clínica qual endereço de e-mail você usa no PetOrlândia para que o convite chegue corretamente.</p>
+        </div>
+      </div>
+      {% endif %}
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/tests/test_clinic_invites_template.py
+++ b/tests/test_clinic_invites_template.py
@@ -1,0 +1,104 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import app as flask_app, db
+from sqlalchemy.pool import StaticPool
+from models import Clinica, User, Veterinario, VetClinicInvite
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_ENGINE_OPTIONS={
+            "poolclass": StaticPool,
+            "connect_args": {"check_same_thread": False},
+        },
+    )
+    engines = db._app_engines.setdefault(flask_app, {})
+    default_engine = engines.get(None)
+    if default_engine is not None:
+        default_engine.dispose()
+    engine_options = db._engine_options.copy()
+    engine_options.update(flask_app.config.setdefault("SQLALCHEMY_ENGINE_OPTIONS", {}))
+    engine_options["url"] = flask_app.config["SQLALCHEMY_DATABASE_URI"]
+    echo = flask_app.config.setdefault("SQLALCHEMY_ECHO", False)
+    engine_options.setdefault("echo", echo)
+    engine_options.setdefault("echo_pool", echo)
+    db._make_metadata(None)
+    db._apply_driver_defaults(engine_options, flask_app)
+    engines[None] = db._make_engine(None, engine_options, flask_app)
+    with flask_app.app_context():
+        db.session.remove()
+    yield flask_app
+
+
+def login(monkeypatch, user):
+    import flask_login.utils as login_utils
+    from flask_login import login_user
+
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+    with flask_app.test_request_context():
+        login_user(user)
+
+
+def test_clinic_invites_template_renders_details(monkeypatch, app):
+    client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        owner = User(
+            name="Dra. Ana",
+            email="owner@example.com",
+            password_hash="owner-password",
+            worker="clinica",
+        )
+        clinic = Clinica(
+            nome="Clínica Lua",
+            endereco="Rua das Flores, 123 - Centro",
+            logotipo="https://example.com/logo.png",
+            owner=owner,
+        )
+        vet_user = User(
+            name="Dr. João",
+            email="vet@example.com",
+            password_hash="vet-password",
+            worker="veterinario",
+        )
+        vet = Veterinario(user=vet_user, crmv="CRMV-1234")
+        invite = VetClinicInvite(clinica=clinic, veterinario=vet)
+        db.session.add_all([owner, clinic, vet_user, vet, invite])
+        db.session.commit()
+
+        login(monkeypatch, vet_user)
+
+        response = client.get('/convites/clinica')
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+
+        assert "Clínica Lua" in html
+        assert "Rua das Flores, 123 - Centro" in html
+        assert "Dra. Ana" in html
+        assert f"Logo da clínica {clinic.nome}" in html
+        assert "Aceitar" in html
+        assert "Recusar" in html
+        assert 'name="csrf_token"' in html
+
+        from flask import url_for
+
+        with app.test_request_context():
+            accept_url = url_for('respond_clinic_invite', invite_id=invite.id, action='accept')
+            decline_url = url_for('respond_clinic_invite', invite_id=invite.id, action='decline')
+
+        assert f'action="{accept_url}"' in html
+        assert f'action="{decline_url}"' in html
+
+        db.session.remove()
+        db.drop_all()


### PR DESCRIPTION
## Summary
- eager-load clinic relationships when listing pending invites
- redesign the clinic invites template with richer cards and responsive empty state
- add a template test ensuring invite details and actions render with CSRF protection

## Testing
- pytest tests/test_clinic_invites_template.py

------
https://chatgpt.com/codex/tasks/task_e_68cda1029140832e9fa9f5a06c3cb09f