### PR TITLE
Add required validation to schedule modal fields

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -265,12 +265,12 @@
           <input type="hidden" name="schedule-intervalo_fim" id="schedule-interval-end">
           <div class="mb-3">
             <label class="form-label fw-semibold">Colaborador</label>
-            <select id="schedule-vet" name="schedule-veterinario_id" class="form-select"></select>
+            <select id="schedule-vet" name="schedule-veterinario_id" class="form-select" required></select>
           </div>
           <div class="row g-3">
             <div class="col-md-6">
               <label class="form-label fw-semibold">Dia da Semana</label>
-              <select id="schedule-day" name="schedule-dias_semana" class="form-select">
+              <select id="schedule-day" name="schedule-dias_semana" class="form-select" required>
                 <option value="Segunda">Segunda</option>
                 <option value="Terça">Terça</option>
                 <option value="Quarta">Quarta</option>
@@ -282,11 +282,11 @@
             </div>
             <div class="col-md-3">
               <label class="form-label fw-semibold">Início</label>
-              <input type="time" id="schedule-start" name="schedule-hora_inicio" class="form-control">
+              <input type="time" id="schedule-start" name="schedule-hora_inicio" class="form-control" required>
             </div>
             <div class="col-md-3">
               <label class="form-label fw-semibold">Fim</label>
-              <input type="time" id="schedule-end" name="schedule-hora_fim" class="form-control">
+              <input type="time" id="schedule-end" name="schedule-hora_fim" class="form-control" required>
             </div>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- require the collaborator and day selects in the schedule modal
- mark the schedule start and end time inputs as required to enforce modal validation

## Testing
- pytest
- browser_container.run_playwright_script (manual validation of required fields)


------
https://chatgpt.com/codex/tasks/task_e_68d2213a22e8832eab17a1ffc422fcbb