### PR TITLE
Allow admin appointment API to honor view context

### DIFF
--- a/tests/test_appointment_events_api.py
+++ b/tests/test_appointment_events_api.py
@@ -106,13 +106,16 @@ def test_my_appointments_returns_all_for_admin(client, monkeypatch):
         'id': 99,
         'worker': None,
         'role': 'admin',
+        'clinica_id': None,
         'is_authenticated': True,
     })()
     login(monkeypatch, fake_admin)
     resp = client.get('/api/my_appointments')
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data == []
+    assert len(data) == 1
+    assert data[0]['id'] == appt_id
+    assert data[0]['start'] == start_iso
 
     user_resp = client.get(f'/api/user_appointments/{tutor_id}')
     assert user_resp.status_code == 200


### PR DESCRIPTION
## Summary
- adjust `/api/my_appointments` so admins see events from accessible clinics or the active view context instead of only their own tutor appointments
- derive admin view context data from the request/referrer and keep serialisation through `appointments_to_events`
- extend the appointment events API test to confirm admins receive visible events

## Testing
- pytest tests/test_appointment_events_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d137d2d1e4832e9db266af0785bfa1