### PR TITLE
Ensure appointment metadata stores scheduler and creation time

### DIFF
--- a/app.py
+++ b/app.py
@@ -2387,6 +2387,7 @@ def agendar_retorno(consulta_id):
                     kind='retorno',
                     status='accepted' if same_user else 'scheduled',
                     created_by=current_user.id,
+                    created_at=datetime.utcnow(),
                 )
                 db.session.add(appt)
                 db.session.commit()
@@ -7668,6 +7669,8 @@ def appointments():
                         notes=appointment_form.reason.data,
                         kind=appointment_form.kind.data,
                         status='accepted' if same_user else 'scheduled',
+                        created_by=current_user.id,
+                        created_at=datetime.utcnow(),
                     )
                     db.session.add(appt)
                     db.session.commit()
@@ -8033,6 +8036,7 @@ def appointments():
                         notes=appointment_form.reason.data,
                         kind=appointment_form.kind.data,
                         created_by=current_user.id,
+                        created_at=datetime.utcnow(),
                     )
                     db.session.add(appt)
                     db.session.commit()


### PR DESCRIPTION
## Summary
- record the authenticated user ID and a creation timestamp whenever a consultation appointment is created
- apply the metadata both to veterinarian self-bookings and clinic/admin appointment flows, including return visits

## Testing
- pytest tests/test_agendar_retorno.py tests/test_appointment_edit.py tests/test_appointment_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d21c8a910c832e8aabb0e3f13acfce