### PR TITLE
Link appointments to consultations when starting

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -270,7 +270,7 @@
               data-animal-id="{{ appt.animal_id }}"
               data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
               data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
-              data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}"
+              data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
               data-notes="{{ appt.notes or '' }}"
               data-type="{{ item.kind }}">
             <div class="d-flex justify-content-between align-items-center">
@@ -288,7 +288,7 @@
               <div class="btn-group">
                 <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
                 <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
-                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
+                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
               </div>
             </div>
           </div>
@@ -325,7 +325,7 @@
               data-animal-id="{{ appt.animal_id }}"
               data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
               data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
-              data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}"
+              data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
               data-notes="{{ appt.notes or '' }}">
             <div class="d-flex justify-content-between align-items-center">
               <div class="d-flex align-items-center">
@@ -340,7 +340,7 @@
               <div class="btn-group">
                 <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
                 <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
-                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
+                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
               </div>
             </div>
           </div>

--- a/templates/partials/appointments_table.html
+++ b/templates/partials/appointments_table.html
@@ -151,7 +151,7 @@
                                     <i class="fa-solid fa-user me-1"></i>Ficha do Tutor
                                 </a>
                                 {% if current_user.worker in ['veterinario', 'colaborador'] %}
-                                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-success" title="Iniciar Consulta">
+                                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success" title="Iniciar Consulta">
                                     <i class="fa-solid fa-stethoscope me-1"></i>Iniciar Consulta
                                 </a>
                                 {% endif %}


### PR DESCRIPTION
## Summary
- append the appointment identifier to consultation links in vet schedule and appointments table templates
- load the selected appointment in `consulta_direct`, enforce clinic/animal access, link or create the active consultation, and mark it accepted for the assigned vet
- complete linked appointments when consultations are finalized and include refreshed appointment HTML in JSON responses to support partial refreshes

## Testing
- pytest tests/test_agendar_retorno.py
- pytest tests/test_clinic_access.py

------
https://chatgpt.com/codex/tasks/task_e_68ce180a72cc832ea2ee91b1e1cea8e1