### PR TITLE
Fix appointment form field selectors

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -212,8 +212,8 @@
 <script src="{{ url_for('static', filename='appointments_table.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  const vetField = document.getElementById('veterinario_id');
-  const dateField = document.getElementById('date');
+  const vetField = {% if form %}document.getElementById('{{ form.veterinario_id.id }}'){% else %}null{% endif %};
+  const dateField = {% if form %}document.getElementById('{{ form.date.id }}'){% else %}null{% endif %};
   const datalist = document.getElementById('available-times');
   const scheduleContainer = document.getElementById('schedule-overview');
 
@@ -281,7 +281,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (scheduleBtn && scheduleModalEl) {
     const scheduleModal = new bootstrap.Modal(scheduleModalEl);
     scheduleBtn.addEventListener('click', () => {
-      const vetSelectSrc = document.getElementById('veterinario_id');
+      const vetSelectSrc = vetField;
       const vetSelect = document.getElementById('schedule-vet');
       if (vetSelectSrc && vetSelect) {
         vetSelect.innerHTML = vetSelectSrc.innerHTML;


### PR DESCRIPTION
## Summary
- update the appointments page script to query form fields by their rendered IDs
- reuse the resolved veterinarian select element when copying options into the schedule modal

## Testing
- pytest tests/test_scheduling.py

------
https://chatgpt.com/codex/tasks/task_e_68ce10165620832e9a5b128a46390096