### PR TITLE
Restrict vet appointment API and refresh calendar

### DIFF
--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -419,7 +419,10 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     const vetChanged = previousVetId !== numericVetId;
     if (vetChanged && (shouldActivate || source === 'vet')) {
-      addEvents({ refetch: shouldRefetch });
+      addEvents({ refetch: false });
+      if (shouldRefetch && calendar && typeof calendar.refetchEvents === 'function') {
+        calendar.refetchEvents();
+      }
       return true;
     }
     if (shouldRefetch && calendar && typeof calendar.refetchEvents === 'function') {


### PR DESCRIPTION
## Summary
- tighten the veterinarian appointment API by enforcing clinic access for collaborators and supporting optional admin clinic filters
- continue returning exam and vaccine events alongside appointments via the shared helper
- ensure the calendar refreshes data after switching veterinarians when sourcing events from the vet endpoint

## Testing
- pytest tests/test_appointment_events_api.py::test_vet_appointments_admin_includes_related_events -q
- pytest tests/test_appointment_events_api.py::test_vet_appointments_collaborator_filters_by_clinic -q

------
https://chatgpt.com/codex/tasks/task_e_68d27e4462dc832e848ce7e1a18e449c