### PR TITLE
Preserve appointment filters after scheduling

### DIFF
--- a/app.py
+++ b/app.py
@@ -7430,13 +7430,11 @@ def appointments():
             veterinario = current_user.veterinario
         if not veterinario:
             abort(404)
-        appointments_url = url_for('appointments')
+        query_args = request.args.to_dict()
         if current_user.role == 'admin':
-            appointments_url = url_for(
-                'appointments',
-                view_as='veterinario',
-                veterinario_id=veterinario.id,
-            )
+            query_args['view_as'] = 'veterinario'
+            query_args['veterinario_id'] = veterinario.id
+        appointments_url = url_for('appointments', **query_args)
         schedule_form = VetScheduleForm(prefix='schedule')
         appointment_form = AppointmentForm(is_veterinario=True, prefix='appointment')
         if _is_admin():


### PR DESCRIPTION
## Summary
- keep existing query parameters when redirecting back to the appointments page
- ensure veterinarians viewing filtered ranges continue to see newly created appointments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdccf892c8832ebfc3ba2de625dc78