### PR TITLE
Fix appointment grouping by local date

### DIFF
--- a/app.py
+++ b/app.py
@@ -7766,7 +7766,7 @@ def appointments():
                 .all()
             )
             for vac in vaccine_appointments:
-                vac.scheduled_at = datetime.combine(vac.aplicada_em, time.min)
+                vac.scheduled_at = datetime.combine(vac.aplicada_em, time.min, tzinfo=BR_TZ)
             form = appointment_form
         else:
             tutor_user = current_user
@@ -7793,7 +7793,7 @@ def appointments():
                 .all()
             )
             for vac in vaccine_appointments:
-                vac.scheduled_at = datetime.combine(vac.aplicada_em, time.min)
+                vac.scheduled_at = datetime.combine(vac.aplicada_em, time.min, tzinfo=BR_TZ)
             form = None
         appointments_grouped = group_appointments_by_day(appointments)
         exam_appointments_grouped = group_appointments_by_day(exam_appointments)

--- a/tests/test_group_appointments.py
+++ b/tests/test_group_appointments.py
@@ -1,0 +1,35 @@
+import os
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from helpers import BR_TZ, group_appointments_by_day
+
+
+class AppointmentStub:
+    def __init__(self, scheduled_at, label):
+        self.scheduled_at = scheduled_at
+        self.label = label
+
+
+def test_group_appointments_uses_local_date():
+    utc = ZoneInfo("UTC")
+    midday_local = datetime(2024, 5, 1, 12, 0, tzinfo=BR_TZ)
+    midday_utc = midday_local.astimezone(utc).replace(tzinfo=None)
+    late_local = datetime(2024, 5, 1, 22, 0, tzinfo=BR_TZ)
+    late_utc = late_local.astimezone(utc).replace(tzinfo=None)
+
+    appointments = [
+        AppointmentStub(midday_utc, "midday"),
+        AppointmentStub(late_utc, "late"),
+    ]
+
+    grouped = group_appointments_by_day(appointments)
+
+    assert len(grouped) == 1
+    day, items = grouped[0]
+    assert day == midday_local.date()
+    assert [appt.label for appt in items] == ["midday", "late"]


### PR DESCRIPTION
## Summary
- adjust helpers.group_appointments_by_day to group using appointments converted to America/Sao_Paulo before deriving the date
- ensure vaccine appointment placeholders are created with timezone-aware datetimes so they stay on the expected day
- add a regression test covering an appointment stored at 22:00 BRT so it remains grouped with the correct local date

## Testing
- pytest tests/test_group_appointments.py
- pytest tests/test_vacinas.py::test_fluxo_criacao_edicao_vacina

------
https://chatgpt.com/codex/tasks/task_e_68ce10148f44832e898992627e81cfdb