### PR TITLE
Enable scheduling from calendar clicks

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -21,7 +21,15 @@
     {% endif %}
   </div>
 
-  {% with clinic_id = current_user.clinica_id %}
+  {% set calendar_redirect_url = none %}
+  {% if not form %}
+    {% if current_user.role == 'admin' %}
+      {% set calendar_redirect_url = url_for('appointments', view_as='colaborador') %}
+    {% else %}
+      {% set calendar_redirect_url = url_for('appointments_calendar') %}
+    {% endif %}
+  {% endif %}
+  {% with clinic_id = current_user.clinica_id, calendar_redirect_url = calendar_redirect_url %}
     {% include 'partials/schedule_toggle.html' %}
   {% endwith %}
 
@@ -214,8 +222,45 @@
 document.addEventListener('DOMContentLoaded', () => {
   const vetField = {% if form %}document.getElementById('{{ form.veterinario_id.id }}'){% else %}null{% endif %};
   const dateField = {% if form %}document.getElementById('{{ form.date.id }}'){% else %}null{% endif %};
+  const timeField = {% if form %}document.getElementById('{{ form.time.id }}'){% else %}null{% endif %};
   const datalist = document.getElementById('available-times');
   const scheduleContainer = document.getElementById('schedule-overview');
+  const calendarContainer = document.querySelector('[data-calendar-redirect-url]');
+  const calendarRedirectUrl = (calendarContainer && calendarContainer.dataset && calendarContainer.dataset.calendarRedirectUrl) || '';
+  const newAppointmentCollapseEl = document.getElementById('newAppointmentForm');
+  const newAppointmentToggleBtn = document.querySelector('[data-bs-target="#newAppointmentForm"]');
+  let newAppointmentCollapseInstance = null;
+
+  function ensureNewAppointmentVisible() {
+    if (!newAppointmentCollapseEl || !window.bootstrap || !bootstrap.Collapse) {
+      return;
+    }
+    if (!newAppointmentCollapseInstance) {
+      newAppointmentCollapseInstance = bootstrap.Collapse.getOrCreateInstance(
+        newAppointmentCollapseEl,
+        { toggle: false }
+      );
+    }
+    if (!newAppointmentCollapseEl.classList.contains('show')) {
+      newAppointmentCollapseInstance.show();
+    }
+    if (newAppointmentToggleBtn) {
+      newAppointmentToggleBtn.setAttribute('aria-expanded', 'true');
+    }
+  }
+
+  function focusFirstAppointmentField() {
+    if (!newAppointmentCollapseEl) {
+      return;
+    }
+    const firstField = newAppointmentCollapseEl.querySelector('input, select, textarea');
+    if (!firstField) {
+      return;
+    }
+    window.setTimeout(() => {
+      firstField.focus({ preventScroll: false });
+    }, 150);
+  }
 
   async function updateTimes() {
     if (!vetField || !dateField || !datalist) return;
@@ -290,6 +335,36 @@ document.addEventListener('DOMContentLoaded', () => {
       scheduleModal.show();
     });
   }
+
+  document.addEventListener('calendarSlotChosen', event => {
+    const detail = event.detail || {};
+    if (!detail.date) {
+      return;
+    }
+    if (!dateField) {
+      if (calendarRedirectUrl) {
+        const targetUrl = new URL(calendarRedirectUrl, window.location.origin);
+        targetUrl.searchParams.set('date', detail.date);
+        if (detail.time) {
+          targetUrl.searchParams.set('time', detail.time);
+        }
+        window.location.href = targetUrl.toString();
+      }
+      return;
+    }
+
+    ensureNewAppointmentVisible();
+
+    dateField.value = detail.date;
+    dateField.dispatchEvent(new Event('change', { bubbles: true }));
+
+    if (timeField && detail.time) {
+      timeField.value = detail.time;
+      timeField.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    focusFirstAppointmentField();
+  });
 
   vetField && vetField.addEventListener('change', () => { updateTimes(); loadSchedule(); });
   dateField && dateField.addEventListener('change', () => { updateTimes(); loadSchedule(); });

--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -11,7 +11,10 @@
     </div>
   </div>
   <div class="card-body p-0">
-    <div id="{{ calendar_id }}"></div>
+    <div id="{{ calendar_id }}" data-calendar-redirect-url="{{ calendar_redirect_url|default('') }}"></div>
+  </div>
+  <div class="card-footer bg-light small text-muted text-center">
+    💡 Clique em um dia do calendário para iniciar um novo agendamento.
   </div>
 </div>
 
@@ -26,6 +29,10 @@ document.addEventListener('DOMContentLoaded', function() {
   const userPicker = document.getElementById('admin-agenda-user-picker');
   let source = '{{ 'clinic' if clinic_id else 'user' }}';
   let selectedUserId = userPicker && userPicker.value ? userPicker.value : null;
+
+  if (!calendarEl) {
+    return;
+  }
 
   function eventUrl() {
     if (source === 'clinic') {
@@ -51,8 +58,53 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
+  function pad(value) {
+    return String(value).padStart(2, '0');
+  }
+
+  function formatLocalDate(dateObj) {
+    return [
+      dateObj.getFullYear(),
+      pad(dateObj.getMonth() + 1),
+      pad(dateObj.getDate())
+    ].join('-');
+  }
+
+  function inferApproximateTime(dateObj, isAllDay) {
+    if (isAllDay) {
+      return '09:00';
+    }
+    return `${pad(dateObj.getHours())}:${pad(dateObj.getMinutes())}`;
+  }
+
+  function emitSlotChosen(dateObj, isAllDay) {
+    if (!dateObj) {
+      return;
+    }
+    const detail = {
+      date: formatLocalDate(dateObj),
+      time: inferApproximateTime(dateObj, isAllDay),
+      allDay: !!isAllDay,
+      source,
+    };
+    const customEvent = new CustomEvent('calendarSlotChosen', {
+      detail,
+      bubbles: true,
+    });
+    calendarEl.dispatchEvent(customEvent);
+  }
+
   const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
+    selectable: true,
+    selectMirror: true,
+    select: function(info) {
+      emitSlotChosen(info.start, info.allDay);
+      calendar.unselect();
+    },
+    dateClick: function(info) {
+      emitSlotChosen(info.date, info.allDay);
+    },
   });
 
   window.sharedCalendar = calendar;


### PR DESCRIPTION
## Summary
- emit a `calendarSlotChosen` event from the shared schedule calendar when a day or range is selected and highlight that clicks create appointments
- react to the new event on the appointments page by pre-filling the New Consultation form or redirecting to the proper view when the form is unavailable

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ceb04cf658832e84cf3da70f249f87