### PR TITLE
Improve vet calendar color handling and summary panel

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -140,6 +140,14 @@
   padding-top: 1.25rem;
 }
 
+.calendar-summary-card.has-data [data-calendar-summary-empty] {
+  display: none !important;
+}
+
+.calendar-summary-card:not(.has-data) [data-calendar-summary-list] {
+  display: none;
+}
+
 .calendar-summary-total-badge {
   background: rgba(37, 99, 235, 0.12);
   color: #1d4ed8;

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -482,6 +482,51 @@ document.addEventListener('DOMContentLoaded', () => {
     return null;
   }
 
+  function decorateSummaryItemWithVet(element, vetId) {
+    if (!element) {
+      return null;
+    }
+    const normalizedVetId = normalizeSummaryVetId(vetId);
+    if (!normalizedVetId) {
+      if (element.dataset) {
+        delete element.dataset.veterinarioId;
+        delete element.dataset.vetId;
+      }
+      element.removeAttribute('data-veterinario-id');
+      return null;
+    }
+
+    let colorClass = null;
+    if (typeof window !== 'undefined'
+      && window.calendarVetColorManager
+      && typeof window.calendarVetColorManager.applyClasses === 'function') {
+      colorClass = window.calendarVetColorManager.applyClasses(element, normalizedVetId, {
+        assignedClass: null,
+        clearWhenInvalid: true,
+      });
+    } else {
+      const classesToRemove = Array.from(element.classList).filter(cls => (
+        cls.startsWith('calendar-vet-color-') || cls.startsWith('calendar-vet-')
+      ));
+      classesToRemove.forEach(cls => element.classList.remove(cls));
+      element.classList.add(`calendar-vet-${normalizedVetId}`);
+      colorClass = resolveSummaryColorClass(normalizedVetId);
+      if (colorClass) {
+        element.classList.add(colorClass);
+      }
+      if (element.dataset) {
+        element.dataset.veterinarioId = normalizedVetId;
+      }
+      element.setAttribute('data-veterinario-id', normalizedVetId);
+    }
+
+    if (element.dataset) {
+      element.dataset.vetId = normalizedVetId;
+    }
+
+    return colorClass;
+  }
+
   function computeSummaryMetrics(events) {
     const summaryMap = new Map();
     const today = startOfDay(new Date());
@@ -597,11 +642,7 @@ document.addEventListener('DOMContentLoaded', () => {
     rows.forEach(entry => {
       const item = document.createElement('div');
       item.classList.add('calendar-summary-item');
-      const colorClass = resolveSummaryColorClass(entry.vetId);
-      if (colorClass) {
-        item.classList.add(colorClass);
-      }
-      item.dataset.vetId = entry.vetId;
+      decorateSummaryItemWithVet(item, entry.vetId);
 
       const header = document.createElement('div');
       header.classList.add('calendar-summary-header');

--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -131,11 +131,66 @@ document.addEventListener('DOMContentLoaded', function() {
     return className;
   }
 
+  function applyVetColorClasses(element, vetId, options = {}) {
+    if (!element || !element.classList) {
+      return null;
+    }
+    const normalizedVetId = normalizeVetColorKey(vetId);
+    if (!normalizedVetId) {
+      if (options.clearWhenInvalid) {
+        const classesToRemove = Array.from(element.classList).filter(function(cls) {
+          return cls.startsWith('calendar-vet-color-') || cls.startsWith('calendar-vet-');
+        });
+        classesToRemove.forEach(function(cls) {
+          element.classList.remove(cls);
+        });
+        if (element.dataset) {
+          delete element.dataset.veterinarioId;
+          delete element.dataset.vetId;
+        }
+        element.removeAttribute('data-veterinario-id');
+      }
+      return null;
+    }
+
+    const classesToRemove = Array.from(element.classList).filter(function(cls) {
+      return cls.startsWith('calendar-vet-color-') || cls.startsWith('calendar-vet-');
+    });
+    classesToRemove.forEach(function(cls) {
+      element.classList.remove(cls);
+    });
+
+    const assignedClass = options.assignedClass === undefined ? 'calendar-vet-assigned' : options.assignedClass;
+    if (assignedClass) {
+      element.classList.add(assignedClass);
+    }
+
+    if (options.includeIdClass !== false) {
+      element.classList.add(`calendar-vet-${normalizedVetId}`);
+    }
+
+    const colorClass = resolveVetColorClass(normalizedVetId);
+    if (colorClass) {
+      element.classList.add(colorClass);
+    }
+
+    if (element.dataset) {
+      element.dataset.veterinarioId = normalizedVetId;
+      element.dataset.vetId = normalizedVetId;
+    }
+    element.setAttribute('data-veterinario-id', normalizedVetId);
+
+    return colorClass;
+  }
+
   if (typeof window !== 'undefined') {
     window.calendarVetColorManager = window.calendarVetColorManager || {};
     window.calendarVetColorManager.getClass = resolveVetColorClass;
     window.calendarVetColorManager.normalize = normalizeVetColorKey;
     window.calendarVetColorManager.palette = vetColorPalette.slice();
+    window.calendarVetColorManager.applyClasses = function(element, vetId, options) {
+      return applyVetColorClasses(element, vetId, options || {});
+    };
   }
 
   if (typeof window !== 'undefined') {
@@ -518,15 +573,10 @@ document.addEventListener('DOMContentLoaded', function() {
             || info.event.extendedProps.vetId
             || info.event.extendedProps.veterinarianId)
           : null;
-        const normalizedVetId = normalizeVetColorKey(rawVetId);
-        if (normalizedVetId) {
-          const colorClass = resolveVetColorClass(normalizedVetId);
-          info.el.classList.add('calendar-vet-assigned', `calendar-vet-${normalizedVetId}`);
-          if (colorClass) {
-            info.el.classList.add(colorClass);
-          }
-          info.el.dataset.veterinarioId = normalizedVetId;
-        }
+        applyVetColorClasses(info.el, rawVetId, {
+          assignedClass: 'calendar-vet-assigned',
+          clearWhenInvalid: true,
+        });
       }
       if (!info.el || !type || type === 'appointment') {
         return;


### PR DESCRIPTION
## Summary
- centralize the veterinary color palette logic in the shared calendar script and expose a helper to keep event elements in sync
- reuse the new helper while building the appointment summary list so vet rows inherit the same color variables
- adjust calendar summary styles to hide the empty placeholder once real data is rendered

## Testing
- not run (front-end only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d27e46a8a8832e94240ad4013a1317