### PR TITLE
Enhance vet schedule history with consultations and exams

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ from itsdangerous import URLSafeTimedSerializer
 from jinja2 import TemplateNotFound
 import json
 import unicodedata
-from sqlalchemy import func, or_, exists
+from sqlalchemy import func, or_, exists, and_
 from sqlalchemy.orm import joinedload
 
 # ----------------------------------------------------------------
@@ -7681,7 +7681,7 @@ def appointments():
             appt.time_left = (appt.scheduled_at - timedelta(hours=2)) - now
             appointments_pending.append({'kind': 'consulta', 'appt': appt})
 
-        from models import ExamAppointment, Message
+        from models import ExamAppointment, Message, BlocoExames
 
         exam_pending = (
             ExamAppointment.query.filter_by(specialist_id=veterinario.id, status='pending')
@@ -7726,11 +7726,136 @@ def appointments():
             appointments_upcoming.append({'kind': 'exame', 'appt': exam})
         appointments_upcoming.sort(key=lambda x: x['appt'].scheduled_at)
 
-        appointments_past = (
-            Appointment.query.filter_by(veterinario_id=veterinario.id)
-            .filter(Appointment.scheduled_at < start_dt_utc)
-            .order_by(Appointment.scheduled_at.desc())
+        consulta_filters = [Consulta.status == 'finalizada']
+        scope_filters = []
+        if veterinario.user_id:
+            scope_filters.append(Consulta.created_by == veterinario.user_id)
+        if veterinario.clinica_id:
+            scope_filters.append(Consulta.clinica_id == veterinario.clinica_id)
+        if scope_filters:
+            consulta_filters.append(or_(*scope_filters))
+
+        consultas_finalizadas = (
+            Consulta.query.outerjoin(Appointment, Consulta.appointment)
+            .options(
+                joinedload(Consulta.animal).joinedload(Animal.owner),
+                joinedload(Consulta.veterinario),
+                joinedload(Consulta.appointment)
+                .joinedload(Appointment.animal)
+                .joinedload(Animal.owner),
+            )
+            .filter(*consulta_filters)
+            .filter(
+                or_(
+                    and_(
+                        Appointment.id.isnot(None),
+                        Appointment.scheduled_at >= start_dt_utc,
+                        Appointment.scheduled_at < end_dt_utc,
+                    ),
+                    and_(
+                        Appointment.id.is_(None),
+                        Consulta.created_at >= start_dt_utc,
+                        Consulta.created_at < end_dt_utc,
+                    ),
+                )
+            )
             .all()
+        )
+
+        consulta_animal_ids = {c.animal_id for c in consultas_finalizadas}
+        exam_blocks_by_consulta = defaultdict(list)
+        exam_blocks_by_animal = defaultdict(list)
+        if consulta_animal_ids:
+            blocos_query = (
+                BlocoExames.query.options(joinedload(BlocoExames.exames))
+                .filter(BlocoExames.animal_id.in_(consulta_animal_ids))
+            )
+            for bloco in blocos_query.all():
+                exam_blocks_by_animal[bloco.animal_id].append(bloco)
+                consulta_ref = getattr(bloco, 'consulta_id', None)
+                if consulta_ref:
+                    exam_blocks_by_consulta[consulta_ref].append(bloco)
+
+        schedule_events = []
+
+        def _consulta_timestamp(consulta_obj):
+            if consulta_obj.appointment and consulta_obj.appointment.scheduled_at:
+                return consulta_obj.appointment.scheduled_at
+            return consulta_obj.created_at
+
+        for consulta in consultas_finalizadas:
+            timestamp = _consulta_timestamp(consulta)
+            if not timestamp or not (start_dt_utc <= timestamp < end_dt_utc):
+                continue
+            relevant_blocks = exam_blocks_by_consulta.get(consulta.id)
+            if not relevant_blocks:
+                relevant_blocks = [
+                    bloco
+                    for bloco in exam_blocks_by_animal.get(consulta.animal_id, [])
+                    if bloco.data_criacao
+                    and timestamp
+                    and bloco.data_criacao.date() == timestamp.date()
+                ]
+            exam_summary = []
+            exam_ids = []
+            for bloco in relevant_blocks or []:
+                for exame in bloco.exames:
+                    exam_ids.append(exame.id)
+                    exam_summary.append(
+                        {
+                            'nome': exame.nome,
+                            'status': exame.status,
+                            'justificativa': exame.justificativa,
+                            'bloco_id': bloco.id,
+                        }
+                    )
+            schedule_events.append(
+                {
+                    'kind': 'consulta_finalizada',
+                    'timestamp': timestamp,
+                    'animal': consulta.animal,
+                    'consulta': consulta,
+                    'consulta_id': consulta.id,
+                    'appointment': consulta.appointment,
+                    'exam_summary': exam_summary,
+                    'exam_blocks': relevant_blocks or [],
+                    'exam_ids': exam_ids,
+                }
+            )
+
+        for item in appointments_upcoming:
+            if item['kind'] == 'retorno':
+                appt = item['appt']
+                schedule_events.append(
+                    {
+                        'kind': 'retorno',
+                        'timestamp': appt.scheduled_at,
+                        'animal': appt.animal,
+                        'appointment': appt,
+                        'consulta_id': appt.consulta_id,
+                        'exam_summary': [],
+                        'exam_blocks': [],
+                        'exam_ids': [],
+                    }
+                )
+
+        for exam in upcoming_exams:
+            schedule_events.append(
+                {
+                    'kind': 'exame',
+                    'timestamp': exam.scheduled_at,
+                    'animal': exam.animal,
+                    'exam': exam,
+                    'consulta_id': None,
+                    'exam_summary': [],
+                    'exam_blocks': [],
+                    'exam_ids': [exam.id],
+                }
+            )
+
+        schedule_events.sort(
+            key=lambda event: event.get('timestamp') or datetime.min,
+            reverse=True,
         )
 
         session['exam_pending_seen_count'] = ExamAppointment.query.filter_by(
@@ -7751,7 +7876,7 @@ def appointments():
             horarios_grouped=horarios_grouped,
             appointments_pending=appointments_pending,
             appointments_upcoming=appointments_upcoming,
-            appointments_past=appointments_past,
+            schedule_events=schedule_events,
             start_dt=start_dt,
             end_dt=end_dt,
             timedelta=timedelta,

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -303,53 +303,129 @@
     </div>
   </div>
 
-  <!-- Seção de Agendamentos Passados -->
+  <!-- Consultas finalizadas, retornos e exames -->
   <div class="card mb-4 border-secondary">
     <div class="card-header bg-secondary text-white d-flex justify-content-between align-items-center">
-      <h5 class="mb-0"><i class="fas fa-history me-2"></i>Agendamentos Passados</h5>
+      <h5 class="mb-0"><i class="fas fa-history me-2"></i>Consultas e exames no período</h5>
       <button id="toggle-past" class="btn btn-sm btn-light">
         <i class="fas fa-chevron-down me-1"></i>Mostrar
       </button>
     </div>
     <div class="card-body p-0 d-none" id="past-list">
       <div class="list-group list-group-flush">
-        {% for appt in appointments_past %}
-          <div class="list-group-item list-group-item-action appointment-item"
-              data-id="{{ appt.id }}"
-              data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
-              data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
-              data-vet="{{ appt.veterinario.user.name }}"
-              data-tutor="{{ appt.tutor.name }}"
-              data-tutor-id="{{ appt.tutor_id }}"
-              data-animal="{{ appt.animal.name }}"
-              data-animal-id="{{ appt.animal_id }}"
-              data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
-              data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
-              data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
-              data-notes="{{ appt.notes or '' }}">
-            <div class="d-flex justify-content-between align-items-center">
-              <div class="d-flex align-items-center">
-                <div class="me-3">
-                  <i class="fas fa-history fa-2x text-secondary"></i>
-                </div>
+        {% set finalizadas = schedule_events | selectattr('kind', 'equalto', 'consulta_finalizada') | list %}
+        <div class="px-3 py-2 bg-light border-bottom fw-semibold text-uppercase small">Consultas finalizadas</div>
+        {% if finalizadas %}
+          {% for event in finalizadas %}
+            {% set consulta = event.consulta %}
+            {% set animal = event.animal %}
+            {% set tutor = animal.owner %}
+            <div class="list-group-item list-group-item-action">
+              <div class="d-flex justify-content-between align-items-start gap-3">
                 <div>
-                  <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                  <small class="text-muted">{{ appt.tutor.name }}</small>
+                  <h6 class="mb-1">{{ event.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }} – {{ animal.name }}</h6>
+                  <small class="text-muted d-block">Tutor: {{ tutor.name if tutor else '—' }}</small>
+                  {% if consulta.retorno_de_id %}
+                    <span class="badge bg-warning text-dark mt-1">Retorno da consulta #{{ consulta.retorno_de_id }}</span>
+                  {% endif %}
+                  {% if event.exam_summary %}
+                    <div class="mt-2">
+                      <small class="text-muted d-block">Exames solicitados:</small>
+                      <ul class="mb-0 small ps-3">
+                        {% for exame in event.exam_summary %}
+                          <li>
+                            {{ exame.nome }}
+                            {% if exame.status %}
+                              <span class="text-muted">({{ exame.status|replace('_', ' ')|capitalize }})</span>
+                            {% endif %}
+                            {% if exame.justificativa %}
+                              <span class="text-muted">– {{ exame.justificativa }}</span>
+                            {% endif %}
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  {% endif %}
                 </div>
-              </div>
-              <div class="btn-group">
-                <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
-                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
+                <div class="d-flex flex-column align-items-end gap-2">
+                  <div class="btn-group">
+                    <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                    {% if tutor %}
+                    <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                    {% endif %}
+                    <a href="{{ url_for('consulta_direct', animal_id=animal.id, c=consulta.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-stethoscope me-1"></i>Detalhes</a>
+                  </div>
+                  <a href="{{ url_for('imprimir_consulta', consulta_id=consulta.id) }}" class="btn btn-sm btn-outline-dark" target="_blank"><i class="fas fa-print me-1"></i>Imprimir consulta</a>
+                </div>
               </div>
             </div>
-          </div>
+          {% endfor %}
         {% else %}
-          <div class="list-group-item text-center py-4">
-            <i class="fas fa-inbox fa-2x text-muted mb-2"></i>
-            <p class="text-muted mb-0">Nenhum agendamento passado.</p>
+          <div class="list-group-item text-center py-4 text-muted">
+            <i class="fas fa-inbox me-2"></i>Nenhuma consulta finalizada no período selecionado.
           </div>
-        {% endfor %}
+        {% endif %}
+
+        {% set retornos = schedule_events | selectattr('kind', 'equalto', 'retorno') | list %}
+        <div class="px-3 py-2 bg-light border-bottom fw-semibold text-uppercase small mt-2">Retornos</div>
+        {% if retornos %}
+          {% for event in retornos %}
+            {% set appt = event.appointment %}
+            {% set animal = appt.animal %}
+            {% set tutor = animal.owner %}
+            <div class="list-group-item list-group-item-action">
+              <div class="d-flex justify-content-between align-items-start gap-3">
+                <div>
+                  <h6 class="mb-1">{{ event.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }} – {{ animal.name }}</h6>
+                  <small class="text-muted d-block">Tutor: {{ tutor.name if tutor else '—' }}</small>
+                  <small class="text-muted d-block">Consulta de origem: #{{ event.consulta_id }}</small>
+                </div>
+                <div class="btn-group">
+                  <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                  {% if tutor %}
+                  <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                  {% endif %}
+                  <a href="{{ url_for('consulta_direct', animal_id=animal.id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-redo me-1"></i>Abrir retorno</a>
+                </div>
+              </div>
+            </div>
+          {% endfor %}
+        {% else %}
+          <div class="list-group-item text-center py-4 text-muted">
+            <i class="fas fa-calendar-times me-2"></i>Nenhum retorno agendado no período.
+          </div>
+        {% endif %}
+
+        {% set exames = schedule_events | selectattr('kind', 'equalto', 'exame') | list %}
+        <div class="px-3 py-2 bg-light border-bottom fw-semibold text-uppercase small mt-2">Exames</div>
+        {% if exames %}
+          {% for event in exames %}
+            {% set exam = event.exam %}
+            {% set animal = event.animal %}
+            {% set tutor = animal.owner %}
+            {% set especialista = exam.specialist.user if exam.specialist and exam.specialist.user else None %}
+            <div class="list-group-item list-group-item-action">
+              <div class="d-flex justify-content-between align-items-start gap-3">
+                <div>
+                  <h6 class="mb-1">{{ event.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }} – {{ animal.name }}</h6>
+                  <small class="text-muted d-block">Tutor: {{ tutor.name if tutor else '—' }}</small>
+                  <small class="text-muted d-block">Especialista: {{ especialista.name if especialista else '—' }}</small>
+                  <small class="text-muted d-block">Status: {{ exam.status_display }}</small>
+                </div>
+                <div class="btn-group">
+                  <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                  {% if tutor %}
+                  <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+          {% endfor %}
+        {% else %}
+          <div class="list-group-item text-center py-4 text-muted">
+            <i class="fas fa-flask me-2"></i>Nenhum exame confirmado no período.
+          </div>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add consolidated history events for finalized consultations, scheduled returns, and exams in the veterinarian agenda
- include exam request summaries sourced from BlocoExames when displaying finalized consultations
- update the agenda template to render the new grouped timeline with quick access actions and print links
- fix the veterinarian history query to use attribute-based joinedload paths compatible with SQLAlchemy 2

## Testing
- pytest tests/test_agendar_retorno.py tests/test_imprimir_bloco_exames.py

------
https://chatgpt.com/codex/tasks/task_e_68cea5ba03e0832e9cc28c0444407e7c