### PR TITLE
Expose scheduler metadata in appointment detail modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -2386,6 +2386,7 @@ def agendar_retorno(consulta_id):
                     notes=form.reason.data,
                     kind='retorno',
                     status='accepted' if same_user else 'scheduled',
+                    created_by=current_user.id,
                 )
                 db.session.add(appt)
                 db.session.commit()
@@ -8023,18 +8024,19 @@ def appointments():
                             )
                             return _redirect_to_current_appointments()
 
-                        appt = Appointment(
-                            animal_id=animal.id,
-                            tutor_id=tutor_id,
-                            veterinario_id=appointment_form.veterinario_id.data,
-                            scheduled_at=scheduled_at,
-                            clinica_id=clinica_id,
-                            notes=appointment_form.reason.data,
-                            kind=appointment_form.kind.data,
-                        )
-                        db.session.add(appt)
-                        db.session.commit()
-                        flash('Agendamento criado com sucesso.', 'success')
+                    appt = Appointment(
+                        animal_id=animal.id,
+                        tutor_id=tutor_id,
+                        veterinario_id=appointment_form.veterinario_id.data,
+                        scheduled_at=scheduled_at,
+                        clinica_id=clinica_id,
+                        notes=appointment_form.reason.data,
+                        kind=appointment_form.kind.data,
+                        created_by=current_user.id,
+                    )
+                    db.session.add(appt)
+                    db.session.commit()
+                    flash('Agendamento criado com sucesso.', 'success')
                 return _redirect_to_current_appointments()
             appointments = (
                 Appointment.query

--- a/migrations/versions/6e9a3f4c2b18_add_scheduler_fields_to_appointment.py
+++ b/migrations/versions/6e9a3f4c2b18_add_scheduler_fields_to_appointment.py
@@ -1,0 +1,38 @@
+"""add scheduler metadata to appointment"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6e9a3f4c2b18'
+down_revision = '7ac809e3c0a9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('appointment') as batch_op:
+        batch_op.add_column(sa.Column('created_by', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('created_at', sa.DateTime(), nullable=True))
+        batch_op.create_foreign_key(
+            'fk_appointment_created_by_user',
+            'user',
+            ['created_by'],
+            ['id'],
+            ondelete='SET NULL'
+        )
+
+    op.execute(
+        "UPDATE appointment SET created_at = COALESCE(created_at, scheduled_at, CURRENT_TIMESTAMP)"
+    )
+
+    with op.batch_alter_table('appointment') as batch_op:
+        batch_op.alter_column('created_at', existing_type=sa.DateTime(), nullable=False)
+
+
+def downgrade():
+    with op.batch_alter_table('appointment') as batch_op:
+        batch_op.drop_constraint('fk_appointment_created_by_user', type_='foreignkey')
+        batch_op.drop_column('created_at')
+        batch_op.drop_column('created_by')

--- a/models.py
+++ b/models.py
@@ -764,6 +764,12 @@ class Appointment(db.Model):
     notes = db.Column(db.Text, nullable=True)
     consulta_id = db.Column(db.Integer, db.ForeignKey('consulta.id'), nullable=True)
     clinica_id = db.Column(db.Integer, db.ForeignKey('clinica.id'), nullable=True)
+    created_by = db.Column(
+        db.Integer,
+        db.ForeignKey('user.id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
     animal = db.relationship(
         'Animal',
@@ -783,6 +789,11 @@ class Appointment(db.Model):
         'Consulta',
         backref=db.backref('appointment', uselist=False),
         uselist=False,
+    )
+    creator = db.relationship(
+        'User',
+        foreign_keys=[created_by],
+        backref='created_appointments',
     )
 
     @classmethod

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -261,6 +261,7 @@
               data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
               data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
               data-vet="{{ appt.veterinario.user.name }}"
+              data-vet-id="{{ appt.veterinario_id }}"
               data-tutor="{{ appt.tutor.name }}"
               data-tutor-id="{{ appt.tutor_id }}"
               data-animal="{{ appt.animal.name }}"
@@ -269,6 +270,8 @@
               data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
               data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
               data-notes="{{ appt.notes or '' }}"
+              data-created-by="{{ appt.creator.name if appt.creator else '' }}"
+              data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
               data-type="{{ item.kind }}">
             <div class="d-flex justify-content-between align-items-center">
               <div class="d-flex align-items-center">
@@ -510,12 +513,24 @@
           </div>
           <div class="row">
             <div class="col-md-6 mb-3">
+              <label class="form-label fw-bold">Agendado por</label>
+              <input type="text" class="form-control" id="modal-created-by" readonly>
+            </div>
+            <div class="col-md-6 mb-3">
+              <label class="form-label fw-bold">Agendado em</label>
+              <input type="text" class="form-control" id="modal-created-at" readonly>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-6 mb-3">
               <label class="form-label fw-bold">Data</label>
               <input type="date" class="form-control" id="modal-date">
             </div>
             <div class="col-md-6 mb-3">
               <label class="form-label fw-bold">Hora</label>
-              <input type="time" class="form-control" id="modal-time">
+              <select class="form-select" id="modal-time" data-placeholder="Selecione...">
+                <option value="">Selecione...</option>
+              </select>
             </div>
           </div>
           <div class="mb-3">


### PR DESCRIPTION
## Summary
- store appointment creator metadata with new database columns
- show who created the appointment and when inside the detail modal
- reuse available-slot fetching when editing appointments for consistent UX

## Testing
- pytest tests/test_appointment_edit.py
- pytest tests/test_appointment_events_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d2164ddfac832e926f6588d5e99438