### PR TITLE
Ensure vet schedule submit button posts WTForm field

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -113,7 +113,11 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-          <button type="submit" form="schedule-form" class="btn btn-primary">Salvar Horário</button>
+          <button type="submit"
+                  form="schedule-form"
+                  class="btn btn-primary"
+                  name="{{ schedule_form.submit.name }}"
+                  value="Salvar Horário">Salvar Horário</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure the "Salvar Horário" button in the vet schedule modal posts the WTForms submit field so the backend sees `schedule_form.submit`

## Testing
- pytest
- manual verification: created a veterinarian schedule via the `/appointments` page and confirmed it appears after reload

------
https://chatgpt.com/codex/tasks/task_e_68cdbfe94cec832e85fb1266c8114dde