### PR TITLE
Enable async schedule edits

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -186,15 +186,24 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
       </div>
       <div class="modal-body">
-        <form id="schedule-edit-form">
+        <form
+          id="schedule-edit-form"
+          method="post"
+          action="{{ url_for('edit_vet_schedule_slot', veterinario_id=0, horario_id=0) }}"
+          data-action-template="{{ url_for('edit_vet_schedule_slot', veterinario_id=0, horario_id=0) }}"
+        >
+          <input type="hidden" name="schedule-csrf_token" value="{{ csrf_token() if csrf_token is defined else '' }}">
+          <input type="hidden" id="schedule-slot-id">
+          <input type="hidden" name="schedule-intervalo_inicio" id="schedule-interval-start">
+          <input type="hidden" name="schedule-intervalo_fim" id="schedule-interval-end">
           <div class="mb-3">
             <label class="form-label fw-semibold">Colaborador</label>
-            <select id="schedule-vet" class="form-select"></select>
+            <select id="schedule-vet" name="schedule-veterinario_id" class="form-select"></select>
           </div>
           <div class="row g-3">
             <div class="col-md-6">
               <label class="form-label fw-semibold">Dia da Semana</label>
-              <select id="schedule-day" class="form-select">
+              <select id="schedule-day" name="schedule-dias_semana" class="form-select">
                 <option value="Segunda">Segunda</option>
                 <option value="Terça">Terça</option>
                 <option value="Quarta">Quarta</option>
@@ -206,18 +215,24 @@
             </div>
             <div class="col-md-3">
               <label class="form-label fw-semibold">Início</label>
-              <input type="time" id="schedule-start" class="form-control">
+              <input type="time" id="schedule-start" name="schedule-hora_inicio" class="form-control">
             </div>
             <div class="col-md-3">
               <label class="form-label fw-semibold">Fim</label>
-              <input type="time" id="schedule-end" class="form-control">
+              <input type="time" id="schedule-end" name="schedule-hora_fim" class="form-control">
             </div>
           </div>
         </form>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-        <button type="submit" form="schedule-edit-form" class="btn btn-primary">Salvar</button>
+        <button
+          type="submit"
+          form="schedule-edit-form"
+          class="btn btn-primary"
+          name="schedule-submit"
+          value="Salvar"
+        >Salvar</button>
       </div>
     </div>
   </div>
@@ -268,6 +283,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const newAppointmentForm = newAppointmentCollapseEl
     ? newAppointmentCollapseEl.querySelector('form')
     : null;
+  const appointmentsContainer = document.querySelector('[data-appointments-container]');
   let newAppointmentCollapseInstance = null;
 
   function updateNewAppointmentToggleAria() {
@@ -456,19 +472,273 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const scheduleBtn = document.getElementById('openScheduleModal');
   const scheduleModalEl = document.getElementById('scheduleEditModal');
-  if (scheduleBtn && scheduleModalEl) {
-    const scheduleModal = new bootstrap.Modal(scheduleModalEl);
-    scheduleBtn.addEventListener('click', () => {
-      const vetSelectSrc = vetField;
-      const vetSelect = document.getElementById('schedule-vet');
-      if (vetSelectSrc && vetSelect) {
-        vetSelect.innerHTML = vetSelectSrc.innerHTML;
-        vetSelect.value = vetSelectSrc.value;
+  const scheduleForm = scheduleModalEl ? scheduleModalEl.querySelector('#schedule-edit-form') : null;
+  const scheduleModalBody = scheduleModalEl ? scheduleModalEl.querySelector('.modal-body') : null;
+  const scheduleVetSelect = scheduleForm ? scheduleForm.querySelector('#schedule-vet') : null;
+  const scheduleDaySelect = scheduleForm ? scheduleForm.querySelector('#schedule-day') : null;
+  const scheduleStartInput = scheduleForm ? scheduleForm.querySelector('#schedule-start') : null;
+  const scheduleEndInput = scheduleForm ? scheduleForm.querySelector('#schedule-end') : null;
+  const scheduleIntervalStart = scheduleForm ? scheduleForm.querySelector('#schedule-interval-start') : null;
+  const scheduleIntervalEnd = scheduleForm ? scheduleForm.querySelector('#schedule-interval-end') : null;
+  const scheduleSlotInput = scheduleForm ? scheduleForm.querySelector('#schedule-slot-id') : null;
+  const scheduleActionTemplate = scheduleForm
+    ? (scheduleForm.dataset && scheduleForm.dataset.actionTemplate)
+      || scheduleForm.getAttribute('data-action-template')
+      || scheduleForm.getAttribute('action')
+    : '';
+  const canShowScheduleAlert = typeof clearModalAlerts === 'function' && typeof showModalAlert === 'function';
+  let scheduleModalInstance = null;
+
+  function clearScheduleFeedback() {
+    if (!scheduleModalBody || !canShowScheduleAlert) {
+      return;
+    }
+    clearModalAlerts(scheduleModalBody);
+  }
+
+  function showScheduleFeedback(type, message) {
+    if (!scheduleModalBody || !canShowScheduleAlert) {
+      return;
+    }
+    showModalAlert(scheduleModalBody, type, message);
+  }
+
+  function resolveScheduleId() {
+    if (!scheduleForm) {
+      return '';
+    }
+    if (scheduleForm.dataset && scheduleForm.dataset.scheduleId) {
+      return scheduleForm.dataset.scheduleId;
+    }
+    return scheduleSlotInput ? scheduleSlotInput.value : '';
+  }
+
+  function buildScheduleAction(vetId, scheduleId) {
+    if (!scheduleActionTemplate || !vetId || !scheduleId) {
+      return '';
+    }
+    return scheduleActionTemplate.replace('/0/schedule/0/edit', `/${vetId}/schedule/${scheduleId}/edit`);
+  }
+
+  function updateScheduleFormAction() {
+    if (!scheduleForm) {
+      return '';
+    }
+    const vetId = scheduleVetSelect ? scheduleVetSelect.value : '';
+    const scheduleId = resolveScheduleId();
+    const actionUrl = buildScheduleAction(vetId, scheduleId);
+    if (actionUrl) {
+      scheduleForm.setAttribute('action', actionUrl);
+    }
+    return actionUrl;
+  }
+
+  function setScheduleFormContext(rawContext = {}, { copyVetOptions = true } = {}) {
+    if (!scheduleForm) {
+      return;
+    }
+    const context = {
+      scheduleId: rawContext.scheduleId || rawContext.horarioId || rawContext.id || '',
+      vetId: rawContext.vetId || rawContext.veterinarioId || rawContext.veterinarianId || '',
+      day: rawContext.day || rawContext.scheduleDay || rawContext.dia || '',
+      start: rawContext.start || rawContext.scheduleStart || rawContext.horaInicio || rawContext.hora_inicio || '',
+      end: rawContext.end || rawContext.scheduleEnd || rawContext.horaFim || rawContext.hora_fim || '',
+      intervaloInicio: rawContext.intervaloInicio || rawContext.intervalo_inicio || '',
+      intervaloFim: rawContext.intervaloFim || rawContext.intervalo_fim || '',
+    };
+
+    if (copyVetOptions && vetField && scheduleVetSelect) {
+      scheduleVetSelect.innerHTML = vetField.innerHTML;
+    }
+
+    if (scheduleForm.dataset) {
+      scheduleForm.dataset.scheduleId = context.scheduleId || '';
+    }
+    if (scheduleSlotInput) {
+      scheduleSlotInput.value = context.scheduleId || '';
+    }
+
+    if (scheduleVetSelect) {
+      if (context.vetId) {
+        scheduleVetSelect.value = context.vetId;
+      } else if (vetField && vetField.value) {
+        scheduleVetSelect.value = vetField.value;
       }
-      handleVetChange();
-      scheduleModal.show();
+    }
+    if (scheduleDaySelect && context.day) {
+      scheduleDaySelect.value = context.day;
+    }
+    if (scheduleStartInput) {
+      scheduleStartInput.value = context.start || '';
+    }
+    if (scheduleEndInput) {
+      scheduleEndInput.value = context.end || '';
+    }
+    if (scheduleIntervalStart) {
+      scheduleIntervalStart.value = context.intervaloInicio || '';
+    }
+    if (scheduleIntervalEnd) {
+      scheduleIntervalEnd.value = context.intervaloFim || '';
+    }
+
+    clearScheduleFeedback();
+    updateScheduleFormAction();
+  }
+
+  function openScheduleModalWithContext(context = {}, options = {}) {
+    if (!scheduleModalEl) {
+      return;
+    }
+    if (window.bootstrap && bootstrap.Modal) {
+      scheduleModalInstance = bootstrap.Modal.getOrCreateInstance(scheduleModalEl);
+    }
+    setScheduleFormContext(context, options);
+    handleVetChange();
+    if (scheduleModalInstance) {
+      scheduleModalInstance.show();
+    }
+  }
+
+  function extractTriggerContext(trigger) {
+    if (!trigger) {
+      return {};
+    }
+    const dataset = trigger.dataset || {};
+    return {
+      scheduleId: dataset.scheduleId,
+      vetId: dataset.vetId || dataset.veterinarioId,
+      day: dataset.scheduleDay || dataset.day || dataset.dia,
+      start: dataset.scheduleStart || dataset.start || dataset.horaInicio,
+      end: dataset.scheduleEnd || dataset.end || dataset.horaFim,
+      intervaloInicio: dataset.intervaloInicio,
+      intervaloFim: dataset.intervaloFim,
+    };
+  }
+
+  async function submitScheduleForm(event) {
+    if (!scheduleForm) {
+      return;
+    }
+    event.preventDefault();
+    clearScheduleFeedback();
+
+    const submitter = event.submitter || scheduleForm.querySelector('[type="submit"]');
+    if (submitter) {
+      submitter.disabled = true;
+    }
+
+    try {
+      const vetId = scheduleVetSelect ? scheduleVetSelect.value : '';
+      const scheduleId = resolveScheduleId();
+      const actionUrl = updateScheduleFormAction();
+
+      if (!vetId || !scheduleId || !actionUrl) {
+        showScheduleFeedback('danger', 'Selecione um horário válido para editar.');
+        return;
+      }
+
+      const formData = new FormData(scheduleForm);
+      if (submitter && submitter.name && !formData.has(submitter.name)) {
+        formData.append(submitter.name, submitter.value || submitter.textContent || '');
+      } else if (!formData.has('schedule-submit')) {
+        formData.append('schedule-submit', submitter && submitter.value ? submitter.value : 'Salvar');
+      }
+
+      const response = await fetch(actionUrl, {
+        method: 'POST',
+        body: formData,
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        credentials: 'same-origin',
+      });
+
+      const contentType = response.headers ? response.headers.get('Content-Type') || '' : '';
+      let payload = null;
+      if (contentType.includes('application/json')) {
+        payload = await response.json();
+      }
+
+      if (!response.ok || (payload && payload.success === false)) {
+        const message = (payload && (payload.message || payload.error)) || 'Não foi possível atualizar o horário.';
+        showScheduleFeedback('danger', message);
+        return;
+      }
+
+      const successMessage = (payload && payload.message) || 'Horário atualizado com sucesso.';
+      showScheduleFeedback('success', successMessage);
+
+      try {
+        if (typeof updateTimes === 'function') {
+          await updateTimes();
+        }
+        if (typeof loadSchedule === 'function') {
+          await loadSchedule();
+        }
+      } catch (scheduleError) {
+        console.warn('Não foi possível atualizar os horários disponíveis.', scheduleError);
+      }
+
+      try {
+        if (appointmentsContainer && typeof refreshAppointmentsContainer === 'function') {
+          await refreshAppointmentsContainer(appointmentsContainer);
+        }
+      } catch (listError) {
+        console.warn('Não foi possível atualizar a lista de agendamentos.', listError);
+      }
+
+      if (scheduleModalInstance) {
+        window.setTimeout(() => {
+          scheduleModalInstance.hide();
+        }, 1200);
+      }
+    } catch (error) {
+      console.error('Erro ao atualizar horário do colaborador.', error);
+      showScheduleFeedback('danger', 'Erro ao atualizar o horário. Tente novamente.');
+    } finally {
+      if (submitter) {
+        submitter.disabled = false;
+      }
+    }
+  }
+
+  if (scheduleForm) {
+    scheduleForm.addEventListener('submit', submitScheduleForm);
+    if (scheduleVetSelect) {
+      scheduleVetSelect.addEventListener('change', updateScheduleFormAction);
+    }
+  }
+
+  if (scheduleBtn) {
+    scheduleBtn.addEventListener('click', () => {
+      const context = extractTriggerContext(scheduleBtn);
+      if (!context.vetId && vetField) {
+        context.vetId = vetField.value;
+      }
+      openScheduleModalWithContext(context, { copyVetOptions: true });
     });
   }
+
+  document.addEventListener('click', event => {
+    const trigger = event.target ? event.target.closest('[data-schedule-edit]') : null;
+    if (!trigger || trigger === scheduleBtn) {
+      return;
+    }
+    event.preventDefault();
+    const context = extractTriggerContext(trigger);
+    if (!context.vetId && vetField) {
+      context.vetId = vetField.value;
+    }
+    openScheduleModalWithContext(context, { copyVetOptions: true });
+  });
+
+  document.addEventListener('scheduleEditRequested', event => {
+    const detail = (event && event.detail) || {};
+    if (!detail.vetId && vetField) {
+      detail.vetId = vetField.value;
+    }
+    openScheduleModalWithContext(detail, { copyVetOptions: true });
+  });
 
   document.addEventListener('calendarSlotChosen', event => {
     const detail = event.detail || {};


### PR DESCRIPTION
## Summary
- add proper names, CSRF token, and action template metadata to the schedule edit modal form
- intercept schedule edit submissions in JavaScript, post via fetch, and refresh schedule data on success
- return JSON responses from the schedule edit endpoint to support asynchronous updates

## Testing
- pytest tests/test_vet_schedule_permissions.py tests/test_colleague_schedule.py *(fails: database host unreachable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ca778a18832eaeeae2a856cfe51f