### PR TITLE
Support appointment duration by type

### DIFF
--- a/tests/test_schedule_exam.py
+++ b/tests/test_schedule_exam.py
@@ -62,7 +62,7 @@ def test_schedule_exam_creates_event_and_blocks_time(client, monkeypatch):
     with flask_app.app_context():
         assert ExamAppointment.query.count() == 1
         assert AgendaEvento.query.count() == 1
-        times = get_available_times(vet_id, date(2024,5,20))
+        times = get_available_times(vet_id, date(2024,5,20), kind='exame')
         assert '09:00' not in times
 
 


### PR DESCRIPTION
## Summary
- add centralized appointment duration mapping and helper to compute slot conflicts
- update scheduling checks and available slot generation to honor per-kind durations
- adjust calendar/event builders and exam routes to use dynamic appointment lengths

## Testing
- pytest tests/test_schedule_interval.py tests/test_schedule_exam.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0c2cf470832eaa6019af62ac228a