### PR TITLE
Auto-accept self-scheduled appointments

### DIFF
--- a/app.py
+++ b/app.py
@@ -2264,6 +2264,8 @@ def agendar_retorno(consulta_id):
             if conflict_exam:
                 flash('Horário indisponível para o veterinário selecionado.', 'danger')
             else:
+                current_vet = getattr(current_user, 'veterinario', None)
+                same_user = current_vet and current_vet.id == vet_id
                 appt = Appointment(
                     consulta_id=consulta.id,
                     animal_id=consulta.animal_id,
@@ -2272,6 +2274,7 @@ def agendar_retorno(consulta_id):
                     scheduled_at=scheduled_at,
                     notes=form.reason.data,
                     kind='retorno',
+                    status='accepted' if same_user else 'scheduled',
                 )
                 db.session.add(appt)
                 db.session.commit()
@@ -7433,6 +7436,8 @@ def appointments():
                         .astimezone(timezone.utc)
                         .replace(tzinfo=None)
                     )
+                    current_vet = getattr(current_user, 'veterinario', None)
+                    same_user = current_vet and current_vet.id == veterinario.id
                     appt = Appointment(
                         animal_id=animal.id,
                         tutor_id=tutor_id,
@@ -7441,6 +7446,7 @@ def appointments():
                         clinica_id=veterinario.clinica_id or animal.clinica_id,
                         notes=appointment_form.reason.data,
                         kind=appointment_form.kind.data,
+                        status='accepted' if same_user else 'scheduled',
                     )
                     db.session.add(appt)
                     db.session.commit()

--- a/tests/test_agendar_retorno.py
+++ b/tests/test_agendar_retorno.py
@@ -91,6 +91,7 @@ def test_agendar_retorno_cria_appointment(client, monkeypatch):
         assert appt.animal_id == animal_id
         assert appt.tutor_id == tutor_id
         assert appt.veterinario_id == vet_id
+        assert appt.status == 'accepted'
 
 
 def test_agendar_retorno_falha_quando_horario_ocupado(client, monkeypatch):

--- a/tests/test_appointment_vet.py
+++ b/tests/test_appointment_vet.py
@@ -101,6 +101,7 @@ def test_veterinarian_can_schedule_for_other_users_animal(client, monkeypatch):
         assert appt.animal_id == animal_id
         assert appt.veterinario_id == vet_id
         assert appt.clinica_id == clinic_id
+        assert appt.status == 'accepted'
 
 
 def test_tutor_sees_only_their_animals_in_form(client):

--- a/tests/test_collaborator_appointment.py
+++ b/tests/test_collaborator_appointment.py
@@ -64,3 +64,4 @@ def test_collaborator_can_schedule_consulta(client, monkeypatch):
         assert appt is not None
         assert appt.kind == 'consulta'
         assert appt.notes == 'Checkup'
+        assert appt.status == 'scheduled'


### PR DESCRIPTION
## Summary
- auto-accept appointments scheduled by the attending veterinarian both for new bookings and return visits
- cover the new behaviour with assertions in veterinarian, return and collaborator scheduling tests

## Testing
- pytest tests/test_appointment_vet.py tests/test_collaborator_appointment.py tests/test_agendar_retorno.py


------
https://chatgpt.com/codex/tasks/task_e_68cdac4bafc4832e8e9b65c59ca594d6