### PR TITLE
Improve schedule edit modal accessibility

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -245,14 +245,25 @@
 </div>
 
 <!-- Modal Editar Horário do Colaborador -->
-<div class="modal fade" id="scheduleEditModal" tabindex="-1" aria-hidden="true">
+<div
+  class="modal fade"
+  id="scheduleEditModal"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="scheduleEditModalLabel"
+  aria-describedby="scheduleEditModalDescription"
+  aria-hidden="true"
+>
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><i class="bi bi-clock-history me-2"></i>Editar Horário</h5>
+        <h5 class="modal-title" id="scheduleEditModalLabel"><i class="bi bi-clock-history me-2"></i>Editar Horário</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
       </div>
       <div class="modal-body">
+        <p class="text-muted small" id="scheduleEditModalDescription">
+          Utilize o formulário abaixo para atualizar o horário do colaborador selecionado.
+        </p>
         <form
           id="schedule-edit-form"
           method="post"


### PR DESCRIPTION
## Summary
- add an accessible label for the schedule edit modal title
- expose the modal as a dialog with the appropriate ARIA attributes
- provide a short description in the modal body that is referenced by assistive technologies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d221280ab8832e88bc29d42fd635d3