### PR TITLE
Adjust tutor calendar layout to stack sidebar above calendar

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -25,7 +25,7 @@
   </div>
 
   <div class="row g-4 align-items-start">
-    <div class="col-12 col-lg-4">
+    <div class="col-12">
       <div class="card shadow-sm border-0 h-100">
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-start mb-3 flex-wrap gap-2">
@@ -64,7 +64,7 @@
       </div>
     </div>
 
-    <div class="col-12 col-lg-8">
+    <div class="col-12">
       <div class="card shadow-sm border-0 h-100">
         <div class="card-body">
           <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-3">


### PR DESCRIPTION
## Summary
- update the tutor calendar template so the sidebar content spans the full width and sits above the calendar grid
- ensure the calendar column always uses the complete container width for better readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d28ae12820832e8a7105ffdb52a83d