### PR TITLE
Fix down revision for appointment migration

### DIFF
--- a/migrations/versions/529be1d96219_fix_appointment_kind_default_backfill.py
+++ b/migrations/versions/529be1d96219_fix_appointment_kind_default_backfill.py
@@ -1,12 +1,9 @@
 """fix appointment.kind default/backfill
 
 Revision ID: 529be1d96219
-Revises: 2f9a0dc93f25
+Revises: 9d3d3cdb1de4
 Create Date: 2025-09-20 18:38:44.919801
 """
-
-
-from importlib import util as importlib_util
 
 
 from alembic import op
@@ -15,12 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "529be1d96219"
-
-
-_HAS_MEDICAMENTO_TEXT_EXPANSION = importlib_util.find_spec(
-    "migrations.versions.2f9a0dc93f25_expand_medicamento_text_fields"
-) is not None
-down_revision = "2f9a0dc93f25" if _HAS_MEDICAMENTO_TEXT_EXPANSION else "b1db1e768d50"
+down_revision = "9d3d3cdb1de4"
 
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- point the 529be1d96219 migration at the preceding revision 9d3d3cdb1de4
- remove the conditional import used to choose between legacy revisions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceffc9b300832ea1d19ef8325803cb