### PR TITLE
Remove tutor calendar hero banner

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -18,21 +18,6 @@
   data-can-start-consulta="{{ 'true' if current_user.worker in ['veterinario', 'colaborador'] else 'false' }}"
   data-can-manage-status="{{ 'true' if (current_user.worker in ['veterinario', 'colaborador']) or current_user.role == 'admin' else 'false' }}"
 >
-  <div class="tutor-calendar__hero bg-gradient text-white rounded-4 p-4 mb-4">
-    <div class="d-flex align-items-start gap-3">
-      <div class="tutor-calendar__hero-icon">
-        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M12 2C13.657 2 15 3.343 15 5C15 6.657 13.657 8 12 8C10.343 8 9 6.657 9 5C9 3.343 10.343 2 12 2Z" fill="currentColor"/>
-          <path d="M3 21C3 16.589 6.589 13 11 13H13C17.411 13 21 16.589 21 21H3Z" fill="currentColor"/>
-        </svg>
-      </div>
-      <div>
-        <h2 class="h4 fw-semibold mb-1">Calendário Veterinário — Agendamentos &amp; Vacinas</h2>
-        <p class="mb-0 small opacity-75">Visualize consultas, exames e vacinas usando os mesmos dados da agenda oficial.</p>
-      </div>
-    </div>
-  </div>
-
   <div class="row g-4 align-items-start">
     <div class="col-12">
       <div class="card shadow-sm border-0 h-100">


### PR DESCRIPTION
## Summary
- remove the hero banner div from the tutor calendar partial so it no longer renders between the tab button and card content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2b73f38c8832ea03cf035afe35c8e