### PR TITLE
Atualiza agendamentos no modal sem recarregar a página

### DIFF
--- a/app.py
+++ b/app.py
@@ -8017,6 +8017,12 @@ def appointments():
         appointments_grouped = group_appointments_by_day(appointments)
         exam_appointments_grouped = group_appointments_by_day(exam_appointments)
         vaccine_appointments_grouped = group_appointments_by_day(vaccine_appointments)
+        if request.headers.get('X-Partial') == 'appointments_table' or request.args.get('partial') == 'appointments_table':
+            return render_template(
+                'partials/appointments_table.html',
+                appointments_grouped=appointments_grouped,
+            )
+
         return render_template(
             'agendamentos/appointments.html',
             appointments=appointments,
@@ -8197,7 +8203,13 @@ def edit_appointment(appointment_id):
         if notes is not None:
             appointment.notes = notes
         db.session.commit()
-        return jsonify({'success': True})
+        card_html = render_template('partials/_appointment_card.html', appt=appointment)
+        return jsonify({
+            'success': True,
+            'message': 'Agendamento atualizado com sucesso.',
+            'card_html': card_html,
+            'appointment_id': appointment.id,
+        })
 
     veterinarios = Veterinario.query.all()
     if request.headers.get('X-Requested-With') == 'XMLHttpRequest':

--- a/static/appointments_table.js
+++ b/static/appointments_table.js
@@ -1,58 +1,351 @@
+const EMPTY_STATE_HTML = `
+  <div class="empty-state">
+    <span class="icon-circle bg-secondary text-white"><i class="fa-regular fa-calendar-xmark"></i></span>
+    <h3>Nenhum agendamento encontrado</h3>
+    <p>Não há agendamentos para exibir no momento.</p>
+  </div>
+`;
+
+function parseHTML(html) {
+  if (!html) {
+    return null;
+  }
+  const template = document.createElement('template');
+  template.innerHTML = html.trim();
+  return template.content.firstElementChild;
+}
+
+function findAppointmentsContainer(element) {
+  if (!element) {
+    return null;
+  }
+  return element.closest('[data-appointments-container]');
+}
+
+function ensureModalAlertContainer(modalBody) {
+  if (!modalBody) {
+    return null;
+  }
+  let container = modalBody.querySelector('.modal-feedback');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'modal-feedback';
+    modalBody.prepend(container);
+  }
+  return container;
+}
+
+function clearModalAlerts(modalBody) {
+  const container = ensureModalAlertContainer(modalBody);
+  if (container) {
+    container.innerHTML = '';
+  }
+}
+
+function showModalAlert(modalBody, type, message) {
+  const container = ensureModalAlertContainer(modalBody);
+  if (!container) {
+    return;
+  }
+  const alert = document.createElement('div');
+  alert.className = `alert alert-${type} mt-2`;
+  alert.textContent = message;
+  container.innerHTML = '';
+  container.appendChild(alert);
+}
+
+function removeEmptyState(container) {
+  if (!container) {
+    return;
+  }
+  container.querySelectorAll('.empty-state').forEach((el) => el.remove());
+}
+
+function insertBeforeTrailingScript(container, element) {
+  if (!container || !element) {
+    return;
+  }
+  const scriptSibling = Array.from(container.children).find((child) => child.tagName === 'SCRIPT');
+  if (scriptSibling) {
+    container.insertBefore(element, scriptSibling);
+  } else {
+    container.appendChild(element);
+  }
+}
+
+function ensureEmptyState(container) {
+  if (!container) {
+    return;
+  }
+  const hasAppointments = container.querySelector('.appointments-day-block .appointment-card');
+  const hasEmptyState = container.querySelector('.empty-state');
+  if (!hasAppointments && !hasEmptyState) {
+    const emptyStateEl = parseHTML(EMPTY_STATE_HTML);
+    if (emptyStateEl) {
+      insertBeforeTrailingScript(container, emptyStateEl);
+    }
+  }
+}
+
+function createDayBlock(day, dayLabel) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'appointments-day-block';
+  wrapper.dataset.day = day;
+  wrapper.dataset.dayLabel = dayLabel;
+  wrapper.innerHTML = `
+    <div class="day-header d-flex align-items-center gap-2" data-day="${day}" data-day-label="${dayLabel}">
+      <span class="icon-circle bg-primary text-white"><i class="fa-solid fa-calendar-day"></i></span>
+      ${dayLabel}
+    </div>
+    <div class="day-appointments"></div>
+  `;
+  return wrapper;
+}
+
+function insertDayBlock(container, block) {
+  const day = block.dataset.day;
+  const existingBlocks = Array.from(container.querySelectorAll('.appointments-day-block'));
+  let inserted = false;
+  for (const existing of existingBlocks) {
+    if ((existing.dataset.day || '') > day) {
+      container.insertBefore(block, existing);
+      inserted = true;
+      break;
+    }
+  }
+  if (!inserted) {
+    insertBeforeTrailingScript(container, block);
+  }
+  return block;
+}
+
+function insertAppointmentRow(container, row) {
+  if (!container || !row) {
+    return false;
+  }
+  const day = row.dataset.day;
+  if (!day) {
+    return false;
+  }
+  const dayLabel = row.dataset.dayLabel || day;
+  removeEmptyState(container);
+
+  let block = container.querySelector(`.appointments-day-block[data-day="${day}"]`);
+  if (!block) {
+    block = insertDayBlock(container, createDayBlock(day, dayLabel));
+  }
+
+  let appointmentsContainer = block.querySelector('.day-appointments');
+  if (!appointmentsContainer) {
+    appointmentsContainer = document.createElement('div');
+    appointmentsContainer.className = 'day-appointments';
+    block.appendChild(appointmentsContainer);
+  }
+
+  const siblings = Array.from(appointmentsContainer.querySelectorAll('.appointment-card'));
+  const newTime = row.dataset.scheduled || '';
+  const target = siblings.find((sibling) => {
+    const siblingTime = sibling.dataset.scheduled || '';
+    return siblingTime && siblingTime > newTime;
+  });
+
+  if (target) {
+    appointmentsContainer.insertBefore(row, target);
+  } else {
+    appointmentsContainer.appendChild(row);
+  }
+
+  return true;
+}
+
+function updateAppointmentRow(existingRow, newRow) {
+  if (!existingRow || !newRow) {
+    return false;
+  }
+  const container = findAppointmentsContainer(existingRow);
+  if (!container) {
+    return false;
+  }
+
+  const oldBlock = existingRow.closest('.appointments-day-block');
+  existingRow.remove();
+
+  if (oldBlock) {
+    const remaining = oldBlock.querySelector('.appointment-card');
+    if (!remaining) {
+      oldBlock.remove();
+    }
+  }
+
+  const inserted = insertAppointmentRow(container, newRow);
+  if (!inserted) {
+    ensureEmptyState(container);
+    return false;
+  }
+
+  bindAppointmentRowClicks();
+  return true;
+}
+
+function buildPartialUrl(url) {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    parsed.searchParams.set('partial', 'appointments_table');
+    return parsed.toString();
+  } catch (error) {
+    return url;
+  }
+}
+
+async function refreshAppointmentsContainer(container) {
+  if (!container) {
+    return false;
+  }
+  const refreshUrl = container.dataset.refreshUrl || window.location.href;
+  const targetUrl = buildPartialUrl(refreshUrl);
+  try {
+    const response = await fetch(targetUrl, {
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-Partial': 'appointments_table'
+      }
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const html = await response.text();
+    container.innerHTML = html;
+    bindAppointmentRowClicks();
+    return true;
+  } catch (error) {
+    console.error('Erro ao atualizar lista de agendamentos', error);
+    return false;
+  }
+}
+
 function bindAppointmentRowClicks() {
   const modalEl = document.getElementById('appointmentEditModal');
   const modalBody = modalEl ? modalEl.querySelector('.modal-body') : null;
-  const bsModal = modalEl ? new bootstrap.Modal(modalEl) : null;
+  const bsModal = modalEl ? bootstrap.Modal.getOrCreateInstance(modalEl) : null;
 
-  document.querySelectorAll('.appointment-row').forEach(function(row) {
-    row.addEventListener('click', function(e) {
-      if (e.target.closest('.btn')) {
+  document.querySelectorAll('.appointment-row').forEach((row) => {
+    if (row.dataset.boundClick === 'true') {
+      return;
+    }
+    row.dataset.boundClick = 'true';
+    row.addEventListener('click', (event) => {
+      if (event.target.closest('.btn')) {
         return;
       }
-      const url = this.dataset.href;
-      if (!url) return;
+      const url = row.dataset.href;
+      if (!url) {
+        return;
+      }
       if (modalEl && modalBody && bsModal) {
+        bsModal.show();
         fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-          .then(resp => resp.text())
-          .then(html => {
+          .then((resp) => {
+            if (!resp.ok) {
+              throw new Error('Erro ao carregar formulário');
+            }
+            return resp.text();
+          })
+          .then((html) => {
             modalBody.innerHTML = html;
+            clearModalAlerts(modalBody);
             const form = modalBody.querySelector('#edit-appointment-form');
             if (form) {
-              form.addEventListener('submit', async function(ev) {
-                ev.preventDefault();
-                const payload = {
-                  date: modalBody.querySelector('#edit-date').value,
-                  time: modalBody.querySelector('#edit-time').value,
-                  veterinario_id: modalBody.querySelector('#edit-vet').value
-                };
-                const tokenEl = modalBody.querySelector('#csrf_token');
-                const token = tokenEl ? tokenEl.value : '';
-                const resp = await fetch(url, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': token
-                  },
-                  body: JSON.stringify(payload)
-                });
-                if (resp.ok) {
-                  bsModal.hide();
-                  window.location.reload();
-                } else {
-                  let err = 'Erro ao salvar';
-                  try {
-                    const data = await resp.json();
-                    if (data.message) err = data.message;
-                  } catch (e) {}
-                  alert(err);
-                }
-              });
+              attachAppointmentFormHandler(form, { url, row, modalBody, bsModal });
             }
-            bsModal.show();
+          })
+          .catch((error) => {
+            console.error('Erro ao carregar o formulário de agendamento', error);
+            showModalAlert(modalBody, 'danger', 'Não foi possível carregar o formulário. Tente novamente.');
           });
       } else {
         window.location = url;
       }
     });
+  });
+}
+
+function attachAppointmentFormHandler(form, { url, row, modalBody, bsModal }) {
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearModalAlerts(modalBody);
+
+    const payload = {
+      date: form.querySelector('#edit-date')?.value,
+      time: form.querySelector('#edit-time')?.value,
+      veterinario_id: form.querySelector('#edit-vet')?.value
+    };
+    const notesField = form.querySelector('#edit-notes');
+    if (notesField) {
+      payload.notes = notesField.value;
+    }
+    const token = form.querySelector('#csrf_token')?.value || '';
+    const submitButton = form.querySelector('[type="submit"]');
+    if (submitButton) {
+      submitButton.disabled = true;
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': token
+        },
+        body: JSON.stringify(payload)
+      });
+      let data = null;
+      try {
+        data = await response.json();
+      } catch (err) {
+        data = null;
+      }
+
+      if (!response.ok || !data || !data.success) {
+        const message = (data && data.message) ? data.message : 'Erro ao salvar. Verifique os dados e tente novamente.';
+        showModalAlert(modalBody, 'danger', message);
+        return;
+      }
+
+      showModalAlert(modalBody, 'success', data.message || 'Agendamento atualizado com sucesso.');
+
+      let updated = false;
+      if (data.card_html) {
+        const newRow = parseHTML(data.card_html);
+        if (newRow) {
+          updated = updateAppointmentRow(row, newRow);
+        }
+      }
+      if (!updated) {
+        const container = findAppointmentsContainer(row);
+        if (container) {
+          updated = await refreshAppointmentsContainer(container);
+        }
+      }
+
+      if (window.sharedCalendar && typeof window.sharedCalendar.refetchEvents === 'function') {
+        try {
+          window.sharedCalendar.refetchEvents();
+        } catch (calendarError) {
+          console.warn('Não foi possível atualizar o calendário compartilhado.', calendarError);
+        }
+      }
+
+      setTimeout(() => {
+        bsModal.hide();
+      }, 1500);
+    } catch (error) {
+      console.error('Erro ao salvar agendamento', error);
+      showModalAlert(modalBody, 'danger', 'Erro ao salvar. Tente novamente.');
+    } finally {
+      if (submitButton) {
+        submitButton.disabled = false;
+      }
+    }
   });
 }
 

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -126,7 +126,7 @@
 
   <!-- Lista de Agendamentos -->
   <h5 class="fw-bold mb-3"><i class="bi bi-list-check me-2"></i> Consultas Agendadas</h5>
-  <div id="appointmentsList">
+  <div id="appointmentsList" data-appointments-container data-refresh-url="{{ request.url }}">
     {% include 'partials/appointments_table.html' %}
   </div>
 

--- a/templates/partials/_appointment_card.html
+++ b/templates/partials/_appointment_card.html
@@ -1,0 +1,86 @@
+{% set day_key = appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') %}
+{% set scheduled_key = appt.scheduled_at|format_datetime_brazil('%Y-%m-%dT%H:%M') %}
+{% set day_label = appt.scheduled_at|format_datetime_brazil('%A, %d/%m/%Y') %}
+{% set card_classes = 'appointment-card appointment-row ' + (appt.status or '') %}
+<div
+  class="{{ card_classes.strip() }}"
+  data-appointment-id="{{ appt.id }}"
+  data-href="{{ url_for('edit_appointment', appointment_id=appt.id) }}"
+  data-day="{{ day_key }}"
+  data-day-label="{{ day_label }}"
+  data-scheduled="{{ scheduled_key }}"
+>
+  <div class="card-body">
+    <div class="row align-items-center">
+      <div class="col-md-2">
+        <div class="time-display d-flex align-items-center gap-1">
+          <span class="icon-circle bg-secondary text-white"><i class="fa-regular fa-clock"></i></span>
+          {{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="animal-name d-flex align-items-center gap-2">
+          <span class="icon-circle bg-danger text-white"><i class="fa-solid fa-paw"></i></span>{{ appt.animal.name }}
+        </div>
+      </div>
+      <div class="col-md-2">
+        <div class="vet-name d-flex align-items-center gap-2">
+          <span class="icon-circle bg-info text-white"><i class="fa-solid fa-user-doctor"></i></span>{{ appt.veterinario.user.name }}
+        </div>
+      </div>
+      <div class="col-md-2">
+        <span class="status-badge status-{{ appt.status }}">
+          {% if appt.status == 'scheduled' %}A fazer{% endif %}
+          {% if appt.status == 'completed' %}Realizada{% endif %}
+          {% if appt.status == 'canceled' %}Cancelada{% endif %}
+          {% if appt.status == 'accepted' %}Aceita{% endif %}
+        </span>
+      </div>
+      <div class="col-md-3">
+        <div class="actions-container">
+          <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary" title="Ficha do Animal">
+            <i class="fa-solid fa-file-medical me-1"></i>Ficha do Animal
+          </a>
+          <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary" title="Ficha do Tutor">
+            <i class="fa-solid fa-user me-1"></i>Ficha do Tutor
+          </a>
+          {% if current_user.worker in ['veterinario', 'colaborador'] %}
+          <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success" title="Iniciar Consulta">
+            <i class="fa-solid fa-stethoscope me-1"></i>Iniciar Consulta
+          </a>
+          {% endif %}
+          <a href="{{ url_for('edit_appointment', appointment_id=appt.id) }}" class="btn btn-sm btn-outline-info" title="Propor novo horário">
+            <i class="fa-solid fa-arrows-rotate me-1"></i>Propor novo horário
+          </a>
+          <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
+            {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
+            <input type="hidden" name="status" value="completed">
+            <button class="btn btn-sm btn-outline-success" title="Marcar como realizada">
+              <i class="fa-solid fa-check me-1"></i>Realizada
+            </button>
+          </form>
+          <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
+            {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
+            <input type="hidden" name="status" value="canceled">
+            <button class="btn btn-sm btn-outline-warning" title="Cancelar">
+              <i class="fa-solid fa-xmark me-1"></i>Cancelar
+            </button>
+          </form>
+          <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
+            {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
+            <input type="hidden" name="status" value="scheduled">
+            <button class="btn btn-sm btn-outline-secondary" title="Marcar como a fazer">
+              <i class="fa-solid fa-clock me-1"></i>A fazer
+            </button>
+          </form>
+          <form method="POST" action="{{ url_for('delete_appointment', appointment_id=appt.id) }}" class="form-confirm" data-confirm="Excluir este agendamento?">
+            {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
+            <button class="btn btn-sm btn-outline-danger" title="Excluir">
+              <i class="fa-solid fa-trash me-1"></i>Excluir
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/partials/appointments_table.html
+++ b/templates/partials/appointments_table.html
@@ -109,88 +109,17 @@
 
 {% if appointments_grouped %}
     {% for day, items in appointments_grouped %}
-        <div class="day-header d-flex align-items-center gap-2">
-            <span class="icon-circle bg-primary text-white"><i class="fa-solid fa-calendar-day"></i></span>
-            {{ day|format_datetime_brazil('%A, %d/%m/%Y') }}
-        </div>
-
-        {% for appt in items %}
-            <div class="appointment-card appointment-row" data-href="{{ url_for('edit_appointment', appointment_id=appt.id) }}">
-                <div class="card-body">
-                    <div class="row align-items-center">
-                        <div class="col-md-2">
-                            <div class="time-display d-flex align-items-center gap-1">
-                                <span class="icon-circle bg-secondary text-white"><i class="fa-regular fa-clock"></i></span>
-                                {{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}
-                            </div>
-                        </div>
-                        <div class="col-md-3">
-                            <div class="animal-name d-flex align-items-center gap-2">
-                                <span class="icon-circle bg-danger text-white"><i class="fa-solid fa-paw"></i></span>{{ appt.animal.name }}
-                            </div>
-                        </div>
-                        <div class="col-md-2">
-                            <div class="vet-name d-flex align-items-center gap-2">
-                                <span class="icon-circle bg-info text-white"><i class="fa-solid fa-user-doctor"></i></span>{{ appt.veterinario.user.name }}
-                            </div>
-                        </div>
-                        <div class="col-md-2">
-                            <span class="status-badge status-{{ appt.status }}">
-                                {% if appt.status == 'scheduled' %}A fazer{% endif %}
-                                {% if appt.status == 'completed' %}Realizada{% endif %}
-                                {% if appt.status == 'canceled' %}Cancelada{% endif %}
-                                {% if appt.status == 'accepted' %}Aceita{% endif %}
-                            </span>
-                        </div>
-                        <div class="col-md-3">
-                            <div class="actions-container">
-                                <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary" title="Ficha do Animal">
-                                    <i class="fa-solid fa-file-medical me-1"></i>Ficha do Animal
-                                </a>
-                                <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary" title="Ficha do Tutor">
-                                    <i class="fa-solid fa-user me-1"></i>Ficha do Tutor
-                                </a>
-                                {% if current_user.worker in ['veterinario', 'colaborador'] %}
-                                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success" title="Iniciar Consulta">
-                                    <i class="fa-solid fa-stethoscope me-1"></i>Iniciar Consulta
-                                </a>
-                                {% endif %}
-                                <a href="{{ url_for('edit_appointment', appointment_id=appt.id) }}" class="btn btn-sm btn-outline-info" title="Propor novo horário">
-                                    <i class="fa-solid fa-arrows-rotate me-1"></i>Propor novo horário
-                                </a>
-                                <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
-                                    {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
-                                    <input type="hidden" name="status" value="completed">
-                                    <button class="btn btn-sm btn-outline-success" title="Marcar como realizada">
-                                        <i class="fa-solid fa-check me-1"></i>Realizada
-                                    </button>
-                                </form>
-                                <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
-                                    {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
-                                    <input type="hidden" name="status" value="canceled">
-                                    <button class="btn btn-sm btn-outline-warning" title="Cancelar">
-                                        <i class="fa-solid fa-xmark me-1"></i>Cancelar
-                                    </button>
-                                </form>
-                                <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}" class="form-confirm">
-                                    {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
-                                    <input type="hidden" name="status" value="scheduled">
-                                    <button class="btn btn-sm btn-outline-secondary" title="Marcar como a fazer">
-                                        <i class="fa-solid fa-clock me-1"></i>A fazer
-                                    </button>
-                                </form>
-                                <form method="POST" action="{{ url_for('delete_appointment', appointment_id=appt.id) }}" class="form-confirm" data-confirm="Excluir este agendamento?">
-                                    {% if csrf_token is defined %}{{ csrf_token() }}{% endif %}
-                                    <button class="btn btn-sm btn-outline-danger" title="Excluir">
-                                        <i class="fa-solid fa-trash me-1"></i>Excluir
-                                    </button>
-                                </form>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+        <div class="appointments-day-block" data-day="{{ day.isoformat() }}" data-day-label="{{ day|format_datetime_brazil('%A, %d/%m/%Y') }}">
+            <div class="day-header d-flex align-items-center gap-2" data-day="{{ day.isoformat() }}" data-day-label="{{ day|format_datetime_brazil('%A, %d/%m/%Y') }}">
+                <span class="icon-circle bg-primary text-white"><i class="fa-solid fa-calendar-day"></i></span>
+                {{ day|format_datetime_brazil('%A, %d/%m/%Y') }}
             </div>
-        {% endfor %}
+            <div class="day-appointments">
+                {% for appt in items %}
+                    {% include 'partials/_appointment_card.html' %}
+                {% endfor %}
+            </div>
+        </div>
     {% endfor %}
 {% else %}
     <div class="empty-state">

--- a/templates/partials/clinic_agendamentos_tab.html
+++ b/templates/partials/clinic_agendamentos_tab.html
@@ -32,7 +32,7 @@
             </a>
           </div>
         </form>
-        <div id="appointments-table-container">
+        <div id="appointments-table-container" data-appointments-container data-refresh-url="{{ request.url }}">
           {% include 'partials/appointments_table.html' %}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- substitui o recarregamento completo por atualização local dos cards, exibindo alertas no modal e acionando o calendário compartilhado
- adiciona partial reutilizável para cards e marcações de dia para permitir reordenação dinâmica
- expõe respostas parciais e URLs de atualização para recarregar a lista via AJAX quando necessário

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceb049b02c832e866e4b9686d412a7