### PR TITLE
Allow admins to manage appointments while impersonating staff

### DIFF
--- a/app.py
+++ b/app.py
@@ -8373,17 +8373,23 @@ def edit_appointment(appointment_id):
 def update_appointment_status(appointment_id):
     """Update the status of an appointment."""
     appointment = Appointment.query.get_or_404(appointment_id)
-    if current_user.worker in ['veterinario', 'colaborador']:
+
+    if current_user.role == 'admin':
+        pass
+    elif current_user.worker in ['veterinario', 'colaborador']:
         if current_user.worker == 'veterinario':
-            user_clinic = current_user.veterinario.clinica_id
+            veterinario = getattr(current_user, 'veterinario', None)
+            user_clinic = getattr(veterinario, 'clinica_id', None)
         else:
-            user_clinic = current_user.clinica_id
+            user_clinic = getattr(current_user, 'clinica_id', None)
+
         appointment_clinic = appointment.clinica_id
         if appointment_clinic is None and appointment.veterinario:
             appointment_clinic = appointment.veterinario.clinica_id
+
         if appointment_clinic != user_clinic:
             abort(403)
-    elif current_user.role != 'admin' and appointment.tutor_id != current_user.id:
+    elif appointment.tutor_id != current_user.id:
         abort(403)
 
     accepts = request.accept_mimetypes
@@ -8435,14 +8441,23 @@ def update_appointment_status(appointment_id):
 @login_required
 def delete_appointment(appointment_id):
     appointment = Appointment.query.get_or_404(appointment_id)
-    if current_user.worker in ['veterinario', 'colaborador']:
+
+    if current_user.role == 'admin':
+        pass
+    elif current_user.worker in ['veterinario', 'colaborador']:
         if current_user.worker == 'veterinario':
-            user_clinic = current_user.veterinario.clinica_id
+            veterinario = getattr(current_user, 'veterinario', None)
+            user_clinic = getattr(veterinario, 'clinica_id', None)
         else:
-            user_clinic = current_user.clinica_id
-        if appointment.clinica_id != user_clinic:
+            user_clinic = getattr(current_user, 'clinica_id', None)
+
+        appointment_clinic = appointment.clinica_id
+        if appointment_clinic is None and appointment.veterinario:
+            appointment_clinic = appointment.veterinario.clinica_id
+
+        if appointment_clinic != user_clinic:
             abort(403)
-    elif current_user.role != 'admin':
+    else:
         abort(403)
     db.session.delete(appointment)
     db.session.commit()


### PR DESCRIPTION
## Summary
- allow administrators to bypass clinic-based checks when updating or deleting appointments while leaving protections in place for collaborators and veterinarians
- reuse veterinarian clinic fallback for clinic validation when deleting appointments that do not have `clinica_id`
- add regression tests covering admin impersonation scenarios and tutor access restrictions

## Testing
- pytest tests/test_appointment_status.py tests/test_event_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_68d2aeedb514832e8f85df7f727b6001