### PR TITLE
Fix Inputmask CDN URL in layout template

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -898,7 +898,7 @@
       });
     });
   </script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/inputmask/5.0.8/inputmask.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.8/dist/inputmask.min.js"></script>
   <script src="{{ url_for('static', filename='masks.js') }}"></script>
   <script src="{{ url_for('static', filename='avatar_helper.js') }}"></script>
   <script src="{{ url_for('static', filename='js/mobile.js') }}"></script>


### PR DESCRIPTION
## Summary
- replace the broken cdnjs Inputmask script in the shared layout with the working jsDelivr URL so the asset loads correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cea51cac3c832ea8547c8fc678d735