### PR TITLE
Add label associations to schedule edit modal

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -264,12 +264,12 @@
           <input type="hidden" name="schedule-intervalo_inicio" id="schedule-interval-start">
           <input type="hidden" name="schedule-intervalo_fim" id="schedule-interval-end">
           <div class="mb-3">
-            <label class="form-label fw-semibold">Colaborador</label>
+            <label for="schedule-vet" class="form-label fw-semibold">Colaborador</label>
             <select id="schedule-vet" name="schedule-veterinario_id" class="form-select"></select>
           </div>
           <div class="row g-3">
             <div class="col-md-6">
-              <label class="form-label fw-semibold">Dia da Semana</label>
+              <label for="schedule-day" class="form-label fw-semibold">Dia da Semana</label>
               <select id="schedule-day" name="schedule-dias_semana" class="form-select">
                 <option value="Segunda">Segunda</option>
                 <option value="Terça">Terça</option>
@@ -281,11 +281,11 @@
               </select>
             </div>
             <div class="col-md-3">
-              <label class="form-label fw-semibold">Início</label>
+              <label for="schedule-start" class="form-label fw-semibold">Início</label>
               <input type="time" id="schedule-start" name="schedule-hora_inicio" class="form-control">
             </div>
             <div class="col-md-3">
-              <label class="form-label fw-semibold">Fim</label>
+              <label for="schedule-end" class="form-label fw-semibold">Fim</label>
               <input type="time" id="schedule-end" name="schedule-hora_fim" class="form-control">
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add explicit `for` attributes to the schedule edit modal labels to reference their associated inputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d221350cdc832e8f64e34b9289b03a