### PR TITLE
Improve tutor calendar day detail UX

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -514,7 +514,7 @@
   padding: 0.9rem 1.1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.85rem;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-card + .tutor-calendar__day-detail-card {
@@ -677,6 +677,7 @@
 #{{ component_id }} .tutor-calendar__appointment-meta {
   padding-top: 0.75rem;
   border-top: 1px dashed rgba(148, 163, 184, 0.4);
+  gap: 0.5rem;
 }
 
 #{{ component_id }} .tutor-calendar__appointment-meta dt {
@@ -777,9 +778,10 @@
 
 #{{ component_id }} .tutor-calendar__day-detail-meta {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  justify-content: flex-start;
+  gap: 0.5rem;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-time {
@@ -798,6 +800,31 @@
   letter-spacing: 0.05em;
   background: rgba(59, 130, 246, 0.16);
   color: #1d4ed8;
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-status {
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  background: rgba(59, 130, 246, 0.16);
+  color: #1d4ed8;
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-status.status-completed {
+  background: rgba(22, 163, 74, 0.15);
+  color: #15803d;
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-status.status-canceled {
+  background: rgba(239, 68, 68, 0.16);
+  color: #b91c1c;
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-status.status-accepted {
+  background: rgba(14, 165, 233, 0.16);
+  color: #0369a1;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-card--exam .tutor-calendar__day-detail-type {
@@ -824,25 +851,52 @@
 
 #{{ component_id }} .tutor-calendar__day-detail-info {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 0.4rem 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
   margin: 0;
+  padding: 0;
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-info-item {
+  background: rgba(241, 245, 249, 0.7);
+  border-radius: 0.9rem;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-info dt {
-  font-size: 0.7rem;
-  font-weight: 600;
+  margin: 0;
+  font-size: 0.68rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   color: var(--bs-gray-600);
-  margin-bottom: 0;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-info dd {
   margin: 0;
-  font-size: 0.8rem;
-  color: var(--bs-gray-800);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--bs-gray-900);
   word-break: break-word;
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-info-item--compact {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  gap: 0.2rem;
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-info-item--compact dt {
+  color: var(--bs-gray-500);
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-info-item--compact dd {
+  font-weight: 500;
+  color: var(--bs-gray-800);
 }
 
 #{{ component_id }} .tutor-calendar__day.is-selected,
@@ -1178,6 +1232,61 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
+  function formatDisplayDate(value) {
+    let date = null;
+    if (value instanceof Date) {
+      date = value;
+    } else if (typeof value === 'string') {
+      date = parseDate(value) || parseDateKey(value);
+    }
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+      return '';
+    }
+    return date.toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+  }
+
+  function formatDuration(startDate, endDate) {
+    if (!(startDate instanceof Date) || !(endDate instanceof Date)) {
+      return '';
+    }
+    const diffMs = endDate.getTime() - startDate.getTime();
+    if (!Number.isFinite(diffMs) || diffMs <= 0) {
+      return '';
+    }
+    const totalMinutes = Math.round(diffMs / 60000);
+    if (totalMinutes <= 0) {
+      return '';
+    }
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    const parts = [];
+    if (hours > 0) {
+      parts.push(`${hours}h`);
+    }
+    if (minutes > 0) {
+      parts.push(`${minutes}min`);
+    }
+    if (!parts.length) {
+      parts.push(`${totalMinutes}min`);
+    }
+    return parts.join(' ');
+  }
+
+  function humanizeLabel(value) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    const text = String(value).replace(/[_\-]+/g, ' ').trim();
+    if (!text) {
+      return '';
+    }
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  }
+
   function getStartOfWeek(date) {
     const base = date instanceof Date ? new Date(date.getTime()) : parseDate(date);
     const target = base || new Date();
@@ -1500,116 +1609,70 @@ document.addEventListener('DOMContentLoaded', function() {
     return el;
   }
 
-  function formatRawDetailValue(value) {
-    if (value === null || typeof value === 'undefined') {
-      return '';
-    }
-    if (value instanceof Date) {
-      return value.toLocaleString('pt-BR');
-    }
-    if (Array.isArray(value)) {
-      return value.map(function(item) {
-        if (item === null || typeof item === 'undefined') {
-          return '';
-        }
-        if (item instanceof Date) {
-          return item.toLocaleString('pt-BR');
-        }
-        if (typeof item === 'object') {
-          try {
-            return JSON.stringify(item);
-          } catch (error) {
-            return String(item);
-          }
-        }
-        return String(item);
-      }).filter(Boolean).join(', ');
-    }
-    if (typeof value === 'object') {
-      try {
-        return JSON.stringify(value);
-      } catch (error) {
-        return String(value);
-      }
-    }
-    return String(value);
-  }
-
   function appendDetailRow(list, label, value) {
     if (!list || !label) {
       return;
     }
+    const normalized = value === null || value === undefined || value === '' ? '—' : String(value);
+    const item = document.createElement('div');
+    item.className = 'tutor-calendar__day-detail-info-item';
+    if (list.classList && list.classList.contains('tutor-calendar__appointment-meta')) {
+      item.classList.add('tutor-calendar__day-detail-info-item--compact');
+    }
     const dt = document.createElement('dt');
     dt.textContent = String(label);
     const dd = document.createElement('dd');
-    const normalized = value === null || value === undefined || value === '' ? '—' : String(value);
     dd.textContent = normalized;
-    list.appendChild(dt);
-    list.appendChild(dd);
-  }
-
-  function appendRawFields(list, source, prefix, depth, visited, renderedLabels) {
-    if (!list || !source || typeof source !== 'object') {
-      return;
-    }
-    const rawSkipRootKeys = ['title', 'id'];
-    const safeVisited = visited || new WeakSet();
-    if (safeVisited.has(source)) {
-      return;
-    }
-    safeVisited.add(source);
-    Object.keys(source).forEach(function(key) {
-      if (!prefix && rawSkipRootKeys.indexOf(key) !== -1) {
-        return;
-      }
-      const value = source[key];
-      if (value === null || typeof value === 'undefined' || typeof value === 'function') {
-        return;
-      }
-      const path = prefix ? `${prefix}.${key}` : key;
-      if (renderedLabels && renderedLabels.has(path)) {
-        return;
-      }
-      if (typeof value === 'object' && !(value instanceof Date)) {
-        if (Array.isArray(value)) {
-          if (!value.length) {
-            return;
-          }
-          appendDetailRow(list, path, formatRawDetailValue(value));
-          renderedLabels && renderedLabels.add(path);
-          return;
-        }
-        if (depth < 2) {
-          appendRawFields(list, value, path, depth + 1, safeVisited, renderedLabels);
-          return;
-        }
-        appendDetailRow(list, path, formatRawDetailValue(value));
-        renderedLabels && renderedLabels.add(path);
-        return;
-      }
-      appendDetailRow(list, path, formatRawDetailValue(value));
-      renderedLabels && renderedLabels.add(path);
-    });
+    item.appendChild(dt);
+    item.appendChild(dd);
+    list.appendChild(item);
   }
 
   function buildDayDetailCard(eventData) {
     const card = document.createElement('article');
-    card.className = 'tutor-calendar__day-detail-card tutor-calendar__day-detail-card--' + (eventData.type || 'appointment');
+    const typeKey = eventData.type || 'appointment';
+    const raw = eventData && eventData.raw ? eventData.raw : {};
+    const ext = raw.extendedProps || {};
+    const typeLabel = typeLabels[typeKey] || 'Evento';
+    const kindLabel = humanizeLabel(ext.kind) || typeLabel;
+    const tutorName = ext.tutorName || null;
+    const vetName = ext.vetName || ext.veterinarioName || null;
+    const statusKey = String(ext.status || '').toLowerCase();
+    const statusLabel = statusLabels[statusKey] || humanizeLabel(statusKey);
+    const statusClass = statusKey ? `status-${statusKey}` : 'status-scheduled';
+    const recordId = ext.recordId !== undefined && ext.recordId !== null ? ext.recordId : null;
+    const startDate = eventData.start instanceof Date ? eventData.start : parseDate(raw.start || raw.startStr || ext.start);
+    const endDate = parseDate(raw.end || raw.endStr || ext.end);
+    const startTime = eventData.time || (startDate ? formatTime(startDate) : '--:--');
+    const endTime = endDate ? formatTime(endDate) : '';
+    const timeRange = endTime ? `${startTime} - ${endTime}` : (startTime || '--:--');
+    const displayDate = formatDisplayDate(startDate || eventData.date || raw.date);
+    const durationText = formatDuration(startDate, endDate);
+    const appointmentCode = recordId !== null ? `#${recordId}` : null;
+
+    card.className = 'tutor-calendar__day-detail-card tutor-calendar__day-detail-card--' + typeKey;
 
     const meta = document.createElement('div');
     meta.className = 'tutor-calendar__day-detail-meta';
 
     const timeEl = document.createElement('div');
     timeEl.className = 'tutor-calendar__day-detail-time';
-    timeEl.textContent = eventData.time || '--:--';
+    timeEl.textContent = timeRange || '--:--';
 
-    const typeLabel = typeLabels[eventData.type] || 'Evento';
     const typeEl = document.createElement('div');
     typeEl.className = 'tutor-calendar__day-detail-type';
     typeEl.textContent = typeLabel;
 
     meta.appendChild(timeEl);
     meta.appendChild(typeEl);
+
+    if (statusLabel) {
+      const statusEl = document.createElement('span');
+      statusEl.className = `tutor-calendar__day-detail-status ${statusClass}`;
+      statusEl.textContent = statusLabel;
+      meta.appendChild(statusEl);
+    }
+
     card.appendChild(meta);
 
     const titleEl = document.createElement('h4');
@@ -1626,18 +1689,20 @@ document.addEventListener('DOMContentLoaded', function() {
     const infoList = document.createElement('dl');
     infoList.className = 'tutor-calendar__day-detail-info';
 
-    appendDetailRow(infoList, 'Horário', eventData.time || '--:--');
-    appendDetailRow(infoList, 'Paciente', petName || '—');
-    appendDetailRow(infoList, 'Tipo', typeLabel);
-    if (eventData.date) {
-      appendDetailRow(infoList, 'Data', eventData.date);
+    if (displayDate) {
+      appendDetailRow(infoList, 'Data', displayDate);
     }
-    if (eventData.id) {
-      appendDetailRow(infoList, 'ID', eventData.id);
+    appendDetailRow(infoList, 'Tipo de atendimento', kindLabel);
+    if (statusLabel) {
+      appendDetailRow(infoList, 'Situação', statusLabel);
     }
-
-    if (eventData.raw && typeof eventData.raw === 'object') {
-      appendRawFields(infoList, eventData.raw, '', 0, new WeakSet(), new Set());
+    appendDetailRow(infoList, 'Tutor responsável', tutorName);
+    appendDetailRow(infoList, 'Veterinário responsável', vetName);
+    if (durationText) {
+      appendDetailRow(infoList, 'Duração prevista', durationText);
+    }
+    if (appointmentCode) {
+      appendDetailRow(infoList, 'Código do agendamento', appointmentCode);
     }
 
     card.appendChild(infoList);


### PR DESCRIPTION
## Summary
- refine the tutor calendar day detail card with status badges and curated labels instead of raw event data
- add javascript helpers to format dates, durations and human friendly labels when rendering the detail card
- refresh the day detail layout styles to highlight relevant information and provide compact variants for appointment metadata

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d29bcd4560832e8bbaf6ba090717ed