### PR TITLE
Manage clinic invites in clinic detail

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 # ───────────────────────────  app.py  ───────────────────────────
 import os, sys, pathlib, importlib, logging, uuid, re
+from collections import defaultdict
 from io import BytesIO
 from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal
@@ -247,7 +248,7 @@ from forms import (
     DeliveryRequestForm, AddToCartForm, SubscribePlanForm,
     ProductUpdateForm, ProductPhotoForm, ChangePasswordForm,
     DeleteAccountForm, ClinicForm, ClinicHoursForm,
-    ClinicInviteVeterinarianForm, ClinicInviteResponseForm,
+    ClinicInviteVeterinarianForm, ClinicInviteCancelForm, ClinicInviteResendForm, ClinicInviteResponseForm,
     ClinicAddStaffForm, ClinicStaffPermissionForm, VetScheduleForm, VetSpecialtyForm, AppointmentForm, AppointmentDeleteForm,
     InventoryItemForm, OrcamentoForm
 )
@@ -2441,6 +2442,56 @@ def minha_clinica():
     return render_template('clinica/multi_clinic_dashboard.html', clinics=overview)
 
 
+def _user_can_manage_clinic(clinica):
+    """Return True when the current user can manage the given clinic."""
+    if not current_user.is_authenticated:
+        return False
+    if _is_admin():
+        return True
+    if current_user.id == clinica.owner_id:
+        return True
+    if (
+        current_user.worker == 'veterinario'
+        and getattr(current_user, 'veterinario', None)
+        and current_user.veterinario.clinica_id == clinica.id
+    ):
+        return True
+    return False
+
+
+def _send_clinic_invite_email(clinica, veterinarian_user, inviter):
+    """Send the invite email for a clinic invitation."""
+    if not veterinarian_user:
+        current_app.logger.warning(
+            'Convite para clínica %s ignorado: veterinário sem usuário associado.',
+            clinica.id,
+        )
+        return False
+
+    acceptance_url = url_for('clinic_invites', _external=True)
+    inviter_name = getattr(inviter, 'name', None) or 'Um membro da clínica'
+    recipient_name = getattr(veterinarian_user, 'name', None) or 'veterinário(a)'
+    subject = f"Convite para ingressar na clínica {clinica.nome}"
+    body = (
+        f"Olá {recipient_name},\n\n"
+        f"{inviter_name} convidou você para ingressar na clínica {clinica.nome} na PetOrlândia.\n"
+        f"Acesse {acceptance_url} para aceitar ou recusar o convite e concluir o processo.\n\n"
+        "Se tiver dúvidas, responda a este e-mail ou entre em contato com a clínica.\n\n"
+        "Equipe PetOrlândia"
+    )
+    msg = MailMessage(
+        subject=subject,
+        sender=app.config['MAIL_DEFAULT_SENDER'],
+        recipients=[veterinarian_user.email],
+        body=body,
+    )
+    try:
+        mail.send(msg)
+    except Exception as exc:  # noqa: BLE001
+        current_app.logger.exception('Falha ao enviar e-mail de convite da clínica: %s', exc)
+        return False
+    return True
+
 
 @app.route('/clinica/<int:clinica_id>', methods=['GET', 'POST'])
 @login_required
@@ -2458,6 +2509,8 @@ def clinic_detail(clinica_id):
             .filter(Clinica.id == clinica_id)
             .first_or_404()
         )
+    from models import VetClinicInvite
+
     is_owner = current_user.id == clinica.owner_id if current_user.is_authenticated else False
     staff = None
     if current_user.is_authenticated:
@@ -2476,18 +2529,12 @@ def clinic_detail(clinica_id):
     hours_form = ClinicHoursForm()
     clinic_form = ClinicForm(obj=clinica)
     invite_form = ClinicInviteVeterinarianForm()
+    invite_cancel_form = ClinicInviteCancelForm(prefix='cancel_invite')
+    invite_resend_form = ClinicInviteResendForm(prefix='resend_invite')
     staff_form = ClinicAddStaffForm()
     if request.method == 'GET':
         hours_form.clinica_id.data = clinica.id
-    pode_editar = current_user.is_authenticated and (
-        _is_admin()
-        or (
-            current_user.worker == 'veterinario'
-            and getattr(current_user, 'veterinario', None)
-            and current_user.veterinario.clinica_id == clinica_id
-        )
-        or current_user.id == clinica.owner_id
-    )
+    pode_editar = _user_can_manage_clinic(clinica)
     if staff_form.submit.data and staff_form.validate_on_submit():
         if not (_is_admin() or current_user.id == clinica.owner_id):
             abort(403)
@@ -2533,8 +2580,6 @@ def clinic_detail(clinica_id):
         if not user or getattr(user, 'worker', '') != 'veterinario' or not getattr(user, 'veterinario', None):
             flash('Veterinário não encontrado.', 'danger')
         else:
-            from models import VetClinicInvite
-
             existing = VetClinicInvite.query.filter_by(
                 clinica_id=clinica.id,
                 veterinario_id=user.veterinario.id,
@@ -2551,33 +2596,13 @@ def clinic_detail(clinica_id):
                 )
                 db.session.add(invite)
                 db.session.commit()
-                acceptance_url = url_for('clinic_invites', _external=True)
-                inviter_name = getattr(current_user, 'name', None) or 'Um membro da clínica'
-                recipient_name = getattr(user, 'name', None) or 'veterinário(a)'
-                subject = f"Convite para ingressar na clínica {clinica.nome}"
-                body = (
-                    f"Olá {recipient_name},\n\n"
-                    f"{inviter_name} convidou você para ingressar na clínica {clinica.nome} na PetOrlândia.\n"
-                    f"Acesse {acceptance_url} para aceitar ou recusar o convite e concluir o processo.\n\n"
-                    "Se tiver dúvidas, responda a este e-mail ou entre em contato com a clínica.\n\n"
-                    "Equipe PetOrlândia"
-                )
-                msg = MailMessage(
-                    subject=subject,
-                    sender=app.config['MAIL_DEFAULT_SENDER'],
-                    recipients=[user.email],
-                    body=body,
-                )
-                try:
-                    mail.send(msg)
-                except Exception as exc:  # noqa: BLE001
-                    current_app.logger.exception('Falha ao enviar e-mail de convite da clínica: %s', exc)
+                if _send_clinic_invite_email(clinica, user, current_user):
+                    flash('Convite enviado.', 'success')
+                else:
                     flash(
                         'Convite criado, mas houve um problema ao enviar o e-mail para o veterinário.',
                         'warning',
                     )
-                else:
-                    flash('Convite enviado.', 'success')
         return redirect(url_for('clinic_detail', clinica_id=clinica.id) + '#veterinarios')
     if hours_form.submit.data and hours_form.validate_on_submit():
         if not pode_editar:
@@ -2610,6 +2635,18 @@ def clinic_detail(clinica_id):
         ClinicStaff.clinic_id == clinica.id,
         ClinicStaff.user.has(User.veterinario == None),
     ).all()
+
+    clinic_invites = (
+        VetClinicInvite.query
+        .filter_by(clinica_id=clinica.id)
+        .order_by(VetClinicInvite.created_at.desc())
+        .all()
+    )
+    invites_by_status = defaultdict(list)
+    for invite in clinic_invites:
+        invites_by_status[invite.status].append(invite)
+    invites_by_status = dict(invites_by_status)
+    invite_status_order = ['pending', 'declined', 'accepted', 'cancelled']
 
     staff_permission_forms = {}
     for s in staff_members:
@@ -2741,6 +2778,8 @@ def clinic_detail(clinica_id):
         form=hours_form,
         clinic_form=clinic_form,
         invite_form=invite_form,
+        invite_cancel_form=invite_cancel_form,
+        invite_resend_form=invite_resend_form,
         veterinarios=veterinarios,
         all_veterinarios=all_veterinarios,
         vet_schedule_forms=vet_schedule_forms,
@@ -2764,7 +2803,68 @@ def clinic_detail(clinica_id):
         inventory_items=inventory_items,
         inventory_form=inventory_form,
         show_inventory=show_inventory,
+        invites_by_status=invites_by_status,
+        invite_status_order=invite_status_order,
     )
+
+
+@app.route('/clinica/<int:clinica_id>/convites/<int:invite_id>/cancel', methods=['POST'])
+@login_required
+def cancel_clinic_invite(clinica_id, invite_id):
+    """Cancel a pending clinic invite."""
+    clinica = Clinica.query.get_or_404(clinica_id)
+    if not _user_can_manage_clinic(clinica):
+        abort(403)
+
+    invite = VetClinicInvite.query.get_or_404(invite_id)
+    if invite.clinica_id != clinica.id:
+        abort(404)
+
+    form = ClinicInviteCancelForm()
+    if not form.validate_on_submit():
+        abort(400)
+
+    if invite.status != 'pending':
+        flash('Somente convites pendentes podem ser cancelados.', 'warning')
+    else:
+        invite.status = 'cancelled'
+        db.session.commit()
+        flash('Convite cancelado.', 'success')
+
+    return redirect(url_for('clinic_detail', clinica_id=clinica.id) + '#veterinarios')
+
+
+@app.route('/clinica/<int:clinica_id>/convites/<int:invite_id>/resend', methods=['POST'])
+@login_required
+def resend_clinic_invite(clinica_id, invite_id):
+    """Resend a declined clinic invite."""
+    clinica = Clinica.query.get_or_404(clinica_id)
+    if not _user_can_manage_clinic(clinica):
+        abort(403)
+
+    invite = VetClinicInvite.query.get_or_404(invite_id)
+    if invite.clinica_id != clinica.id:
+        abort(404)
+
+    form = ClinicInviteResendForm()
+    if not form.validate_on_submit():
+        abort(400)
+
+    if invite.status != 'declined':
+        flash('Apenas convites recusados podem ser reenviados.', 'warning')
+        return redirect(url_for('clinic_detail', clinica_id=clinica.id) + '#veterinarios')
+
+    invite.status = 'pending'
+    invite.created_at = datetime.utcnow()
+    db.session.commit()
+
+    vet_user = invite.veterinario.user if invite.veterinario else None
+    if _send_clinic_invite_email(clinica, vet_user, current_user):
+        flash('Convite reenviado.', 'success')
+    else:
+        flash('Convite reativado, mas houve um problema ao reenviar o e-mail.', 'warning')
+
+    return redirect(url_for('clinic_detail', clinica_id=clinica.id) + '#veterinarios')
 
 
 @app.route('/clinica/<int:clinica_id>/veterinario', methods=['POST'])

--- a/forms.py
+++ b/forms.py
@@ -280,6 +280,14 @@ class ClinicInviteVeterinarianForm(FlaskForm):
     submit = SubmitField('Convidar')
 
 
+class ClinicInviteCancelForm(FlaskForm):
+    submit = SubmitField('Cancelar')
+
+
+class ClinicInviteResendForm(FlaskForm):
+    submit = SubmitField('Reenviar')
+
+
 class ClinicInviteResponseForm(FlaskForm):
     submit = SubmitField('Enviar')
 

--- a/templates/partials/clinic_veterinarios_tab.html
+++ b/templates/partials/clinic_veterinarios_tab.html
@@ -209,6 +209,61 @@
           </table>
         </div>
         {% if pode_editar %}
+        <div class="mt-4">
+          <h5>Convites enviados</h5>
+          {% set status_badges = {
+            'pending': ('Pendente', 'bg-warning text-dark'),
+            'declined': ('Recusado', 'bg-danger'),
+            'accepted': ('Aceito', 'bg-success'),
+            'cancelled': ('Cancelado', 'bg-secondary')
+          } %}
+          {% if invites_by_status %}
+          <div class="list-group">
+            {% for status in invite_status_order %}
+            {% set invites = invites_by_status.get(status, []) %}
+            {% if invites %}
+            {% set status_info = status_badges.get(status, (status|capitalize, 'bg-secondary')) %}
+            <div class="list-group-item">
+              <div class="d-flex align-items-center mb-2">
+                <span class="badge {{ status_info[1] }}">{{ status_info[0] }}</span>
+              </div>
+              <ul class="list-unstyled mb-0">
+                {% for invite in invites %}
+                {% set vet_user = invite.veterinario.user if invite.veterinario and invite.veterinario.user else None %}
+                <li class="mb-3">
+                  <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <div>
+                      <strong>{{ vet_user.name if vet_user else 'Veterinário convidado' }}</strong>
+                      {% if vet_user %}
+                      <div class="small text-muted">{{ vet_user.email }}</div>
+                      {% endif %}
+                      <div class="small text-muted">Enviado em {{ invite.created_at|datetime_brazil }}</div>
+                    </div>
+                    <div class="d-flex gap-2">
+                      {% if status == 'pending' %}
+                      <form method="post" class="d-inline" action="{{ url_for('cancel_clinic_invite', clinica_id=clinica.id, invite_id=invite.id) }}">
+                        {{ invite_cancel_form.hidden_tag() }}
+                        {{ invite_cancel_form.submit(class_="btn btn-sm btn-outline-danger") }}
+                      </form>
+                      {% elif status == 'declined' %}
+                      <form method="post" class="d-inline" action="{{ url_for('resend_clinic_invite', clinica_id=clinica.id, invite_id=invite.id) }}">
+                        {{ invite_resend_form.hidden_tag() }}
+                        {{ invite_resend_form.submit(class_="btn btn-sm btn-outline-primary") }}
+                      </form>
+                      {% endif %}
+                    </div>
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+            {% endfor %}
+          </div>
+          {% else %}
+          <p class="text-muted">Nenhum convite enviado.</p>
+          {% endif %}
+        </div>
         <button class="btn btn-secondary mt-3" onclick="toggleAddVet()">Adicionar Veterinário</button>
         <div id="add-vet" class="mt-3" style="display:none;">
           <form method="post" class="mb-4">

--- a/tests/test_clinic_vet.py
+++ b/tests/test_clinic_vet.py
@@ -6,7 +6,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 from unittest.mock import MagicMock
-from app import app as flask_app, db
+from werkzeug.exceptions import Forbidden
+from flask_login import login_user, logout_user
+
+from app import app as flask_app, db, cancel_clinic_invite, resend_clinic_invite
 from models import User, Clinica, Veterinario, VetClinicInvite
 
 
@@ -22,6 +25,7 @@ def app():
 
 def login(client, user_id):
     with client.session_transaction() as sess:
+        sess.clear()
         sess['_user_id'] = str(user_id)
         sess['_fresh'] = True
 
@@ -92,6 +96,115 @@ def test_creating_invite_sends_email(app, monkeypatch):
         mocked_send.assert_called_once()
         sent_message = mocked_send.call_args[0][0]
         assert vet_user.email in sent_message.recipients
+
+        db.session.remove()
+        db.drop_all()
+
+
+def test_cancel_invite_requires_permission(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        owner = User(id=1, name='Owner', email='owner@test', password_hash='x')
+        clinic = Clinica(id=1, nome='Clinica', owner_id=owner.id)
+        vet_user = User(
+            id=2,
+            name='Vet',
+            email='vet@test',
+            password_hash='x',
+            worker='veterinario',
+        )
+        vet = Veterinario(id=1, user_id=vet_user.id, crmv='123')
+        invite = VetClinicInvite(id=1, clinica_id=clinic.id, veterinario_id=vet.id)
+        outsider = User(id=3, name='Other', email='other@test', password_hash='x')
+        db.session.add_all([owner, clinic, vet_user, vet, invite, outsider])
+        db.session.commit()
+
+        request_path = f'/clinica/{clinic.id}/convites/{invite.id}/cancel'
+
+        with flask_app.test_request_context(
+            request_path,
+            method='POST',
+            data={'cancel_invite-submit': 'Cancelar'},
+        ):
+            login_user(outsider)
+            with pytest.raises(Forbidden):
+                cancel_clinic_invite(clinic.id, invite.id)
+            logout_user()
+        db.session.refresh(invite)
+        assert invite.status == 'pending'
+
+        with flask_app.test_request_context(
+            request_path,
+            method='POST',
+            data={'cancel_invite-submit': 'Cancelar'},
+        ):
+            login_user(owner)
+            response = cancel_clinic_invite(clinic.id, invite.id)
+            logout_user()
+        assert response.status_code == 302
+        db.session.refresh(invite)
+        assert invite.status == 'cancelled'
+
+        db.session.remove()
+        db.drop_all()
+
+
+def test_resend_invite_requires_admin_or_owner(app, monkeypatch):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        admin = User(id=10, name='Admin', email='admin@test', password_hash='x', role='admin')
+        clinic = Clinica(id=2, nome='Outra Clinica', owner_id=99)
+        vet_user = User(
+            id=20,
+            name='Vet',
+            email='vet2@test',
+            password_hash='x',
+            worker='veterinario',
+        )
+        vet = Veterinario(id=5, user_id=vet_user.id, crmv='456')
+        invite = VetClinicInvite(
+            id=5,
+            clinica_id=clinic.id,
+            veterinario_id=vet.id,
+            status='declined',
+        )
+        db.session.add_all([admin, clinic, vet_user, vet, invite])
+        db.session.commit()
+
+        mocked_send = MagicMock()
+        monkeypatch.setattr('app.mail.send', mocked_send)
+
+        request_path = f'/clinica/{clinic.id}/convites/{invite.id}/resend'
+
+        with flask_app.test_request_context(
+            request_path,
+            method='POST',
+            data={'resend_invite-submit': 'Reenviar'},
+        ):
+            login_user(vet_user)
+            with pytest.raises(Forbidden):
+                resend_clinic_invite(clinic.id, invite.id)
+            logout_user()
+        db.session.refresh(invite)
+        assert invite.status == 'declined'
+        mocked_send.assert_not_called()
+
+        with flask_app.test_request_context(
+            request_path,
+            method='POST',
+            data={'resend_invite-submit': 'Reenviar'},
+        ):
+            login_user(admin)
+            response = resend_clinic_invite(clinica_id=clinic.id, invite_id=invite.id)
+            logout_user()
+        assert response.status_code == 302
+        db.session.refresh(invite)
+        assert invite.status == 'pending'
+        mocked_send.assert_called_once()
 
         db.session.remove()
         db.drop_all()


### PR DESCRIPTION
## Summary
- allow clinic managers to view pending, declined, accepted and cancelled invitations directly in the clinic detail view
- add helper utilities and endpoints to cancel or resend invites while reusing the email delivery logic
- cover invite management permissions with unit tests for owners and admins

## Testing
- pytest tests/test_clinic_vet.py

------
https://chatgpt.com/codex/tasks/task_e_68cda1196570832ea19351ef9f561ef5