### PR TITLE
Ensure calendar events use timezone-aware datetimes

### DIFF
--- a/app.py
+++ b/app.py
@@ -263,6 +263,7 @@ from helpers import (
     group_appointments_by_day,
     group_vet_schedules_by_day,
     appointments_to_events,
+    to_timezone_aware,
     get_available_times,
     get_weekly_schedule,
 )
@@ -8130,11 +8131,13 @@ def api_user_appointments(user_id):
             if getattr(exam, 'specialist', None) and getattr(exam.specialist, 'user', None):
                 title = f"{title} - {exam.specialist.user.name}"
             end_time = exam.scheduled_at + timedelta(minutes=30)
+            start = to_timezone_aware(exam.scheduled_at)
+            end = to_timezone_aware(end_time)
             return {
                 'id': f"exam-{exam.id}",
                 'title': title,
-                'start': exam.scheduled_at.isoformat(),
-                'end': end_time.isoformat(),
+                'start': start.isoformat() if start else None,
+                'end': end.isoformat() if end else None,
             }
 
         exam_events = [exam_to_event(exam) for exam in unique_exam_appointments]
@@ -8162,16 +8165,18 @@ def api_user_appointments(user_id):
                 unique_vaccines.append(vac)
 
         def vaccine_to_event(vaccine):
-            start = datetime.combine(vaccine.aplicada_em, time.min)
+            start = datetime.combine(vaccine.aplicada_em, time.min, tzinfo=BR_TZ)
             end = start + timedelta(hours=1)
             title = f"Vacina: {vaccine.nome}"
             if getattr(vaccine, 'animal', None):
                 title = f"{title} - {vaccine.animal.name}"
+            start_aware = to_timezone_aware(start)
+            end_aware = to_timezone_aware(end)
             return {
                 'id': f"vaccine-{vaccine.id}",
                 'title': title,
-                'start': start.isoformat(),
-                'end': end.isoformat(),
+                'start': start_aware.isoformat() if start_aware else None,
+                'end': end_aware.isoformat() if end_aware else None,
             }
 
         vaccine_events = [vaccine_to_event(vac) for vac in unique_vaccines]


### PR DESCRIPTION
## Summary
- add a helper to convert naive UTC values into timezone-aware datetimes for calendar serialization
- update appointment, exam, and vaccine event builders to emit start/end timestamps with explicit offsets
- extend appointment API tests to verify the timezone-aware payloads

## Testing
- pytest tests/test_appointment_events_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ce13aa429c832ea758f5e7bd084dfb