### PR TITLE
Fix timezone conversion for appointment range filters

### DIFF
--- a/tests/test_appointment_timezone_filters.py
+++ b/tests/test_appointment_timezone_filters.py
@@ -1,0 +1,85 @@
+import os
+import sys
+from datetime import datetime, timezone
+
+import flask_login.utils as login_utils
+import pytest
+
+
+os.environ.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import app as flask_app, db
+from helpers import BR_TZ
+from models import Animal, Appointment, Clinica, User, Veterinario
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        SECRET_KEY='testing',
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def _local_naive_to_utc(local_dt: datetime) -> datetime:
+    return local_dt.replace(tzinfo=BR_TZ).astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def test_late_brt_appointment_survives_local_filters(client, monkeypatch):
+    with flask_app.app_context():
+        admin = User(name='Admin', email='admin@example.com', password_hash='x', role='admin')
+        clinic = Clinica(nome='Clínica Teste', owner=admin)
+        tutor = User(name='Tutor', email='tutor@example.com', password_hash='x')
+        vet_user = User(
+            name='Vet',
+            email='vet@example.com',
+            password_hash='x',
+            worker='veterinario',
+        )
+        vet = Veterinario(user=vet_user, crmv='123', clinica=clinic)
+        animal = Animal(name='Rex', owner=tutor, clinica=clinic)
+        db.session.add_all([admin, clinic, tutor, vet_user, vet, animal])
+        db.session.commit()
+
+        scheduled_local = datetime(2024, 5, 1, 23, 30)
+        scheduled_utc = _local_naive_to_utc(scheduled_local)
+        appointment = Appointment(
+            animal_id=animal.id,
+            tutor_id=tutor.id,
+            veterinario_id=vet.id,
+            scheduled_at=scheduled_utc,
+            clinica_id=clinic.id,
+            status='accepted',
+            kind='consulta',
+        )
+        db.session.add(appointment)
+        db.session.commit()
+
+        vet_user_id = vet_user.id
+        admin_id = admin.id
+        clinic_id = clinic.id
+
+    start = '2024-05-01'
+
+    monkeypatch.setattr(login_utils, '_get_user', lambda: User.query.get(vet_user_id))
+    resp = client.get(f'/appointments?start={start}&end={start}')
+    assert resp.status_code == 200
+    vet_html = resp.data.decode()
+    assert '01/05/2024 23:30' in vet_html
+
+    monkeypatch.setattr(login_utils, '_get_user', lambda: User.query.get(admin_id))
+    resp = client.get(f'/clinica/{clinic_id}?start={start}&end={start}')
+    assert resp.status_code == 200
+    clinic_html = resp.data.decode()
+    assert '23:30' in clinic_html
+    assert 'Rex' in clinic_html


### PR DESCRIPTION
## Summary
- add a helper to convert local date filters to the UTC-naive timestamps stored for appointments
- update the veterinarian agenda and clinic detail views to use the normalized UTC boundaries for appointment and exam queries
- add a regression test to ensure a 23:30 BRT appointment remains visible when filtering by that local day in both views

## Testing
- pytest tests/test_appointment_timezone_filters.py

------
https://chatgpt.com/codex/tasks/task_e_68ce13a712f8832e9c4b2a6d431110aa