### PR TITLE
Adjust pet list layout to grid

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -154,12 +154,13 @@
 }
 
 #{{ component_id }} .tutor-calendar__pet-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 0.75rem;
   max-height: 320px;
   overflow-y: auto;
   padding-right: 0.25rem;
+  align-content: start;
 }
 
 #{{ component_id }} .tutor-calendar__pet {


### PR DESCRIPTION
## Summary
- switch the pet list container to a responsive CSS grid so pet cards can display side by side and use space more efficiently

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d28f727d58832eab6e44f7e01a35f5