### PR TITLE
Highlight booked appointment times

### DIFF
--- a/app.py
+++ b/app.py
@@ -8750,7 +8750,13 @@ def api_specialist_available_times(veterinario_id):
         return jsonify([])
     date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
     kind = request.args.get('kind', 'consulta')
-    times = get_available_times(veterinario_id, date_obj, kind=kind)
+    include_booked = request.args.get('include_booked', '').lower() in ('1', 'true', 'yes', 'on')
+    times = get_available_times(
+        veterinario_id,
+        date_obj,
+        kind=kind,
+        include_booked=include_booked,
+    )
     return jsonify(times)
 
 

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -417,22 +417,33 @@ document.addEventListener('DOMContentLoaded', () => {
     timeField.dataset.currentTime = '';
   }
 
-  function populateTimeFieldOptions(times) {
+  function populateTimeFieldOptions(times, { bookedTimes = [], placeholderText } = {}) {
     if (!timeField) {
       return;
     }
+
     const currentTime = timeField.dataset.currentTime || timeField.value || '';
+    const availableTimes = Array.from(new Set(Array.isArray(times) ? times : []));
+    availableTimes.sort();
+
+    let bookedList = Array.from(new Set(Array.isArray(bookedTimes) ? bookedTimes : []));
+    bookedList.sort();
+    bookedList = bookedList.filter(t => !availableTimes.includes(t));
+
+    const placeholderLabel = placeholderText
+      || (availableTimes.length ? timeFieldPlaceholder : timeFieldEmptyText);
+
     timeField.innerHTML = '';
 
     const placeholderOption = document.createElement('option');
     placeholderOption.value = '';
-    placeholderOption.textContent = timeFieldPlaceholder;
+    placeholderOption.textContent = placeholderLabel;
     placeholderOption.disabled = true;
     placeholderOption.selected = !currentTime;
     timeField.appendChild(placeholderOption);
 
     let hasCurrentTime = false;
-    times.forEach(t => {
+    availableTimes.forEach(t => {
       const option = document.createElement('option');
       option.value = t;
       option.textContent = t;
@@ -444,13 +455,29 @@ document.addEventListener('DOMContentLoaded', () => {
       timeField.appendChild(option);
     });
 
+    const currentIsBooked = currentTime && bookedList.includes(currentTime);
     if (currentTime && !hasCurrentTime) {
       const preservedOption = document.createElement('option');
       preservedOption.value = currentTime;
-      preservedOption.textContent = currentTime;
+      preservedOption.textContent = currentIsBooked ? `${currentTime} — ocupado` : currentTime;
       preservedOption.selected = true;
+      if (currentIsBooked) {
+        preservedOption.dataset.status = 'booked';
+        preservedOption.style.color = 'var(--bs-danger)';
+        bookedList = bookedList.filter(t => t !== currentTime);
+      }
       timeField.appendChild(preservedOption);
     }
+
+    bookedList.forEach(t => {
+      const option = document.createElement('option');
+      option.value = t;
+      option.textContent = `${t} — ocupado`;
+      option.disabled = true;
+      option.dataset.status = 'booked';
+      option.style.color = 'var(--bs-danger)';
+      timeField.appendChild(option);
+    });
 
     timeField.disabled = false;
     timeField.dataset.currentTime = timeField.value;
@@ -467,16 +494,27 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     try {
-      const resp = await fetch(`/api/specialist/${vetId}/available_times?date=${date}`);
+      const resp = await fetch(`/api/specialist/${vetId}/available_times?date=${date}&include_booked=1`);
       if (!resp.ok) {
         throw new Error('Erro ao carregar horários disponíveis');
       }
-      const times = await resp.json();
-      if (!Array.isArray(times) || times.length === 0) {
-        setTimeFieldMessage(timeFieldEmptyText, { disable: true });
-        return;
+      const payload = await resp.json();
+      let availableTimes = [];
+      let bookedTimes = [];
+      if (Array.isArray(payload)) {
+        availableTimes = payload;
+      } else if (payload && typeof payload === 'object') {
+        if (Array.isArray(payload.available)) {
+          availableTimes = payload.available;
+        }
+        if (Array.isArray(payload.booked)) {
+          bookedTimes = payload.booked;
+        }
       }
-      populateTimeFieldOptions(times);
+      populateTimeFieldOptions(availableTimes, { bookedTimes });
+      if (!availableTimes.length && !bookedTimes.length) {
+        timeField.disabled = true;
+      }
     } catch (error) {
       console.error(error);
       setTimeFieldMessage(timeFieldEmptyText, { disable: true });

--- a/tests/test_available_times_api.py
+++ b/tests/test_available_times_api.py
@@ -1,0 +1,106 @@
+import os
+import sys
+
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from datetime import datetime, time, date
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app import app as flask_app, db
+from helpers import BR_TZ, get_available_times
+from models import Appointment, Clinica, Veterinario, VetSchedule, Animal, User
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def _create_basic_entities():
+    clinic = Clinica(id=1, nome="Clinica")
+    tutor = User(id=1, name="Tutor", email="tutor@test")
+    tutor.set_password("x")
+    vet_user = User(id=2, name="Vet", email="vet@test", worker="veterinario")
+    vet_user.set_password("x")
+    vet = Veterinario(id=1, user_id=vet_user.id, crmv="123", clinica_id=clinic.id)
+    animal = Animal(id=1, name="Rex", user_id=tutor.id, clinica_id=clinic.id)
+
+    schedules = [
+        VetSchedule(
+            id=1,
+            veterinario_id=vet.id,
+            dia_semana="Segunda",
+            hora_inicio=time(13, 0),
+            hora_fim=time(17, 30),
+        ),
+        VetSchedule(
+            id=2,
+            veterinario_id=vet.id,
+            dia_semana="Segunda",
+            hora_inicio=time(13, 0),
+            hora_fim=time(17, 30),
+        ),
+        VetSchedule(
+            id=3,
+            veterinario_id=vet.id,
+            dia_semana="Segunda",
+            hora_inicio=time(20, 0),
+            hora_fim=time(21, 30),
+        ),
+    ]
+
+    appt_local = datetime(2024, 5, 20, 13, 0, tzinfo=BR_TZ)
+    appt_utc = appt_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+    appointment = Appointment(
+        id=1,
+        veterinario_id=vet.id,
+        tutor_id=tutor.id,
+        animal_id=animal.id,
+        clinica_id=clinic.id,
+        scheduled_at=appt_utc,
+        status="scheduled",
+        kind="consulta",
+    )
+
+    db.session.add_all([clinic, tutor, vet_user, vet, animal, appointment, *schedules])
+    db.session.commit()
+    return vet
+
+
+def test_available_times_endpoint_marks_booked_slots(client):
+    with flask_app.app_context():
+        vet = _create_basic_entities()
+        target_date = date(2024, 5, 20)
+
+        data_with_status = get_available_times(vet.id, target_date, include_booked=True)
+        available_only = get_available_times(vet.id, target_date)
+
+        assert isinstance(data_with_status, dict)
+        assert sorted(data_with_status["available"]) == sorted(available_only)
+        assert "13:00" not in data_with_status["available"]
+        assert "13:00" in data_with_status["booked"]
+        assert len(data_with_status["available"]) == len(set(data_with_status["available"]))
+
+    resp_full = client.get(f"/api/specialist/{vet.id}/available_times?date=2024-05-20&include_booked=1")
+    assert resp_full.status_code == 200
+    payload = resp_full.get_json()
+    assert "booked" in payload
+    assert "13:00" in payload["booked"]
+    assert len(payload["available"]) == len(set(payload["available"]))
+
+    resp_simple = client.get(f"/api/specialist/{vet.id}/available_times?date=2024-05-20")
+    assert resp_simple.status_code == 200
+    assert resp_simple.get_json() == payload["available"]


### PR DESCRIPTION
## Summary
- return structured data from the available times helper when requested so booked slots are not duplicated
- update the veterinarian scheduling form to consume the new data, showing unavailable slots in red
- add a regression test covering the enriched available times API response

## Testing
- pytest tests/test_available_times_api.py tests/test_schedule_exam.py tests/test_weekly_schedule_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d215215cf8832ea9b34f26b0deb853