### PR TITLE
Fix vet appointment select field name

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -149,7 +149,7 @@
               </div>
               <div class="col-md-6 mb-3">
                 {{ appointment_form.time.label(class="form-label fw-bold") }}
-                <select id="appointment-time" name="time" class="form-select">
+                <select id="appointment-time" name="{{ appointment_form.time.name }}" class="form-select">
                   <option value="">Selecione...</option>
                 </select>
               </div>


### PR DESCRIPTION
## Summary
- ensure the appointment time dropdown in the vet schedule template uses the WTForms field name so submissions bind correctly

## Testing
- `pytest tests/test_appointment_vet.py`


------
https://chatgpt.com/codex/tasks/task_e_68cea9cc5860832ea6c4a71f67209437