### PR TITLE
Modularize veterinary scheduling scripts

### DIFF
--- a/static/appointments_shared.js
+++ b/static/appointments_shared.js
@@ -1,0 +1,107 @@
+const JSON_HEADERS = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json'
+};
+
+const DEFAULT_ERROR_MESSAGE = 'Erro ao salvar. Verifique os dados e tente novamente.';
+const DEFAULT_SUCCESS_MESSAGE = 'Agendamento atualizado com sucesso.';
+
+function buildHeaders(csrfToken = '', extraHeaders = {}) {
+  const headers = { ...JSON_HEADERS, ...extraHeaders };
+  if (csrfToken) {
+    headers['X-CSRFToken'] = csrfToken;
+  }
+  return headers;
+}
+
+function buildUrlSearchParams(params = {}) {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') {
+      return;
+    }
+    searchParams.set(key, value);
+  });
+  return searchParams;
+}
+
+export async function fetchAvailableTimes(veterinarioId, date, options = {}) {
+  if (!veterinarioId || !date) {
+    return [];
+  }
+  const {
+    kind,
+    searchParams = {},
+    fetchOptions = {},
+    basePath = '/api/specialist'
+  } = options;
+  const params = buildUrlSearchParams({ ...searchParams, date, kind });
+  const query = params.toString();
+  const endpointBase = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+  const endpoint = `${endpointBase}/${veterinarioId}/available_times${query ? `?${query}` : ''}`;
+  try {
+    const response = await fetch(endpoint, fetchOptions);
+    if (!response.ok) {
+      return [];
+    }
+    const data = await response.json();
+    return Array.isArray(data) ? data : [];
+  } catch (error) {
+    console.error('Erro ao buscar horários disponíveis', error);
+    return [];
+  }
+}
+
+export async function submitAppointmentUpdate(url, payload, csrfToken = '', options = {}) {
+  const {
+    defaultErrorMessage = DEFAULT_ERROR_MESSAGE,
+    successMessage = DEFAULT_SUCCESS_MESSAGE,
+    fetchOptions = {}
+  } = options;
+  const requestInit = {
+    method: 'POST',
+    ...fetchOptions,
+    headers: buildHeaders(csrfToken, fetchOptions.headers || {}),
+    body: JSON.stringify(payload ?? {})
+  };
+  try {
+    const response = await fetch(url, requestInit);
+    let data = null;
+    try {
+      data = await response.json();
+    } catch (error) {
+      data = null;
+    }
+    if (response.ok && data && data.success) {
+      return {
+        success: true,
+        data,
+        message: data.message || successMessage,
+        response
+      };
+    }
+    const message = (data && data.message) ? data.message : defaultErrorMessage;
+    return {
+      success: false,
+      data,
+      message,
+      response
+    };
+  } catch (error) {
+    console.error('Erro ao enviar atualização de agendamento', error);
+    return {
+      success: false,
+      data: null,
+      message: defaultErrorMessage,
+      response: null
+    };
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.AppointmentsShared = {
+    ...(window.AppointmentsShared || {}),
+    fetchAvailableTimes,
+    submitAppointmentUpdate
+  };
+}

--- a/static/appointments_table.js
+++ b/static/appointments_table.js
@@ -1,3 +1,5 @@
+import { submitAppointmentUpdate } from './appointments_shared.js';
+
 const EMPTY_STATE_HTML = `
   <div class="empty-state">
     <span class="icon-circle bg-secondary text-white"><i class="fa-regular fa-calendar-xmark"></i></span>
@@ -5,6 +7,9 @@ const EMPTY_STATE_HTML = `
     <p>Não há agendamentos para exibir no momento.</p>
   </div>
 `;
+
+const UPDATE_ERROR_MESSAGE = 'Erro ao salvar. Verifique os dados e tente novamente.';
+const UPDATE_SUCCESS_MESSAGE = 'Agendamento atualizado com sucesso.';
 
 function parseHTML(html) {
   if (!html) {
@@ -290,28 +295,18 @@ function attachAppointmentFormHandler(form, { url, row, modalBody, bsModal }) {
     }
 
     try {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': token
-        },
-        body: JSON.stringify(payload)
+      const result = await submitAppointmentUpdate(url, payload, token, {
+        defaultErrorMessage: UPDATE_ERROR_MESSAGE,
+        successMessage: UPDATE_SUCCESS_MESSAGE
       });
-      let data = null;
-      try {
-        data = await response.json();
-      } catch (err) {
-        data = null;
-      }
 
-      if (!response.ok || !data || !data.success) {
-        const message = (data && data.message) ? data.message : 'Erro ao salvar. Verifique os dados e tente novamente.';
-        showModalAlert(modalBody, 'danger', message);
+      if (!result.success || !result.data) {
+        showModalAlert(modalBody, 'danger', result.message || UPDATE_ERROR_MESSAGE);
         return;
       }
 
-      showModalAlert(modalBody, 'success', data.message || 'Agendamento atualizado com sucesso.');
+      const data = result.data;
+      showModalAlert(modalBody, 'success', result.message || UPDATE_SUCCESS_MESSAGE);
 
       let updated = false;
       if (data.card_html) {
@@ -347,6 +342,10 @@ function attachAppointmentFormHandler(form, { url, row, modalBody, bsModal }) {
       }
     }
   });
+}
+
+if (typeof window !== 'undefined') {
+  window.bindAppointmentRowClicks = bindAppointmentRowClicks;
 }
 
 document.addEventListener('DOMContentLoaded', bindAppointmentRowClicks);

--- a/static/appointments_vet.js
+++ b/static/appointments_vet.js
@@ -1,0 +1,476 @@
+import { fetchAvailableTimes, submitAppointmentUpdate } from './appointments_shared.js';
+
+const ROOT_SELECTOR = '[data-vet-schedule-root]';
+const DEFAULT_TIME_PLACEHOLDER = 'Selecione...';
+const DEFAULT_SUCCESS_MESSAGE = 'Agendamento atualizado com sucesso.';
+
+function getRootElement(root) {
+  if (root instanceof HTMLElement) {
+    return root;
+  }
+  if (typeof root === 'string') {
+    return document.querySelector(root);
+  }
+  return document.querySelector(ROOT_SELECTOR);
+}
+
+function sanitizeBaseUrl(url) {
+  if (!url) {
+    return '';
+  }
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function getAppointmentsBaseUrl(root) {
+  const base = root?.dataset?.appointmentsBaseUrl || '/appointments';
+  return sanitizeBaseUrl(base);
+}
+
+function getVetId(root) {
+  return root?.dataset?.vetId || '';
+}
+
+function getCsrfToken(root) {
+  if (root?.dataset?.csrfToken) {
+    return root.dataset.csrfToken;
+  }
+  const tokenInput = document.querySelector('input[name="csrf_token"]');
+  return tokenInput ? tokenInput.value : '';
+}
+
+function getModalInstance(element) {
+  if (!element || typeof window === 'undefined') {
+    return null;
+  }
+  const bootstrapGlobal = window.bootstrap;
+  if (!bootstrapGlobal || typeof bootstrapGlobal.Modal?.getOrCreateInstance !== 'function') {
+    return null;
+  }
+  return bootstrapGlobal.Modal.getOrCreateInstance(element);
+}
+
+function ensurePlaceholderOption(select, placeholder = DEFAULT_TIME_PLACEHOLDER) {
+  if (!select) {
+    return;
+  }
+  select.innerHTML = '';
+  const option = document.createElement('option');
+  option.value = '';
+  option.textContent = placeholder;
+  select.appendChild(option);
+}
+
+function isEvent(value) {
+  return value && typeof value === 'object' && 'target' in value;
+}
+
+export function selectDays(mode, selectEl = document.getElementById('schedule-dias_semana')) {
+  if (isEvent(mode)) {
+    mode.preventDefault();
+    return;
+  }
+  if (!selectEl) {
+    return;
+  }
+  const weekdays = ['Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta'];
+  const weekend = ['Sábado', 'Domingo'];
+  Array.from(selectEl.options).forEach((option) => {
+    if (mode === 'all') {
+      option.selected = true;
+    } else if (mode === 'weekday') {
+      option.selected = weekdays.includes(option.value);
+    } else if (mode === 'weekend') {
+      option.selected = weekend.includes(option.value);
+    } else if (mode === 'clear') {
+      option.selected = false;
+    }
+  });
+  selectEl.dispatchEvent(new Event('change'));
+}
+
+export function toggleScheduleForm(rootParam) {
+  if (isEvent(rootParam)) {
+    rootParam.preventDefault();
+  }
+  const root = getRootElement(rootParam);
+  const modalEl = document.getElementById('scheduleModal');
+  const form = document.getElementById('schedule-form');
+  const daysSelect = document.getElementById('schedule-dias_semana');
+  const vetSelect = document.getElementById('schedule-veterinario_id');
+  const titleEl = document.getElementById('scheduleModalTitle');
+  const modal = getModalInstance(modalEl);
+  if (!modal || !form) {
+    return;
+  }
+
+  form.reset();
+  form.action = getAppointmentsBaseUrl(root);
+
+  if (daysSelect) {
+    daysSelect.multiple = true;
+  }
+
+  const vetId = getVetId(root);
+  if (vetSelect && vetId) {
+    vetSelect.value = vetId;
+  }
+
+  if (titleEl) {
+    titleEl.textContent = 'Adicionar Horário';
+  }
+
+  modal.show();
+}
+
+export function editSchedule(dataset, rootParam) {
+  const root = getRootElement(rootParam);
+  const modalEl = document.getElementById('scheduleModal');
+  const modal = getModalInstance(modalEl);
+  const form = document.getElementById('schedule-form');
+  const titleEl = document.getElementById('scheduleModalTitle');
+  const daysSelect = document.getElementById('schedule-dias_semana');
+  const startField = document.getElementById('schedule-hora_inicio');
+  const endField = document.getElementById('schedule-hora_fim');
+  const intervalStart = document.getElementById('schedule-intervalo_inicio');
+  const intervalEnd = document.getElementById('schedule-intervalo_fim');
+  if (!modal || !form) {
+    return;
+  }
+
+  form.reset();
+  const scheduleId = dataset?.id;
+  const vetId = getVetId(root);
+  if (scheduleId) {
+    const action = `${getAppointmentsBaseUrl(root)}/${vetId}/schedule/${scheduleId}/edit`;
+    form.action = action;
+  }
+
+  if (titleEl) {
+    titleEl.textContent = 'Editar Horário';
+  }
+
+  if (daysSelect) {
+    daysSelect.multiple = false;
+    const targetDay = dataset?.dia;
+    Array.from(daysSelect.options).forEach((option) => {
+      option.selected = option.value === targetDay;
+    });
+  }
+
+  if (startField && dataset?.horaInicio) {
+    startField.value = dataset.horaInicio;
+  }
+  if (endField && dataset?.horaFim) {
+    endField.value = dataset.horaFim;
+  }
+  if (intervalStart) {
+    intervalStart.value = dataset?.intervaloInicio || '';
+  }
+  if (intervalEnd) {
+    intervalEnd.value = dataset?.intervaloFim || '';
+  }
+
+  modal.show();
+}
+
+export function toggleAppointmentForm(rootParam) {
+  if (isEvent(rootParam)) {
+    rootParam.preventDefault();
+  }
+  const root = getRootElement(rootParam);
+  const modalEl = document.getElementById('appointmentModalForm');
+  const modal = getModalInstance(modalEl);
+  if (!modal) {
+    return;
+  }
+  modal.show();
+  updateAppointmentTimes({ root });
+}
+
+export async function updateAppointmentTimes(options = {}) {
+  if (isEvent(options)) {
+    const event = options;
+    return updateAppointmentTimes({ dateInput: event.currentTarget || event.target });
+  }
+  const root = getRootElement(options.root);
+  const dateInput = options.dateInput || document.getElementById('appointment-date');
+  const timeSelect = options.timeSelect || document.getElementById('appointment-time');
+  const placeholder = options.placeholder ?? DEFAULT_TIME_PLACEHOLDER;
+  const vetId = options.veterinarianId || getVetId(root);
+
+  if (!timeSelect) {
+    return [];
+  }
+
+  ensurePlaceholderOption(timeSelect, placeholder);
+
+  if (!dateInput || !vetId || !dateInput.value) {
+    return [];
+  }
+
+  const times = await fetchAvailableTimes(vetId, dateInput.value, {
+    kind: options.kind,
+    searchParams: options.searchParams,
+    fetchOptions: options.fetchOptions
+  });
+
+  if (!Array.isArray(times) || times.length === 0) {
+    return [];
+  }
+
+  const fragment = document.createDocumentFragment();
+  times.forEach((time) => {
+    const option = document.createElement('option');
+    option.value = time;
+    option.textContent = time;
+    fragment.appendChild(option);
+  });
+  timeSelect.appendChild(fragment);
+  return times;
+}
+
+export function toggleScheduleEdit(rootParam) {
+  if (isEvent(rootParam)) {
+    rootParam.preventDefault();
+  }
+  const root = getRootElement(rootParam);
+  if (!root) {
+    return;
+  }
+  const actionContainers = root.querySelectorAll('.schedule-actions');
+  if (!actionContainers.length) {
+    return;
+  }
+  actionContainers.forEach((container) => container.classList.toggle('d-none'));
+  const anyVisible = Array.from(actionContainers).some((container) => !container.classList.contains('d-none'));
+  const toggleButton = root.querySelector('[data-schedule-edit-toggle]');
+  if (toggleButton) {
+    toggleButton.innerHTML = anyVisible
+      ? '<i class="fas fa-times me-1"></i>Cancelar Edição'
+      : '<i class="fas fa-edit me-1"></i>Editar horários';
+  }
+}
+
+export async function responderAgendamentoExame(appointmentId, status) {
+  if (!appointmentId || !status) {
+    return;
+  }
+  try {
+    const response = await fetch(`/exam_appointment/${appointmentId}/status`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      },
+      body: JSON.stringify({ status })
+    });
+    if (!response.ok) {
+      throw new Error('Falha ao atualizar agendamento de exame.');
+    }
+    const data = await response.json();
+    if (data?.success) {
+      window.location.reload();
+    } else {
+      alert(data?.message || 'Erro ao atualizar status.');
+    }
+  } catch (error) {
+    console.error('Erro ao atualizar status do exame', error);
+    alert('Erro ao atualizar status.');
+  }
+}
+
+function bindScheduleEditButtons(root) {
+  root.querySelectorAll('.edit-btn').forEach((button) => {
+    if (button.dataset.vetScheduleBound === 'true') {
+      return;
+    }
+    button.dataset.vetScheduleBound = 'true';
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      editSchedule(button.dataset, root);
+    });
+  });
+}
+
+function bindAppointmentItems(root) {
+  const modalEl = document.getElementById('appointmentDetailModal');
+  const modal = getModalInstance(modalEl);
+  root.querySelectorAll('.appointment-item').forEach((item) => {
+    if (item.dataset.vetScheduleBound === 'true') {
+      return;
+    }
+    item.dataset.vetScheduleBound = 'true';
+    item.addEventListener('click', (event) => {
+      if (event.target.closest('.btn')) {
+        return;
+      }
+      const appointmentId = item.dataset.id;
+      if (!appointmentId) {
+        return;
+      }
+      const vetField = document.getElementById('modal-vet');
+      const tutorField = document.getElementById('modal-tutor');
+      const animalField = document.getElementById('modal-animal');
+      const dateField = document.getElementById('modal-date');
+      const timeField = document.getElementById('modal-time');
+      const notesField = document.getElementById('modal-notes');
+      const animalLink = document.getElementById('modal-animal-link');
+      const tutorLink = document.getElementById('modal-tutor-link');
+      const consultaLink = document.getElementById('modal-consulta-link');
+      const idField = document.getElementById('modal-appt-id');
+
+      if (idField) {
+        idField.value = appointmentId;
+      }
+      if (vetField) {
+        vetField.value = item.dataset.vet || '';
+      }
+      if (tutorField) {
+        tutorField.value = item.dataset.tutor || '';
+      }
+      if (animalField) {
+        animalField.value = item.dataset.animal || '';
+      }
+      if (dateField) {
+        dateField.value = item.dataset.date || '';
+      }
+      if (timeField) {
+        timeField.value = item.dataset.time || '';
+      }
+      if (notesField) {
+        notesField.value = item.dataset.notes || '';
+      }
+      if (animalLink && item.dataset.animalUrl) {
+        animalLink.href = item.dataset.animalUrl;
+      }
+      if (tutorLink && item.dataset.tutorUrl) {
+        tutorLink.href = item.dataset.tutorUrl;
+      }
+      if (consultaLink && item.dataset.consultaUrl) {
+        consultaLink.href = item.dataset.consultaUrl;
+      }
+
+      if (modal) {
+        modal.show();
+      }
+    });
+  });
+}
+
+function bindAppointmentModalSave(root) {
+  const saveButton = document.getElementById('modal-save-btn');
+  if (!saveButton || saveButton.dataset.vetScheduleBound === 'true') {
+    return;
+  }
+  saveButton.dataset.vetScheduleBound = 'true';
+  saveButton.addEventListener('click', async () => {
+    const idField = document.getElementById('modal-appt-id');
+    const dateField = document.getElementById('modal-date');
+    const timeField = document.getElementById('modal-time');
+    const notesField = document.getElementById('modal-notes');
+    const appointmentId = idField?.value;
+    if (!appointmentId) {
+      return;
+    }
+    const updateUrl = `${getAppointmentsBaseUrl(root)}/${appointmentId}/edit`;
+    const payload = {
+      date: dateField?.value || '',
+      time: timeField?.value || '',
+      veterinario_id: getVetId(root),
+      notes: notesField?.value || ''
+    };
+    const result = await submitAppointmentUpdate(updateUrl, payload, getCsrfToken(root), {
+      successMessage: DEFAULT_SUCCESS_MESSAGE
+    });
+    if (result.success) {
+      window.location.reload();
+    } else {
+      alert(result.message || 'Erro ao salvar');
+    }
+  });
+}
+
+function bindAppointmentDateWatcher(root) {
+  const dateInput = document.getElementById('appointment-date');
+  if (!dateInput || dateInput.dataset.vetScheduleBound === 'true') {
+    return;
+  }
+  dateInput.dataset.vetScheduleBound = 'true';
+  dateInput.addEventListener('change', (event) => updateAppointmentTimes({ root, dateInput: event.currentTarget || event.target }));
+}
+
+function bindPastToggle(root) {
+  const toggleButton = document.getElementById('toggle-past');
+  const pastList = document.getElementById('past-list');
+  if (!toggleButton || !pastList || toggleButton.dataset.vetScheduleBound === 'true') {
+    return;
+  }
+  toggleButton.dataset.vetScheduleBound = 'true';
+  toggleButton.addEventListener('click', () => {
+    pastList.classList.toggle('d-none');
+    const isHidden = pastList.classList.contains('d-none');
+    toggleButton.innerHTML = isHidden
+      ? '<i class="fas fa-chevron-down me-1"></i>Mostrar'
+      : '<i class="fas fa-chevron-up me-1"></i>Ocultar';
+  });
+}
+
+function animateCards(root) {
+  const cards = root.querySelectorAll('.card');
+  cards.forEach((card, index) => {
+    card.style.opacity = '0';
+    card.style.transform = 'translateY(20px)';
+    card.style.transition = 'opacity 0.5s ease, transform 0.5s ease';
+    setTimeout(() => {
+      card.style.opacity = '1';
+      card.style.transform = 'translateY(0)';
+    }, 100 + (index * 100));
+  });
+}
+
+export function initVetSchedulePage(options = {}) {
+  const root = getRootElement(options.root);
+  if (!root || root.dataset.vetScheduleInitialized === 'true') {
+    return root;
+  }
+  root.dataset.vetScheduleInitialized = 'true';
+
+  bindScheduleEditButtons(root);
+  bindAppointmentItems(root);
+  bindAppointmentModalSave(root);
+  bindAppointmentDateWatcher(root);
+  bindPastToggle(root);
+  animateCards(root);
+
+  const dateInput = document.getElementById('appointment-date');
+  if (dateInput && dateInput.value) {
+    updateAppointmentTimes({ root, dateInput });
+  }
+
+  return root;
+}
+
+if (typeof window !== 'undefined') {
+  window.selectDays = (mode) => selectDays(mode);
+  window.toggleScheduleForm = (root) => toggleScheduleForm(root);
+  window.toggleAppointmentForm = (root) => toggleAppointmentForm(root);
+  window.updateAppointmentTimes = (options) => updateAppointmentTimes(options);
+  window.toggleScheduleEdit = (root) => toggleScheduleEdit(root);
+  window.responderAgendamentoExame = responderAgendamentoExame;
+  window.initVetSchedulePage = (options) => initVetSchedulePage(options);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initVetSchedulePage();
+});
+
+export default {
+  selectDays,
+  toggleScheduleForm,
+  editSchedule,
+  toggleAppointmentForm,
+  updateAppointmentTimes,
+  toggleScheduleEdit,
+  responderAgendamentoExame,
+  initVetSchedulePage
+};

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -246,7 +246,7 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='appointments_table.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='appointments_table.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const vetField = {% if form %}document.getElementById('{{ form.veterinario_id.id }}'){% else %}null{% endif %};

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -1,7 +1,11 @@
 {% extends "layout.html" %}
 
 {% block main %}
-<div class="container mt-4">
+<div class="container mt-4"
+     data-vet-schedule-root
+     data-vet-id="{{ veterinario.id }}"
+     data-appointments-base-url="{{ url_for('appointments') }}"
+     data-csrf-token="{{ csrf_token() if csrf_token is defined else '' }}">
   <!-- Cabeçalho melhorado -->
   <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4">
     <div>
@@ -427,7 +431,9 @@
   <div class="card mb-4">
     <div class="card-header bg-light d-flex justify-content-between align-items-center">
       <h5 class="mb-0"><i class="fas fa-business-time me-2"></i>Horários Cadastrados</h5>
-      <button class="btn btn-sm btn-outline-primary" onclick="toggleScheduleEdit()">
+      <button class="btn btn-sm btn-outline-primary"
+              data-schedule-edit-toggle
+              onclick="toggleScheduleEdit()">
         <i class="fas fa-edit me-1"></i>Editar horários
       </button>
     </div>
@@ -529,198 +535,7 @@
 
 </div>
 
-<script>
-  // Funções JavaScript para melhorar a interação
-  function selectDays(mode) {
-    const select = document.getElementById('schedule-dias_semana');
-    const weekdays = ['Segunda','Terça','Quarta','Quinta','Sexta'];
-    const weekend = ['Sábado','Domingo'];
-    for (const opt of select.options) {
-      if (mode === 'all') opt.selected = true;
-      else if (mode === 'weekday') opt.selected = weekdays.includes(opt.value);
-      else if (mode === 'weekend') opt.selected = weekend.includes(opt.value);
-      else if (mode === 'clear') opt.selected = false;
-    }
-    select.dispatchEvent(new Event('change'));
-  }
 
-  function toggleScheduleForm() {
-    const modal = new bootstrap.Modal(document.getElementById('scheduleModal'));
-    const title = document.getElementById('scheduleModalTitle');
-    const form = document.getElementById('schedule-form');
-    const select = document.getElementById('schedule-dias_semana');
-    
-    form.reset();
-    document.getElementById('schedule-veterinario_id').value = '{{ veterinario.id }}';
-    title.textContent = 'Adicionar Horário';
-    form.action = "{{ url_for('appointments') }}";
-    select.multiple = true;
-    
-    modal.show();
-  }
-
-  function editSchedule(data) {
-    const modal = new bootstrap.Modal(document.getElementById('scheduleModal'));
-    const title = document.getElementById('scheduleModalTitle');
-    const form = document.getElementById('schedule-form');
-    const select = document.getElementById('schedule-dias_semana');
-    
-    form.reset();
-    form.action = `/appointments/{{ veterinario.id }}/schedule/${data.id}/edit`;
-    title.textContent = 'Editar Horário';
-    select.multiple = false;
-    [...select.options].forEach(opt => opt.selected = opt.value === data.dia);
-    document.getElementById('schedule-hora_inicio').value = data.horaInicio;
-    document.getElementById('schedule-hora_fim').value = data.horaFim;
-    document.getElementById('schedule-intervalo_inicio').value = data.intervaloInicio;
-    document.getElementById('schedule-intervalo_fim').value = data.intervaloFim;
-    
-    modal.show();
-  }
-
-  document.querySelectorAll('.edit-btn').forEach(btn => {
-    btn.addEventListener('click', function() {
-      editSchedule(this.dataset);
-    });
-  });
-
-  function toggleAppointmentForm() {
-    const modal = new bootstrap.Modal(document.getElementById('appointmentModalForm'));
-    modal.show();
-    updateAppointmentTimes();
-  }
-
-  async function updateAppointmentTimes() {
-    const date = document.getElementById('appointment-date').value;
-    const select = document.getElementById('appointment-time');
-    if (!date) {
-      select.innerHTML = '<option value="">Selecione...</option>';
-      return;
-    }
-    const resp = await fetch(`/api/specialist/{{ veterinario.id }}/available_times?date=${date}`);
-    const times = await resp.json();
-    select.innerHTML = '<option value="">Selecione...</option>';
-    times.forEach(t => {
-      const opt = document.createElement('option');
-      opt.value = t;
-      opt.textContent = t;
-      select.appendChild(opt);
-    });
-  }
-
-  document.getElementById('appointment-date').addEventListener('change', updateAppointmentTimes);
-
-  function toggleScheduleEdit() {
-    document.querySelectorAll('.schedule-actions').forEach(el => {
-      el.classList.toggle('d-none');
-    });
-    
-    const btn = document.querySelector('[onclick="toggleScheduleEdit()"]');
-    if (btn.querySelector('i').classList.contains('fa-edit')) {
-      btn.innerHTML = '<i class="fas fa-times me-1"></i>Cancelar Edição';
-    } else {
-      btn.innerHTML = '<i class="fas fa-edit me-1"></i>Editar horários';
-    }
-  }
-
-  async function responderAgendamentoExame(id, status) {
-    const resp = await fetch(`/exam_appointment/${id}/status`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-      },
-      body: JSON.stringify({ status })
-    });
-    if (resp.ok) {
-      const data = await resp.json();
-      if (data.success) {
-        location.reload();
-      } else {
-        alert(data.message || 'Erro ao atualizar status.');
-      }
-    } else {
-      alert('Erro ao atualizar status.');
-    }
-  }
-
-  // Modal de detalhes das consultas
-  document.querySelectorAll('.appointment-item').forEach(item => {
-    item.addEventListener('click', function(e) {
-      if (e.target.closest('.btn')) return;
-      document.getElementById('modal-appt-id').value = this.dataset.id;
-      document.getElementById('modal-vet').value = this.dataset.vet;
-      document.getElementById('modal-tutor').value = this.dataset.tutor;
-      document.getElementById('modal-animal').value = this.dataset.animal;
-      document.getElementById('modal-date').value = this.dataset.date;
-      document.getElementById('modal-time').value = this.dataset.time;
-      document.getElementById('modal-notes').value = this.dataset.notes || '';
-      document.getElementById('modal-animal-link').href = this.dataset.animalUrl;
-      document.getElementById('modal-tutor-link').href = this.dataset.tutorUrl;
-      document.getElementById('modal-consulta-link').href = this.dataset.consultaUrl;
-      
-      const modal = new bootstrap.Modal(document.getElementById('appointmentDetailModal'));
-      modal.show();
-    });
-  });
-
-  document.getElementById('modal-save-btn').addEventListener('click', function() {
-    const id = document.getElementById('modal-appt-id').value;
-    const date = document.getElementById('modal-date').value;
-    const time = document.getElementById('modal-time').value;
-    const notes = document.getElementById('modal-notes').value;
-    
-    fetch(`/appointments/${id}/edit`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': '{{ csrf_token() if csrf_token is defined else '' }}'
-      },
-      body: JSON.stringify({
-        date: date,
-        time: time,
-        veterinario_id: '{{ veterinario.id }}',
-        notes: notes
-      })
-    }).then(r => r.json()).then(data => {
-      if (data.success) {
-        location.reload();
-      } else {
-        alert(data.message || 'Erro ao salvar');
-      }
-    }).catch(() => alert('Erro ao salvar'));
-  });
-
-  const toggleBtn = document.getElementById('toggle-past');
-  const pastList = document.getElementById('past-list');
-  if (toggleBtn && pastList) {
-    toggleBtn.addEventListener('click', function(){
-      pastList.classList.toggle('d-none');
-      const icon = this.querySelector('i');
-      if (pastList.classList.contains('d-none')) {
-        this.innerHTML = '<i class="fas fa-chevron-down me-1"></i>Mostrar';
-      } else {
-        this.innerHTML = '<i class="fas fa-chevron-up me-1"></i>Ocultar';
-      }
-    });
-  }
-
-  // Adicionar animações de transição suave
-  document.addEventListener('DOMContentLoaded', function() {
-    // Adicionar classes de animação para os elementos
-    const cards = document.querySelectorAll('.card');
-    cards.forEach((card, index) => {
-      card.style.opacity = '0';
-      card.style.transform = 'translateY(20px)';
-      card.style.transition = 'opacity 0.5s ease, transform 0.5s ease';
-      
-      setTimeout(() => {
-        card.style.opacity = '1';
-        card.style.transform = 'translateY(0)';
-      }, 100 + (index * 100));
-    });
-  });
-</script>
 
 <style>
   .appointment-item {
@@ -758,4 +573,9 @@
     }
   }
 </style>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script type="module" src="{{ url_for('static', filename='appointments_vet.js') }}"></script>
 {% endblock %}

--- a/templates/animais/ficha_animal.html
+++ b/templates/animais/ficha_animal.html
@@ -317,5 +317,5 @@
 
 {% endblock %}
 {% block scripts %}
-  <script src="{{ url_for('static', filename='appointments_table.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='appointments_table.js') }}"></script>
 {% endblock %}

--- a/templates/clinica/clinic_detail.html
+++ b/templates/clinica/clinic_detail.html
@@ -254,7 +254,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='appointments_table.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='appointments_table.js') }}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     const storageKey = 'clinicActiveTab_{{ clinica.id }}';


### PR DESCRIPTION
## Summary
- move the inline agenda management logic into a new `appointments_vet.js` module and drive it through data attributes on the template
- add a shared `appointments_shared.js` helper and reuse it from both the vet module and `appointments_table.js`
- load the updated modules via `type="module"` script tags across vet, clinic, and appointment templates

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1ca1b47c4832e81ad8cea53a3c15c