### PR TITLE
Show filtered event counts in tutor calendar

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -213,6 +213,26 @@
   color: var(--bs-gray-900);
 }
 
+#{{ component_id }} .tutor-calendar__day-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+#{{ component_id }} .tutor-calendar__date-count {
+  margin-left: auto;
+  background: var(--bs-primary);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  line-height: 1.2;
+  min-width: 1.5rem;
+  text-align: center;
+}
+
 #{{ component_id }} .tutor-calendar__event-list {
   display: flex;
   flex-direction: column;
@@ -615,10 +635,10 @@ document.addEventListener('DOMContentLoaded', function() {
       const dateLabel = document.createElement('div');
       dateLabel.className = 'tutor-calendar__date';
       dateLabel.textContent = String(cellDate.getDate());
-      cell.appendChild(dateLabel);
 
-      const eventsWrapper = document.createElement('div');
-      eventsWrapper.className = 'tutor-calendar__event-list';
+      const dayHeader = document.createElement('div');
+      dayHeader.className = 'tutor-calendar__day-header';
+      dayHeader.appendChild(dateLabel);
 
       const dayEvents = events.filter(function(event) {
         if (event.date !== iso) {
@@ -637,6 +657,19 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         return 0;
       });
+
+      const totalCount = dayEvents.length;
+      if (totalCount > 0) {
+        const dateCount = document.createElement('div');
+        dateCount.className = 'tutor-calendar__date-count';
+        dateCount.textContent = String(totalCount);
+        dayHeader.appendChild(dateCount);
+      }
+
+      cell.appendChild(dayHeader);
+
+      const eventsWrapper = document.createElement('div');
+      eventsWrapper.className = 'tutor-calendar__event-list';
 
       dayEvents.forEach(function(eventData) {
         eventsWrapper.appendChild(buildEventElement(eventData));


### PR DESCRIPTION
## Summary
- display the number of events on each day in the tutor calendar header based on the current filter
- add styling for the new day count badge to match the calendar aesthetic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d219301d38832ea5dd3d5ad28e4ebf