### PR TITLE
Adjust quick filters placement in tutor calendar

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -65,6 +65,16 @@
               </button>
             </div>
           </div>
+          <h3 class="h6 mb-3 mt-4">Filtros rápidos</h3>
+          <div class="tutor-calendar__filters d-flex flex-wrap gap-2">
+            <button type="button" class="btn btn-outline-primary btn-sm active" data-filter="all">Todos</button>
+            <button type="button" class="btn btn-outline-primary btn-sm" data-filter="appointment">Consultas</button>
+            <button type="button" class="btn btn-outline-primary btn-sm" data-filter="exam">Exames</button>
+            <button type="button" class="btn btn-outline-primary btn-sm" data-filter="vaccine">Vacinas</button>
+          </div>
+          <p class="text-muted small mb-4 mt-3">
+            Eventos sincronizados automaticamente com o FullCalendar. Escolha um dia para iniciar um novo agendamento.
+          </p>
           <div class="tutor-calendar__layout">
             <div class="tutor-calendar__schedule">
               <div class="tutor-calendar__weekdays" data-weekdays></div>
@@ -164,23 +174,6 @@
               <i class="bi bi-arrow-clockwise me-1"></i> Atualizar lista
             </button>
           </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-12">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-body">
-          <h3 class="h6 mb-3">Filtros rápidos</h3>
-          <div class="tutor-calendar__filters d-flex flex-wrap gap-2">
-            <button type="button" class="btn btn-outline-primary btn-sm active" data-filter="all">Todos</button>
-            <button type="button" class="btn btn-outline-primary btn-sm" data-filter="appointment">Consultas</button>
-            <button type="button" class="btn btn-outline-primary btn-sm" data-filter="exam">Exames</button>
-            <button type="button" class="btn btn-outline-primary btn-sm" data-filter="vaccine">Vacinas</button>
-          </div>
-          <p class="text-muted small mb-0 mt-3">
-            Eventos sincronizados automaticamente com o FullCalendar. Escolha um dia para iniciar um novo agendamento.
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move the quick filter controls into the main calendar card so they render immediately before the schedule grid
- remove the separate quick filters card, keeping the pet list card as the only additional section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2b3c0f454832e9051bf1305037a1d