### PR TITLE
Fix veterinarian appointment modal submission

### DIFF
--- a/app.py
+++ b/app.py
@@ -7601,7 +7601,7 @@ def appointments():
             else:
                 flash('Nenhum novo horário foi salvo.', 'info')
             return redirect(appointments_url)
-        if appointment_form.submit.data and appointment_form.validate_on_submit():
+        if appointment_form.validate_on_submit():
             scheduled_at_local = datetime.combine(
                 appointment_form.date.data, appointment_form.time.data
             )
@@ -7902,7 +7902,7 @@ def appointments():
             appointment_form.animal_id.choices = [(a.id, a.name) for a in animals]
             vets = Veterinario.query.filter_by(clinica_id=clinica_id).all()
             appointment_form.veterinario_id.choices = [(v.id, v.user.name) for v in vets]
-            if appointment_form.submit.data and appointment_form.validate_on_submit():
+            if appointment_form.validate_on_submit():
                 scheduled_at_local = datetime.combine(
                     appointment_form.date.data, appointment_form.time.data
                 )

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -166,7 +166,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-          <button type="submit" form="appointment-form" class="btn btn-primary">Agendar Consulta</button>
+          {{ appointment_form.submit(class="btn btn-primary", form="appointment-form", value="Agendar Consulta") }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure the veterinarian appointment modal submits the WTForms `SubmitField` so the backend receives the submit flag
- rely solely on `validate_on_submit()` when handling appointment creation for veterinarians and collaborators, ensuring successful saves

## Testing
- pytest tests/test_appointment_vet.py tests/test_collaborator_appointment.py

------
https://chatgpt.com/codex/tasks/task_e_68d16d7f5440832eb539c59ca3d534ed