### PR TITLE
Improve tutor calendar day detail UX

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -407,15 +407,15 @@
 
 #{{ component_id }} .tutor-calendar__day-detail {
   position: relative;
-  margin: 1rem;
-  width: min(420px, calc(100% - 2rem));
-  max-height: min(80vh, 520px);
+  margin: 1rem auto;
+  width: min(80%, 1040px);
+  max-height: min(85vh, 680px);
   overflow-y: auto;
-  border-radius: 1rem;
+  border-radius: 1.25rem;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
-  padding: 1.25rem 1.5rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+  padding: 1.75rem 2rem;
   opacity: 0;
   transform: translateY(1rem) scale(0.98);
   transition: transform 0.25s ease, opacity 0.25s ease, border-color 0.2s ease, box-shadow 0.2s ease;
@@ -434,8 +434,8 @@
 
 #{{ component_id }} .tutor-calendar__day-detail-close {
   position: absolute;
-  top: 0.75rem;
-  right: 0.75rem;
+  top: 1rem;
+  right: 1rem;
   border: none;
   background: rgba(15, 23, 42, 0.05);
   color: var(--bs-gray-700);
@@ -463,7 +463,7 @@
 #{{ component_id }} .tutor-calendar__day-detail-content {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1.5rem;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-placeholder {
@@ -519,6 +519,260 @@
 
 #{{ component_id }} .tutor-calendar__day-detail-card + .tutor-calendar__day-detail-card {
   margin-top: 0.75rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-card {
+  position: relative;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.9) 0%, #ffffff 100%);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.14);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-card--exam {
+  background: linear-gradient(180deg, rgba(237, 233, 254, 0.85) 0%, #ffffff 100%);
+}
+
+#{{ component_id }} .tutor-calendar__appointment-card--vaccine {
+  background: linear-gradient(180deg, rgba(254, 240, 138, 0.65) 0%, #ffffff 100%);
+}
+
+#{{ component_id }} .tutor-calendar__appointment-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem 1.5rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-time {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1 1 220px;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-time-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  line-height: 1.1;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-subtitle {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--bs-gray-500);
+}
+
+#{{ component_id }} .tutor-calendar__appointment-time-value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--bs-gray-900);
+}
+
+#{{ component_id }} .tutor-calendar__appointment-pill {
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(99, 102, 241, 0.15);
+  color: #4338ca;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-card--exam .tutor-calendar__appointment-pill {
+  background: rgba(139, 92, 246, 0.18);
+  color: #5b21b6;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-card--vaccine .tutor-calendar__appointment-pill {
+  background: rgba(250, 204, 21, 0.2);
+  color: #a16207;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-status {
+  margin-left: auto;
+  font-size: 0.8rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-icon.is-time {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-icon.is-pet {
+  background: rgba(248, 113, 113, 0.16);
+  color: #b91c1c;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-icon.is-tutor {
+  background: rgba(250, 204, 21, 0.22);
+  color: #92400e;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-icon.is-vet {
+  background: rgba(45, 212, 191, 0.2);
+  color: #0f766e;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-icon.is-note {
+  background: rgba(99, 102, 241, 0.18);
+  color: #4338ca;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-people {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-person {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(248, 250, 252, 0.85);
+}
+
+#{{ component_id }} .tutor-calendar__appointment-person-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-person-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--bs-gray-500);
+}
+
+#{{ component_id }} .tutor-calendar__appointment-person-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--bs-gray-900);
+  word-break: break-word;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-meta {
+  padding-top: 0.75rem;
+  border-top: 1px dashed rgba(148, 163, 184, 0.4);
+}
+
+#{{ component_id }} .tutor-calendar__appointment-meta dt {
+  color: var(--bs-gray-500);
+}
+
+#{{ component_id }} .tutor-calendar__appointment-meta dd {
+  font-weight: 500;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-notes {
+  display: flex;
+  gap: 0.9rem;
+  align-items: flex-start;
+  border-radius: 1rem;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(219, 234, 254, 0.6);
+  padding: 1rem 1.25rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-notes-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-notes-title {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #1d4ed8;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-notes-text {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--bs-gray-800);
+  white-space: pre-line;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-actions {
+  border-radius: 1rem;
+  border: 1px solid rgba(99, 102, 241, 0.16);
+  background: linear-gradient(180deg, rgba(99, 102, 241, 0.08) 0%, rgba(248, 250, 252, 0.95) 100%);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-actions-title {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #4338ca;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-actions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-action {
+  width: 100%;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-action.btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-action .btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-actions-grid > form {
+  margin: 0;
+}
+
+#{{ component_id }} .tutor-calendar__appointment-actions-grid > form .btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-meta {
@@ -606,19 +860,20 @@
 
   #{{ component_id }} .tutor-calendar__day-detail {
     margin: 0.5rem auto;
-    width: min(100%, 520px);
-    max-height: min(85vh, 560px);
+    width: min(100%, 560px);
+    max-height: min(90vh, 620px);
+    padding: 1.25rem 1.35rem;
   }
 }
 
 @media (min-width: 768px) {
   #{{ component_id }} .tutor-calendar__day-detail-layer {
-    justify-content: flex-end;
-    padding: 1.5rem 1rem;
+    justify-content: center;
+    padding: 2rem 1.5rem;
   }
 
   #{{ component_id }} .tutor-calendar__day-detail {
-    margin: 0;
+    margin: 0 auto;
   }
 }
 
@@ -1401,41 +1656,19 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     const fragment = document.createDocumentFragment();
-    const block = document.createElement('div');
-    block.className = 'appointments-day-block appointments-day-block--calendar';
-    if (dateKey) {
-      block.dataset.day = dateKey;
-      block.dataset.dayLabel = displayLabel || dateKey;
-    }
-
-    const header = document.createElement('div');
-    header.className = 'day-header d-flex align-items-center gap-2';
-    if (dateKey) {
-      header.dataset.day = dateKey;
-      header.dataset.dayLabel = displayLabel || dateKey;
-    }
-    const headerIconWrapper = document.createElement('span');
-    headerIconWrapper.className = 'icon-circle bg-primary text-white';
-    const headerIcon = document.createElement('i');
-    headerIcon.className = 'fa-solid fa-calendar-day';
-    headerIcon.setAttribute('aria-hidden', 'true');
-    headerIconWrapper.appendChild(headerIcon);
-    header.appendChild(headerIconWrapper);
-    const headerText = document.createElement('span');
-    headerText.textContent = displayLabel || dateKey || 'Compromisso';
-    header.appendChild(headerText);
-    block.appendChild(header);
-
-    const dayAppointments = document.createElement('div');
-    dayAppointments.className = 'day-appointments';
-    block.appendChild(dayAppointments);
-
+    const typeKey = eventData.type || 'appointment';
     const statusKey = String(ext.status || '').toLowerCase();
-    const card = document.createElement('div');
-    card.className = 'appointment-card appointment-row';
-    if (statusKey) {
-      card.classList.add(statusKey);
-    }
+    const statusClass = statusKey || 'scheduled';
+    const statusLabel = statusLabels[statusKey] || statusClass || '—';
+    const typeLabel = typeLabels[typeKey] || 'Evento';
+    const kindLabel = ext.kind ? String(ext.kind) : '';
+    const tutorName = ext.tutorName || null;
+    const animalName = ext.animalName || getPetName(eventData.animalId) || derivePetNameFromTitle(eventData.title) || 'Paciente';
+    const vetName = ext.vetName || ext.veterinarioName || deriveVetNameFromTitle(eventData.title) || '—';
+
+    const card = document.createElement('article');
+    card.className = 'tutor-calendar__appointment-card';
+    card.classList.add('tutor-calendar__appointment-card--' + typeKey);
     card.dataset.appointmentId = String(recordId);
     if (dateKey) {
       card.dataset.day = dateKey;
@@ -1452,82 +1685,147 @@ document.addEventListener('DOMContentLoaded', function() {
       card.dataset.boundClick = 'true';
     }
 
-    const cardBody = document.createElement('div');
-    cardBody.className = 'card-body';
-    card.appendChild(cardBody);
+    const topRow = document.createElement('div');
+    topRow.className = 'tutor-calendar__appointment-top';
 
-    const row = document.createElement('div');
-    row.className = 'row align-items-center';
-    cardBody.appendChild(row);
-
-    const timeCol = document.createElement('div');
-    timeCol.className = 'col-md-2';
-    const timeDisplay = document.createElement('div');
-    timeDisplay.className = 'time-display d-flex align-items-center gap-1';
+    const timeBlock = document.createElement('div');
+    timeBlock.className = 'tutor-calendar__appointment-time';
     const timeIconWrapper = document.createElement('span');
-    timeIconWrapper.className = 'icon-circle bg-secondary text-white';
+    timeIconWrapper.className = 'tutor-calendar__appointment-icon is-time';
     const timeIcon = document.createElement('i');
     timeIcon.className = 'fa-regular fa-clock';
     timeIcon.setAttribute('aria-hidden', 'true');
     timeIconWrapper.appendChild(timeIcon);
-    timeDisplay.appendChild(timeIconWrapper);
-    const timeText = document.createElement('span');
-    timeText.textContent = eventData.time || '--:--';
-    timeDisplay.appendChild(timeText);
-    timeCol.appendChild(timeDisplay);
-    row.appendChild(timeCol);
+    timeBlock.appendChild(timeIconWrapper);
+    const timeTextWrapper = document.createElement('div');
+    timeTextWrapper.className = 'tutor-calendar__appointment-time-text';
+    const timeLabelEl = document.createElement('span');
+    timeLabelEl.className = 'tutor-calendar__appointment-subtitle';
+    timeLabelEl.textContent = 'Horário';
+    const timeValueEl = document.createElement('span');
+    timeValueEl.className = 'tutor-calendar__appointment-time-value';
+    timeValueEl.textContent = eventData.time || '--:--';
+    timeTextWrapper.appendChild(timeLabelEl);
+    timeTextWrapper.appendChild(timeValueEl);
+    timeBlock.appendChild(timeTextWrapper);
+    topRow.appendChild(timeBlock);
 
-    const animalCol = document.createElement('div');
-    animalCol.className = 'col-md-3';
-    const animalWrapper = document.createElement('div');
-    animalWrapper.className = 'animal-name d-flex align-items-center gap-2';
-    const animalIconWrapper = document.createElement('span');
-    animalIconWrapper.className = 'icon-circle bg-danger text-white';
-    const animalIcon = document.createElement('i');
-    animalIcon.className = 'fa-solid fa-paw';
-    animalIcon.setAttribute('aria-hidden', 'true');
-    animalIconWrapper.appendChild(animalIcon);
-    animalWrapper.appendChild(animalIconWrapper);
-    const animalName = ext.animalName || getPetName(eventData.animalId) || derivePetNameFromTitle(eventData.title) || 'Paciente';
-    const animalText = document.createElement('span');
-    animalText.textContent = animalName;
-    animalWrapper.appendChild(animalText);
-    animalCol.appendChild(animalWrapper);
-    row.appendChild(animalCol);
+    const typeBadge = document.createElement('span');
+    typeBadge.className = 'tutor-calendar__appointment-pill';
+    typeBadge.textContent = kindLabel ? kindLabel : typeLabel;
+    topRow.appendChild(typeBadge);
 
-    const vetCol = document.createElement('div');
-    vetCol.className = 'col-md-2';
-    const vetWrapper = document.createElement('div');
-    vetWrapper.className = 'vet-name d-flex align-items-center gap-2';
-    const vetIconWrapper = document.createElement('span');
-    vetIconWrapper.className = 'icon-circle bg-info text-white';
-    const vetIcon = document.createElement('i');
-    vetIcon.className = 'fa-solid fa-user-doctor';
-    vetIcon.setAttribute('aria-hidden', 'true');
-    vetIconWrapper.appendChild(vetIcon);
-    vetWrapper.appendChild(vetIconWrapper);
-    const vetName = ext.vetName || ext.veterinarioName || deriveVetNameFromTitle(eventData.title) || '—';
-    const vetText = document.createElement('span');
-    vetText.textContent = vetName;
-    vetWrapper.appendChild(vetText);
-    vetCol.appendChild(vetWrapper);
-    row.appendChild(vetCol);
-
-    const statusCol = document.createElement('div');
-    statusCol.className = 'col-md-2';
     const statusBadge = document.createElement('span');
-    const statusClass = statusKey || 'scheduled';
-    statusBadge.className = `status-badge status-${statusClass}`;
-    statusBadge.textContent = statusLabels[statusKey] || statusClass;
-    statusCol.appendChild(statusBadge);
-    row.appendChild(statusCol);
+    statusBadge.className = `status-badge status-${statusClass} tutor-calendar__appointment-status`;
+    statusBadge.textContent = statusLabel;
+    topRow.appendChild(statusBadge);
 
-    const actionsCol = document.createElement('div');
-    actionsCol.className = 'col-md-3';
-    const actionsContainer = document.createElement('div');
-    actionsContainer.className = 'actions-container';
-    actionsCol.appendChild(actionsContainer);
-    row.appendChild(actionsCol);
+    card.appendChild(topRow);
+
+    const peopleGrid = document.createElement('div');
+    peopleGrid.className = 'tutor-calendar__appointment-people';
+
+    function appendPerson(label, value, iconClass, modifier) {
+      const person = document.createElement('div');
+      person.className = 'tutor-calendar__appointment-person';
+
+      const iconWrapper = document.createElement('span');
+      iconWrapper.className = 'tutor-calendar__appointment-icon' + (modifier ? ` ${modifier}` : '');
+      const icon = document.createElement('i');
+      icon.className = iconClass;
+      icon.setAttribute('aria-hidden', 'true');
+      iconWrapper.appendChild(icon);
+      person.appendChild(iconWrapper);
+
+      const textWrapper = document.createElement('div');
+      textWrapper.className = 'tutor-calendar__appointment-person-text';
+
+      const labelEl = document.createElement('span');
+      labelEl.className = 'tutor-calendar__appointment-person-label';
+      labelEl.textContent = label;
+
+      const valueEl = document.createElement('span');
+      valueEl.className = 'tutor-calendar__appointment-person-value';
+      valueEl.textContent = value || '—';
+
+      textWrapper.appendChild(labelEl);
+      textWrapper.appendChild(valueEl);
+      person.appendChild(textWrapper);
+
+      peopleGrid.appendChild(person);
+    }
+
+    appendPerson('Paciente', animalName, 'fa-solid fa-paw', 'is-pet');
+    if (tutorName) {
+      appendPerson('Tutor', tutorName, 'fa-solid fa-user', 'is-tutor');
+    }
+    appendPerson('Veterinário', vetName, 'fa-solid fa-user-doctor', 'is-vet');
+
+    if (peopleGrid.childNodes.length) {
+      card.appendChild(peopleGrid);
+    }
+
+    const infoList = document.createElement('dl');
+    infoList.className = 'tutor-calendar__day-detail-info tutor-calendar__appointment-meta';
+
+    appendDetailRow(infoList, 'Horário', eventData.time || '--:--');
+    appendDetailRow(infoList, 'Paciente', animalName);
+    if (tutorName) {
+      appendDetailRow(infoList, 'Tutor', tutorName);
+    }
+    appendDetailRow(infoList, 'Veterinário', vetName);
+    appendDetailRow(infoList, 'Tipo', kindLabel ? kindLabel : typeLabel);
+    appendDetailRow(infoList, 'Status', statusLabel);
+    appendDetailRow(infoList, 'Data', eventData.date || dateKey || '—');
+    appendDetailRow(infoList, 'ID', recordId);
+    if (ext.clinicId !== undefined && ext.clinicId !== null) {
+      appendDetailRow(infoList, 'Clínica', ext.clinicId);
+    }
+
+    card.appendChild(infoList);
+
+    if (ext.notes) {
+      const notes = document.createElement('div');
+      notes.className = 'tutor-calendar__appointment-notes';
+
+      const notesIconWrapper = document.createElement('span');
+      notesIconWrapper.className = 'tutor-calendar__appointment-icon is-note';
+      const notesIcon = document.createElement('i');
+      notesIcon.className = 'fa-solid fa-note-sticky';
+      notesIcon.setAttribute('aria-hidden', 'true');
+      notesIconWrapper.appendChild(notesIcon);
+      notes.appendChild(notesIconWrapper);
+
+      const notesBody = document.createElement('div');
+      notesBody.className = 'tutor-calendar__appointment-notes-body';
+      const notesTitle = document.createElement('div');
+      notesTitle.className = 'tutor-calendar__appointment-notes-title';
+      notesTitle.textContent = 'Observações';
+      const notesText = document.createElement('p');
+      notesText.className = 'tutor-calendar__appointment-notes-text';
+      notesText.textContent = ext.notes;
+      notesBody.appendChild(notesTitle);
+      notesBody.appendChild(notesText);
+      notes.appendChild(notesBody);
+
+      card.appendChild(notes);
+    }
+
+    const actionsWrapper = document.createElement('div');
+    actionsWrapper.className = 'tutor-calendar__appointment-actions';
+    const actionsTitle = document.createElement('div');
+    actionsTitle.className = 'tutor-calendar__appointment-actions-title';
+    actionsTitle.textContent = 'Ações rápidas';
+    const actionsGrid = document.createElement('div');
+    actionsGrid.className = 'tutor-calendar__appointment-actions-grid';
+
+    function appendActionElement(element) {
+      if (!element) {
+        return;
+      }
+      element.classList.add('tutor-calendar__appointment-action');
+      actionsGrid.appendChild(element);
+    }
 
     if (ext.animalId) {
       const animalUrl = fillUrlWithId(urlTemplates.animalProfile, ext.animalId);
@@ -1541,7 +1839,7 @@ document.addEventListener('DOMContentLoaded', function() {
         icon.setAttribute('aria-hidden', 'true');
         btn.appendChild(icon);
         btn.appendChild(document.createTextNode('Ficha do Animal'));
-        actionsContainer.appendChild(btn);
+        appendActionElement(btn);
       }
     }
 
@@ -1557,7 +1855,7 @@ document.addEventListener('DOMContentLoaded', function() {
         icon.setAttribute('aria-hidden', 'true');
         btn.appendChild(icon);
         btn.appendChild(document.createTextNode('Ficha do Tutor'));
-        actionsContainer.appendChild(btn);
+        appendActionElement(btn);
       }
     }
 
@@ -1573,7 +1871,7 @@ document.addEventListener('DOMContentLoaded', function() {
         icon.setAttribute('aria-hidden', 'true');
         btn.appendChild(icon);
         btn.appendChild(document.createTextNode('Iniciar Consulta'));
-        actionsContainer.appendChild(btn);
+        appendActionElement(btn);
       }
     }
 
@@ -1587,7 +1885,7 @@ document.addEventListener('DOMContentLoaded', function() {
       icon.setAttribute('aria-hidden', 'true');
       btn.appendChild(icon);
       btn.appendChild(document.createTextNode('Propor novo horário'));
-      actionsContainer.appendChild(btn);
+      appendActionElement(btn);
     }
 
     if (permissions.canManageStatus) {
@@ -1625,7 +1923,7 @@ document.addEventListener('DOMContentLoaded', function() {
           form.appendChild(button);
 
           attachConfirmHandler(form);
-          actionsContainer.appendChild(form);
+          appendActionElement(form);
         });
       }
     }
@@ -1659,42 +1957,17 @@ document.addEventListener('DOMContentLoaded', function() {
         form.appendChild(button);
 
         attachConfirmHandler(form);
-        actionsContainer.appendChild(form);
+        appendActionElement(form);
       }
     }
 
-    dayAppointments.appendChild(card);
-
-    const infoList = document.createElement('dl');
-    infoList.className = 'tutor-calendar__day-detail-info mt-3';
-
-    const typeLabel = typeLabels[eventData.type] || 'Evento';
-    const kindLabel = ext.kind ? String(ext.kind) : '';
-    const tutorName = ext.tutorName || null;
-
-    appendDetailRow(infoList, 'Horário', eventData.time || '--:--');
-    appendDetailRow(infoList, 'Paciente', animalName);
-    if (tutorName) {
-      appendDetailRow(infoList, 'Tutor', tutorName);
-    }
-    appendDetailRow(infoList, 'Veterinário', vetName);
-    appendDetailRow(infoList, 'Tipo', kindLabel ? kindLabel : typeLabel);
-    appendDetailRow(infoList, 'Status', statusLabels[statusKey] || statusKey || '—');
-    appendDetailRow(infoList, 'Data', eventData.date || dateKey || '—');
-    appendDetailRow(infoList, 'ID', recordId);
-    if (ext.clinicId !== undefined && ext.clinicId !== null) {
-      appendDetailRow(infoList, 'Clínica', ext.clinicId);
-    }
-    if (ext.notes) {
-      appendDetailRow(infoList, 'Observações', ext.notes);
+    if (actionsGrid.childNodes.length) {
+      actionsWrapper.appendChild(actionsTitle);
+      actionsWrapper.appendChild(actionsGrid);
+      card.appendChild(actionsWrapper);
     }
 
-    if (infoList.childNodes.length) {
-      fragment.appendChild(block);
-      fragment.appendChild(infoList);
-    } else {
-      fragment.appendChild(block);
-    }
+    fragment.appendChild(card);
 
     return fragment;
   }


### PR DESCRIPTION
## Summary
- expand the tutor calendar day detail overlay to use more of the calendar space and add breathing room for the content
- style appointment detail cards with dedicated sections for schedule, participants, notes, and grouped actions
- update the JavaScript builder to emit the new markup so the reorganized layout and action grid render correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2941a752c832e8520b3553d5e5ae6