### PR TITLE
Add collapsible schedule overview in appointments

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -111,11 +111,27 @@
           </div>
         </form>
         <div class="mt-4">
-          <h6 class="fw-bold"><i class="bi bi-calendar3 me-2"></i>Disponibilidade do Veterinário</h6>
-          <div id="schedule-overview" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 small"></div>
-          <div class="mt-2 small">
-            <span class="badge bg-success me-1">&nbsp;</span> Disponível
-            <span class="badge bg-danger ms-2 me-1">&nbsp;</span> Indisponível
+          <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+            <h6 class="fw-bold mb-0">
+              <i class="bi bi-calendar3 me-2"></i>Disponibilidade do Veterinário
+            </h6>
+            <button
+              class="btn btn-outline-primary btn-sm"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#scheduleOverviewCollapse"
+              aria-expanded="true"
+              aria-controls="scheduleOverviewCollapse"
+            >
+              Alternar visualização
+            </button>
+          </div>
+          <div class="collapse show" id="scheduleOverviewCollapse">
+            <div id="schedule-overview" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 small"></div>
+            <div class="mt-2 small">
+              <span class="badge bg-success me-1">&nbsp;</span> Disponível
+              <span class="badge bg-danger ms-2 me-1">&nbsp;</span> Indisponível
+            </div>
           </div>
         </div>
         {% endif %}
@@ -243,6 +259,8 @@ document.addEventListener('DOMContentLoaded', () => {
     ? timeField.dataset.emptyText
     : 'Sem horários disponíveis';
   const scheduleContainer = document.getElementById('schedule-overview');
+  const scheduleCollapseEl = document.getElementById('scheduleOverviewCollapse');
+  const scheduleToggleBtn = document.querySelector('[data-bs-target="#scheduleOverviewCollapse"]');
   const calendarContainer = document.querySelector('[data-calendar-redirect-url]');
   const calendarRedirectUrl = (calendarContainer && calendarContainer.dataset && calendarContainer.dataset.calendarRedirectUrl) || '';
   const newAppointmentCollapseEl = document.getElementById('newAppointmentForm');
@@ -258,6 +276,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const isShown = newAppointmentCollapseEl.classList.contains('show');
     newAppointmentToggleBtn.setAttribute('aria-expanded', isShown ? 'true' : 'false');
+  }
+
+  function updateScheduleToggleAria() {
+    if (!scheduleCollapseEl || !scheduleToggleBtn) {
+      return;
+    }
+    const isShown = scheduleCollapseEl.classList.contains('show');
+    scheduleToggleBtn.setAttribute('aria-expanded', isShown ? 'true' : 'false');
   }
 
   function ensureNewAppointmentVisible() {
@@ -472,6 +498,15 @@ document.addEventListener('DOMContentLoaded', () => {
   dateField && dateField.addEventListener('change', () => { updateTimes(); loadSchedule(); });
   updateTimes();
   loadSchedule();
+
+  if (scheduleCollapseEl && scheduleToggleBtn) {
+    scheduleCollapseEl.addEventListener('shown.bs.collapse', () => {
+      updateScheduleToggleAria();
+      loadSchedule();
+    });
+    scheduleCollapseEl.addEventListener('hidden.bs.collapse', updateScheduleToggleAria);
+    updateScheduleToggleAria();
+  }
 
   if (newAppointmentCollapseEl && newAppointmentToggleBtn) {
     newAppointmentCollapseEl.addEventListener('shown.bs.collapse', updateNewAppointmentToggleAria);


### PR DESCRIPTION
## Summary
- wrap the veterinarian availability block with a collapse controlled by a toggle button
- refresh the schedule overview whenever the collapse is shown and keep accessibility attributes in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c6169534832e84693c4b1be9d526