### PR TITLE
Enable admin agenda switching between vets and collaborators

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -10,13 +10,12 @@
     </h2>
     {% if current_user.role == 'admin' %}
     <div class="w-100 ms-lg-auto">
-      <label for="admin-agenda-user-picker" class="form-label fw-semibold small mb-1">Selecionar usuário</label>
-      <select id="admin-agenda-user-picker" class="form-select" data-placeholder="Buscar usuário">
-        <option value="">Minha agenda</option>
-        {% for user in agenda_users %}
-        <option value="{{ user.id }}">{{ user.name }}{% if user.email %} – {{ user.email }}{% endif %}</option>
-        {% endfor %}
-      </select>
+      {% set switcher_select_id = 'admin-agenda-user-picker' %}
+      {% set switcher_label_text = 'Selecionar usuário' %}
+      {% set switcher_select_classes = 'form-select w-100' %}
+      {% set switcher_form_classes = 'd-flex align-items-center gap-2 w-100' %}
+      {% set switcher_default_option_label = 'Minha agenda' %}
+      {% include 'partials/admin_agenda_switcher.html' %}
     </div>
     {% endif %}
   </div>

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -9,25 +9,15 @@
       <p class="text-muted">Gerencie seus horários e consultas</p>
     </div>
     <div class="ms-auto">
-      {% if current_user.role == 'admin' and agenda_veterinarios %}
-      <form action="{{ url_for('appointments') }}" method="get" class="d-flex align-items-center justify-content-end gap-2 mb-2 flex-wrap">
-        <input type="hidden" name="view_as" value="veterinario">
-        {% set start_arg = request.args.get('start') %}
-        {% if start_arg %}
-        <input type="hidden" name="start" value="{{ start_arg }}">
-        {% endif %}
-        {% set end_arg = request.args.get('end') %}
-        {% if end_arg %}
-        <input type="hidden" name="end" value="{{ end_arg }}">
-        {% endif %}
-        <label for="vet-agenda-picker" class="form-label fw-semibold small mb-0">Pesquisar agenda</label>
-        <select id="vet-agenda-picker" name="veterinario_id" class="form-select form-select-sm text-truncate" onchange="this.form.submit()" style="min-width: 220px;">
-          <option value="" {% if not veterinario %}selected{% endif %}>Selecione um usuário</option>
-          {% for vet in agenda_veterinarios %}
-          <option value="{{ vet.id }}" {% if vet.id == veterinario.id %}selected{% endif %}>{{ vet.user.name }}{% if vet.user.email %} – {{ vet.user.email }}{% endif %}</option>
-          {% endfor %}
-        </select>
-      </form>
+      {% if current_user.role == 'admin' %}
+      {% set preserve_params = ['start', 'end'] %}
+      {% set switcher_select_id = 'vet-agenda-picker' %}
+      {% set switcher_label_text = 'Pesquisar agenda' %}
+      {% set switcher_select_classes = 'form-select form-select-sm text-truncate' %}
+      {% set switcher_select_style = 'min-width: 220px;' %}
+      {% set switcher_form_classes = 'd-flex align-items-center justify-content-end gap-2 mb-2 flex-wrap' %}
+      {% set switcher_default_option_label = 'Selecione um usuário' %}
+      {% include 'partials/admin_agenda_switcher.html' %}
       {% endif %}
       <div class="d-flex flex-wrap justify-content-end gap-2">
         <button class="btn btn-primary mb-1" onclick="toggleScheduleForm()">

--- a/templates/partials/admin_agenda_switcher.html
+++ b/templates/partials/admin_agenda_switcher.html
@@ -1,0 +1,89 @@
+{% set _agenda_veterinarios = agenda_veterinarios|default([]) %}
+{% set _agenda_colaboradores = agenda_colaboradores|default([]) %}
+{% if current_user.role == 'admin' and (_agenda_veterinarios or _agenda_colaboradores) %}
+  {% set _form_classes = switcher_form_classes|default('d-flex align-items-center justify-content-end gap-2 mb-2 flex-wrap') %}
+  {% set _select_classes = switcher_select_classes|default('form-select') %}
+  {% set _select_style = switcher_select_style|default('') %}
+  {% set _label_text = switcher_label_text|default('Pesquisar agenda') %}
+  {% set _default_option_label = switcher_default_option_label|default('Minha agenda (admin)') %}
+  {% set _select_id = switcher_select_id|default('admin-agenda-picker') %}
+  {% set _preserve_params = preserve_params|default([]) %}
+  <form action="{{ url_for('appointments') }}" method="get" class="{{ _form_classes }}" data-admin-agenda-switcher>
+    {% for param in _preserve_params %}
+      {% set value = request.args.get(param) %}
+      {% if value %}
+      <input type="hidden" name="{{ param }}" value="{{ value }}">
+      {% endif %}
+    {% endfor %}
+    <input type="hidden" name="view_as" value="{{ admin_selected_view if admin_selected_view in ['veterinario', 'colaborador', 'tutor'] else '' }}" data-switcher-view>
+    <input type="hidden" name="veterinario_id" value="{{ admin_selected_veterinario_id or '' }}" data-switcher-vet>
+    <input type="hidden" name="colaborador_id" value="{{ admin_selected_colaborador_id or '' }}" data-switcher-colab>
+    <label for="{{ _select_id }}" class="form-label fw-semibold small mb-0">{{ _label_text }}</label>
+    <select id="{{ _select_id }}" class="{{ _select_classes }}" data-switcher-select {% if _select_style %}style="{{ _select_style }}"{% endif %}>
+      <option value="">{{ _default_option_label }}</option>
+      {% if _agenda_veterinarios %}
+      <optgroup label="Veterinários">
+        {% for vet in _agenda_veterinarios %}
+        {% set option_value = 'veterinario:' ~ vet.id %}
+        <option value="{{ option_value }}"{% if admin_selected_view == 'veterinario' and admin_selected_veterinario_id == vet.id %} selected{% endif %}>
+          {{ vet.user.name }}{% if vet.user.email %} – {{ vet.user.email }}{% endif %}
+        </option>
+        {% endfor %}
+      </optgroup>
+      {% endif %}
+      {% if _agenda_colaboradores %}
+      <optgroup label="Colaboradores">
+        {% for colab in _agenda_colaboradores %}
+        {% set option_value = 'colaborador:' ~ colab.id %}
+        <option value="{{ option_value }}"{% if admin_selected_view == 'colaborador' and admin_selected_colaborador_id == colab.id %} selected{% endif %}>
+          {{ colab.name }}{% if colab.email %} – {{ colab.email }}{% endif %}
+        </option>
+        {% endfor %}
+      </optgroup>
+      {% endif %}
+    </select>
+  </form>
+  <script>
+    (function() {
+      const forms = document.querySelectorAll('[data-admin-agenda-switcher]');
+      if (!forms.length) {
+        return;
+      }
+      forms.forEach(function(form) {
+        const select = form.querySelector('[data-switcher-select]');
+        const viewInput = form.querySelector('[data-switcher-view]');
+        const vetInput = form.querySelector('[data-switcher-vet]');
+        const colabInput = form.querySelector('[data-switcher-colab]');
+        if (!select || !viewInput || !vetInput || !colabInput) {
+          return;
+        }
+        function updateHiddenInputs(rawValue) {
+          viewInput.value = '';
+          vetInput.value = '';
+          colabInput.value = '';
+          if (!rawValue) {
+            return;
+          }
+          const parts = String(rawValue).split(':');
+          if (parts.length !== 2) {
+            return;
+          }
+          const kind = parts[0];
+          const id = parts[1];
+          if (kind === 'veterinario') {
+            viewInput.value = 'veterinario';
+            vetInput.value = id || '';
+          } else if (kind === 'colaborador') {
+            viewInput.value = 'colaborador';
+            colabInput.value = id || '';
+          }
+        }
+        updateHiddenInputs(select.value);
+        select.addEventListener('change', function() {
+          updateHiddenInputs(this.value);
+          form.submit();
+        });
+      });
+    })();
+  </script>
+{% endif %}


### PR DESCRIPTION
## Summary
- collect veterinarian and collaborator lists in the appointments view and track the selected admin impersonation target
- add a reusable admin agenda switcher partial that renders a role-aware dropdown and manages its parameters
- update the veterinarian and collaborator agenda templates to include the new selector so admins can jump between roles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d199fe09fc832ead344ec45fce3e27