### PR TITLE
Preserve veterinarian context when filtering schedule

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -47,6 +47,9 @@
     </div>
     <div class="card-body">
       <form method="get" class="row g-3 align-items-end">
+        {% for arg_key, arg_val in request.args.items() if arg_key not in ['start', 'end'] %}
+        <input type="hidden" name="{{ arg_key }}" value="{{ arg_val }}">
+        {% endfor %}
         <div class="col-md-3">
           <label class="form-label fw-bold">Data Inicial</label>
           <input type="date" name="start" value="{{ start_dt.date() }}" class="form-control">


### PR DESCRIPTION
## Summary
- ensure the vet schedule filter form keeps existing query arguments so the selected veterinarian is preserved when admins filter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d19c2d2c2c832e8075fb73210ec9b1