### PR TITLE
Improve calendar summary loading states

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -100,8 +100,11 @@
           </p>
         </div>
         <div class="card-body">
-          <div class="text-muted small" data-calendar-summary-empty>
-            Carregando estatísticas da agenda...
+          <div class="text-muted small" data-calendar-summary-loading>
+            Carregando…
+          </div>
+          <div class="text-muted small d-none" data-calendar-summary-empty>
+            Nenhum agendamento encontrado
           </div>
           <div class="calendar-summary-list d-flex flex-column gap-3 mt-2" data-calendar-summary-list></div>
         </div>
@@ -380,6 +383,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const calendarSummaryList = calendarSummaryPanel
     ? calendarSummaryPanel.querySelector('[data-calendar-summary-list]')
     : null;
+  const calendarSummaryLoading = calendarSummaryPanel
+    ? calendarSummaryPanel.querySelector('[data-calendar-summary-loading]')
+    : null;
   const calendarSummaryEmpty = calendarSummaryPanel
     ? calendarSummaryPanel.querySelector('[data-calendar-summary-empty]')
     : null;
@@ -387,8 +393,33 @@ document.addEventListener('DOMContentLoaded', () => {
     ? calendarSummaryPanel.querySelector('[data-calendar-summary-total]')
     : null;
   let newAppointmentCollapseInstance = null;
+  let calendarSummaryHasRenderedOnce = false;
+  let calendarSummaryIsLoading = false;
 
   const calendarSummaryWeekdays = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
+
+  function setCalendarSummaryLoadingState(isLoading) {
+    if (!calendarSummaryPanel) {
+      return;
+    }
+    const shouldShow = !!isLoading;
+    calendarSummaryIsLoading = shouldShow;
+    calendarSummaryPanel.classList.toggle('is-loading', shouldShow);
+    if (calendarSummaryLoading) {
+      calendarSummaryLoading.classList.toggle('d-none', !shouldShow);
+    }
+    if (shouldShow && calendarSummaryEmpty) {
+      calendarSummaryEmpty.classList.add('d-none');
+    }
+  }
+
+  function isCalendarSummaryDataReady() {
+    if (typeof window !== 'undefined'
+      && Object.prototype.hasOwnProperty.call(window, 'sharedCalendarEventsReady')) {
+      return !!window.sharedCalendarEventsReady;
+    }
+    return calendarSummaryHasRenderedOnce || !calendarSummaryIsLoading;
+  }
 
   function padNumber(value) {
     return String(value).padStart(2, '0');
@@ -573,8 +604,11 @@ document.addEventListener('DOMContentLoaded', () => {
     return source.slice(0, limit);
   }
 
-  function renderCalendarSummary(events) {
+  function renderCalendarSummary(events, { requireDataReady = false } = {}) {
     if (!calendarSummaryPanel || !calendarSummaryList) {
+      return;
+    }
+    if (requireDataReady && !isCalendarSummaryDataReady()) {
       return;
     }
     const { rows, totalEvents } = computeSummaryMetrics(events);
@@ -582,6 +616,8 @@ document.addEventListener('DOMContentLoaded', () => {
       calendarSummaryTotalBadge.textContent = String(totalEvents);
     }
     calendarSummaryList.innerHTML = '';
+    calendarSummaryHasRenderedOnce = true;
+    setCalendarSummaryLoadingState(false);
     if (!rows.length) {
       if (calendarSummaryEmpty) {
         calendarSummaryEmpty.classList.remove('d-none');
@@ -675,13 +711,36 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (calendarSummaryPanel) {
+    setCalendarSummaryLoadingState(true);
+
     const initialEvents = Array.isArray(window.sharedCalendarEvents)
       ? window.sharedCalendarEvents
       : [];
-    renderCalendarSummary(initialEvents);
+    renderCalendarSummary(initialEvents, { requireDataReady: true });
+
     document.addEventListener('sharedCalendarEvents', event => {
-      const items = (event && event.detail && event.detail.events) || [];
+      const detail = event && event.detail ? event.detail : {};
+      const items = Array.isArray(detail.events) ? detail.events : [];
+      const isReady = detail.ready !== false;
+      if (!isReady) {
+        return;
+      }
       renderCalendarSummary(items);
+    });
+
+    document.addEventListener('sharedCalendarLoading', event => {
+      const isLoading = !!(event && event.detail && event.detail.isLoading);
+      if (isLoading) {
+        setCalendarSummaryLoadingState(true);
+        return;
+      }
+      if (!calendarSummaryHasRenderedOnce) {
+        setCalendarSummaryLoadingState(false);
+        if (calendarSummaryEmpty) {
+          calendarSummaryEmpty.classList.remove('d-none');
+        }
+        calendarSummaryPanel.classList.remove('has-data');
+      }
     });
   }
 

--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -46,9 +46,9 @@ document.addEventListener('DOMContentLoaded', function() {
     return document.querySelector('[data-switcher-colab]');
   })();
   const csrfToken = '{{ csrf_token() if csrf_token is defined else '' }}';
-  const clinicId = {{ clinic_id|tojson }};
+  const clinicId = {{ clinic_id|default(none)|tojson }};
   const adminInitialView = {{ (admin_selected_view or '')|tojson }};
-  const defaultSource = {{ ('clinic' if clinic_id else 'user')|tojson }};
+  const defaultSource = {{ ('clinic' if (clinic_id is defined and clinic_id) else 'user')|tojson }};
   const clinicFilters = (function() {
     if (typeof window === 'undefined') {
       return [];
@@ -140,6 +140,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
   if (typeof window !== 'undefined') {
     window.sharedCalendarEvents = window.sharedCalendarEvents || [];
+    if (!Object.prototype.hasOwnProperty.call(window, 'sharedCalendarEventsReady')) {
+      window.sharedCalendarEventsReady = Array.isArray(window.sharedCalendarEvents)
+        && window.sharedCalendarEvents.length > 0;
+    }
   }
 
   if (!calendarEl) {
@@ -367,7 +371,8 @@ document.addEventListener('DOMContentLoaded', function() {
     };
   }
 
-  function dispatchSharedCalendarEvents(events) {
+  function dispatchSharedCalendarEvents(events, options = {}) {
+    const { markReady = true } = options;
     const normalized = (events || []).map(function(item) {
       if (item && typeof item.start === 'string') {
         const plain = Object.assign({
@@ -392,9 +397,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (typeof window !== 'undefined') {
       window.sharedCalendarEvents = normalized;
+      window.sharedCalendarEventsReady = !!markReady;
     }
     document.dispatchEvent(new CustomEvent('sharedCalendarEvents', {
-      detail: { events: normalized },
+      detail: { events: normalized, ready: !!markReady },
     }));
   }
 
@@ -504,6 +510,15 @@ document.addEventListener('DOMContentLoaded', function() {
     eventAllow: function(dropInfo, draggedEvent) {
       return getEventType(draggedEvent) === 'appointment';
     },
+    loading: function(isLoading) {
+      const loadingState = !!isLoading;
+      if (typeof window !== 'undefined' && loadingState) {
+        window.sharedCalendarEventsReady = false;
+      }
+      document.dispatchEvent(new CustomEvent('sharedCalendarLoading', {
+        detail: { isLoading: loadingState },
+      }));
+    },
     eventsSet: function(eventList) {
       dispatchSharedCalendarEvents(eventList);
     },
@@ -545,7 +560,9 @@ document.addEventListener('DOMContentLoaded', function() {
   window.sharedCalendar = calendar;
   addEvents();
   calendar.render();
-  dispatchSharedCalendarEvents(calendar.getEvents());
+  const initialEventList = calendar.getEvents();
+  const initialReady = initialEventList.length > 0;
+  dispatchSharedCalendarEvents(initialEventList, { markReady: initialReady });
   announceSharedCalendarReady(calendar);
 
   if (toggle) {


### PR DESCRIPTION
## Summary
- split the calendar summary placeholder into dedicated loading and empty elements and update the rendering logic to hide the loader only when data is ready
- emit shared calendar loading events, track readiness, and default undefined clinic ids to keep the summary loader in sync with fetch cycles

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d27e5b27a0832e9050a596f2fa19bc