### PR TITLE
Specify appointment time format in AppointmentForm

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -434,6 +434,7 @@ class AppointmentForm(FlaskForm):
 
     time = TimeField(
         'Horário',
+        format='%H:%M',
         validators=[DataRequired()],
     )
 


### PR DESCRIPTION
## Summary
- explicitly set the AppointmentForm time field to parse values in `%H:%M` so it aligns with the HTML time input
- verified the appointments template continues to render the time field with `<input type="time">`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce0fcff6d4832eaf6b59df97f8bc1f