### PR TITLE
Improve calendar summary semantics and accessibility

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -148,6 +148,12 @@
   padding: 0.4rem 0.75rem;
 }
 
+.calendar-summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .calendar-summary-item {
   border-radius: 0.9rem;
   padding: 0.9rem 1rem;
@@ -155,6 +161,7 @@
   border: 1px solid rgba(148, 163, 184, 0.18);
   box-shadow: 0 16px 32px -26px rgba(15, 23, 42, 0.6);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  list-style: none;
 }
 
 .calendar-summary-item:hover {
@@ -208,6 +215,14 @@
   margin-top: 0.75rem;
   font-size: 0.86rem;
   color: #475569;
+  list-style: none;
+  padding: 0;
+}
+
+.calendar-summary-item .calendar-summary-metrics .metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
 }
 
 .calendar-summary-item .calendar-summary-metrics strong {
@@ -219,6 +234,8 @@
   flex-wrap: wrap;
   gap: 0.4rem 0.55rem;
   margin-top: 0.85rem;
+  list-style: none;
+  padding: 0;
 }
 
 .calendar-summary-item .calendar-summary-day {
@@ -231,6 +248,7 @@
   padding: 0.18rem 0.7rem;
   font-size: 0.76rem;
   font-weight: 600;
+  list-style: none;
 }
 
 .calendar-summary-item .calendar-summary-day .label {

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 
 {% block main %}
-<div class="container py-4">
+<section class="container py-4" aria-labelledby="appointments-calendar-title">
 
   <!-- Cabeçalho -->
-  <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
-    <h2 class="fw-bold text-gradient mb-0">
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+      <h2 id="appointments-calendar-title" class="fw-bold text-gradient mb-0">
       <i class="bi bi-calendar4-week me-2"></i> Agenda de Consultas
     </h2>
     {% if current_user.role == 'admin' %}
@@ -100,10 +100,14 @@
           </p>
         </div>
         <div class="card-body">
-          <div class="text-muted small" data-calendar-summary-empty>
+          <div class="text-muted small" data-calendar-summary-empty aria-live="polite">
             Carregando estatísticas da agenda...
           </div>
-          <div class="calendar-summary-list d-flex flex-column gap-3 mt-2" data-calendar-summary-list></div>
+          <ul
+            role="list"
+            class="calendar-summary-list d-flex flex-column gap-3 mt-2"
+            data-calendar-summary-list
+          ></ul>
         </div>
       </div>
     </div>
@@ -267,7 +271,7 @@
   <h5 class="fw-bold mt-5 mb-3"><i class="bi bi-syringe me-2"></i> Agenda de Vacinas</h5>
   {% include 'partials/vaccine_appointments_table.html' %}
 
-</div>
+</section>
 
 <!-- Modal Editar Horário do Colaborador -->
 <div class="modal fade" id="scheduleEditModal" tabindex="-1" aria-hidden="true">
@@ -595,7 +599,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     rows.forEach(entry => {
-      const item = document.createElement('div');
+      const item = document.createElement('li');
       item.classList.add('calendar-summary-item');
       const colorClass = resolveSummaryColorClass(entry.vetId);
       if (colorClass) {
@@ -603,7 +607,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       item.dataset.vetId = entry.vetId;
 
-      const header = document.createElement('div');
+      const header = document.createElement('header');
       header.classList.add('calendar-summary-header');
 
       const nameWrapper = document.createElement('div');
@@ -630,9 +634,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
       item.appendChild(header);
 
-      const metrics = document.createElement('div');
+      const metrics = document.createElement('ul');
       metrics.classList.add('calendar-summary-metrics');
-      const todayMetric = document.createElement('span');
+      metrics.setAttribute('role', 'list');
+      const todayMetric = document.createElement('li');
       todayMetric.classList.add('metric');
       todayMetric.append('Hoje: ');
       const todayValue = document.createElement('strong');
@@ -640,7 +645,7 @@ document.addEventListener('DOMContentLoaded', () => {
       todayMetric.appendChild(todayValue);
       metrics.appendChild(todayMetric);
 
-      const weekMetric = document.createElement('span');
+      const weekMetric = document.createElement('li');
       weekMetric.classList.add('metric');
       weekMetric.append('Semana: ');
       const weekValue = document.createElement('strong');
@@ -652,10 +657,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const upcomingDays = getUpcomingSummaryDays(entry);
       if (upcomingDays.length) {
-        const dayList = document.createElement('div');
+        const dayList = document.createElement('ul');
         dayList.classList.add('calendar-summary-days');
+        dayList.setAttribute('role', 'list');
         upcomingDays.forEach(dayInfo => {
-          const dayItem = document.createElement('span');
+          const dayItem = document.createElement('li');
           dayItem.classList.add('calendar-summary-day');
           const label = document.createElement('span');
           label.classList.add('label');


### PR DESCRIPTION
## Summary
- replace the appointments overview container with a labelled section and expose the empty-state feedback through aria-live
- render the calendar summary as a semantic list using headers and list items while keeping the metrics and day breakdowns accessible
- adjust calendar summary CSS so the new UL/LI/HEADER elements preserve the existing spacing and layout

## Testing
- pytest *(fails: TypeError: Object of type Undefined is not JSON serializable in tests/test_schedule_exam.py::test_exam_appointments_listed_on_page)*

------
https://chatgpt.com/codex/tasks/task_e_68d27e734ae4832ea5386be19769e053