### PR TITLE
Enable vet filtering from calendar summary

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -154,12 +154,36 @@
   background: linear-gradient(135deg, var(--calendar-vet-soft, rgba(148, 163, 184, 0.12)), #ffffff);
   border: 1px solid rgba(148, 163, 184, 0.18);
   box-shadow: 0 16px 32px -26px rgba(15, 23, 42, 0.6);
+  cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .calendar-summary-item:hover {
   transform: translateY(-2px);
   box-shadow: 0 24px 36px -28px rgba(15, 23, 42, 0.65);
+}
+
+.calendar-summary-item.is-active {
+  border-color: var(--calendar-vet-color, #2563eb);
+  box-shadow:
+    0 24px 42px -28px rgba(37, 99, 235, 0.45),
+    0 0 0 2px rgba(37, 99, 235, 0.25);
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.96) 0%,
+    var(--calendar-vet-soft, rgba(148, 163, 184, 0.18)) 55%,
+    rgba(37, 99, 235, 0.08) 100%
+  );
+  transform: translateY(-2px);
+}
+
+.calendar-summary-item.is-active .calendar-summary-total {
+  background-color: rgba(37, 99, 235, 0.14);
+  color: #1d4ed8;
+}
+
+.calendar-summary-item.is-active .calendar-summary-bullet {
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
 }
 
 .calendar-summary-item .calendar-summary-header {

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -386,6 +386,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const calendarSummaryTotalBadge = calendarSummaryPanel
     ? calendarSummaryPanel.querySelector('[data-calendar-summary-total]')
     : null;
+  let activeCalendarSummaryVetId = null;
   let newAppointmentCollapseInstance = null;
 
   const calendarSummaryWeekdays = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
@@ -573,6 +574,28 @@ document.addEventListener('DOMContentLoaded', () => {
     return source.slice(0, limit);
   }
 
+  function refreshCalendarSummaryActiveState() {
+    if (!calendarSummaryList) {
+      return;
+    }
+    const items = calendarSummaryList.querySelectorAll('.calendar-summary-item');
+    items.forEach(element => {
+      const elementVetId = normalizeSummaryVetId(
+        element && element.dataset ? element.dataset.vetId : null,
+      );
+      if (activeCalendarSummaryVetId && elementVetId === activeCalendarSummaryVetId) {
+        element.classList.add('is-active');
+      } else {
+        element.classList.remove('is-active');
+      }
+    });
+  }
+
+  function setActiveCalendarSummaryItem(vetId) {
+    activeCalendarSummaryVetId = vetId ? normalizeSummaryVetId(vetId) : null;
+    refreshCalendarSummaryActiveState();
+  }
+
   function renderCalendarSummary(events) {
     if (!calendarSummaryPanel || !calendarSummaryList) {
       return;
@@ -672,6 +695,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
       calendarSummaryList.appendChild(item);
     });
+
+    refreshCalendarSummaryActiveState();
   }
 
   if (calendarSummaryPanel) {
@@ -682,6 +707,33 @@ document.addEventListener('DOMContentLoaded', () => {
     document.addEventListener('sharedCalendarEvents', event => {
       const items = (event && event.detail && event.detail.events) || [];
       renderCalendarSummary(items);
+    });
+  }
+
+  if (calendarSummaryList) {
+    calendarSummaryList.addEventListener('click', event => {
+      const isTextNode = typeof Node !== 'undefined'
+        && event.target
+        && event.target.nodeType === Node.TEXT_NODE;
+      const origin = isTextNode ? event.target.parentElement : event.target;
+      const targetItem = origin && typeof origin.closest === 'function'
+        ? origin.closest('.calendar-summary-item')
+        : null;
+      if (!targetItem || !calendarSummaryList.contains(targetItem)) {
+        return;
+      }
+      const rawVetId = targetItem.dataset ? targetItem.dataset.vetId : null;
+      const normalizedVetId = normalizeSummaryVetId(rawVetId);
+      const isCurrentlyActive = Boolean(
+        activeCalendarSummaryVetId !== null
+        && normalizedVetId !== null
+        && normalizedVetId === activeCalendarSummaryVetId,
+      );
+      const nextActiveVetId = isCurrentlyActive ? null : normalizedVetId;
+      setActiveCalendarSummaryItem(nextActiveVetId);
+      if (typeof window.updateCalendarVetSelection === 'function') {
+        window.updateCalendarVetSelection(nextActiveVetId, { activate: true, refetch: true });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- add delegated click handling for calendar summary items to toggle vet filters through updateCalendarVetSelection
- track and reflect the active vet selection across summary re-renders
- style the active summary state with highlighted visuals in the shared stylesheet

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d27e668198832e8e72ec350a73d7b6