### PR TITLE
Handle veterinarians without profile when viewing clinic invites

### DIFF
--- a/templates/clinica/clinic_invites.html
+++ b/templates/clinica/clinic_invites.html
@@ -4,7 +4,14 @@
   <div class="row justify-content-center">
     <div class="col-12 col-lg-10 col-xl-8">
       <h1 class="h3 mb-4">Convites de Clínicas</h1>
-      {% if invites %}
+      {% if missing_vet_profile %}
+      <div class="card shadow-sm border-0">
+        <div class="card-body text-center py-5" role="status" aria-live="polite">
+          <h2 class="h5">Complete seu cadastro de veterinário</h2>
+          <p class="text-muted mb-0">{{ missing_vet_profile_message }}</p>
+        </div>
+      </div>
+      {% elif invites %}
       <div class="row gy-4">
         {% for invite in invites %}
         <div class="col-12">


### PR DESCRIPTION
## Summary
- add a reusable helper to require a veterinarian profile or render guidance for completing the registration
- update the clinic invites view/template to surface the guidance instead of aborting when the profile is missing
- reuse the helper in the invite response route and cover the new flow with a template test

## Testing
- pytest tests/test_clinic_invites_template.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb36559e4832eaa72912b4e5151d8