### PR TITLE
Restrict appointments view switch to matching roles

### DIFF
--- a/app.py
+++ b/app.py
@@ -7309,8 +7309,16 @@ def appointments():
 
     view_as = request.args.get('view_as')
     worker = current_user.worker
-    if current_user.role == 'admin' and view_as in ['veterinario', 'colaborador', 'tutor']:
-        worker = view_as
+    if view_as:
+        allowed_views = {'veterinario', 'colaborador', 'tutor'}
+        if current_user.role == 'admin' and view_as in allowed_views:
+            worker = view_as
+        elif current_user.role != 'admin':
+            # Non-admin users can only request the view matching their own role.
+            user_view = worker if worker in allowed_views else 'tutor'
+            if view_as not in allowed_views or view_as != user_view:
+                flash('Você não tem permissão para acessar essa visão de agenda.', 'warning')
+                return redirect(url_for('appointments'))
 
     agenda_users = []
     if current_user.role == 'admin':


### PR DESCRIPTION
## Summary
- prevent non-admin accounts from forcing the veterinarian agenda view by validating the `view_as` query parameter and redirecting unauthorized requests
- add regression coverage asserting collaborators and tutors are redirected when requesting the veterinarian view

## Testing
- pytest tests/test_admin_view_switch.py

------
https://chatgpt.com/codex/tasks/task_e_68cdac9397fc832e9c66995c80347bcc