### PR TITLE
Reorder calendar tabs and persist selection

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -34,29 +34,29 @@
         <li class="nav-item" role="presentation">
           <button
             class="nav-link active"
-            id="calendar-tab-full"
-            data-bs-toggle="tab"
-            data-bs-target="#calendar-pane-full"
-            type="button"
-            role="tab"
-            aria-controls="calendar-pane-full"
-            aria-selected="true"
-          >
-            <i class="bi bi-calendar3 me-1"></i> Agendamento
-          </button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button
-            class="nav-link"
             id="calendar-tab-experimental"
             data-bs-toggle="tab"
             data-bs-target="#calendar-pane-experimental"
             type="button"
             role="tab"
             aria-controls="calendar-pane-experimental"
-            aria-selected="false"
+            aria-selected="true"
           >
             <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link"
+            id="calendar-tab-full"
+            data-bs-toggle="tab"
+            data-bs-target="#calendar-pane-full"
+            type="button"
+            role="tab"
+            aria-controls="calendar-pane-full"
+            aria-selected="false"
+          >
+            <i class="bi bi-calendar3 me-1"></i> Agendamento
           </button>
         </li>
       </ul>
@@ -64,17 +64,6 @@
       <div class="tab-content mt-3" id="appointments-calendar-content">
         <div
           class="tab-pane fade show active pt-2"
-          id="calendar-pane-full"
-          role="tabpanel"
-          aria-labelledby="calendar-tab-full"
-          tabindex="0"
-        >
-          {% with clinic_id = current_user.clinica_id, calendar_redirect_url = calendar_redirect_url %}
-            {% include 'partials/schedule_toggle.html' %}
-          {% endwith %}
-        </div>
-        <div
-          class="tab-pane fade pt-2"
           id="calendar-pane-experimental"
           role="tabpanel"
           aria-labelledby="calendar-tab-experimental"
@@ -92,6 +81,17 @@
           {% endif %}
           {% with component_id = 'tutor-calendar-inline', pets_url = calendar_pets_endpoint %}
             {% include 'partials/tutor_calendar.html' %}
+          {% endwith %}
+        </div>
+        <div
+          class="tab-pane fade pt-2"
+          id="calendar-pane-full"
+          role="tabpanel"
+          aria-labelledby="calendar-tab-full"
+          tabindex="0"
+        >
+          {% with clinic_id = current_user.clinica_id, calendar_redirect_url = calendar_redirect_url %}
+            {% include 'partials/schedule_toggle.html' %}
           {% endwith %}
         </div>
       </div>
@@ -403,6 +403,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const calendarSummaryColumn = document.querySelector('[data-calendar-summary-column]');
   const calendarMainColumn = document.querySelector('[data-calendar-main-column]');
   const calendarTabButtons = document.querySelectorAll('#appointments-calendar-tabs [data-bs-toggle="tab"]');
+  const calendarActiveTabStorageKey = 'appointmentsCalendarActiveTab';
   const calendarMainColumnVisibleClasses = ['col-xl-8', 'col-xxl-9'];
   const calendarMainColumnFullWidthClasses = ['col-xl-12', 'col-xxl-12'];
   let activeCalendarSummaryVetId = null;
@@ -434,15 +435,103 @@ document.addEventListener('DOMContentLoaded', () => {
     setCalendarSummaryVisibility(shouldShow);
   }
 
+  function normalizeCalendarTabTarget(value) {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    return value.trim();
+  }
+
+  function getStoredCalendarActiveTab() {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return '';
+    }
+    try {
+      const storedValue = window.localStorage.getItem(calendarActiveTabStorageKey);
+      return normalizeCalendarTabTarget(storedValue || '');
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function storeCalendarActiveTab(target) {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+    const normalized = normalizeCalendarTabTarget(target);
+    try {
+      if (normalized) {
+        window.localStorage.setItem(calendarActiveTabStorageKey, normalized);
+      } else {
+        window.localStorage.removeItem(calendarActiveTabStorageKey);
+      }
+    } catch (error) {
+      // Ignorado intencionalmente.
+    }
+  }
+
+  function showCalendarTab(button) {
+    if (!button) {
+      return false;
+    }
+    let bootstrapNamespace = null;
+    if (typeof window !== 'undefined'
+      && window.bootstrap
+      && window.bootstrap.Tab
+      && typeof window.bootstrap.Tab.getOrCreateInstance === 'function') {
+      bootstrapNamespace = window.bootstrap;
+    } else if (typeof bootstrap !== 'undefined'
+      && bootstrap
+      && bootstrap.Tab
+      && typeof bootstrap.Tab.getOrCreateInstance === 'function') {
+      bootstrapNamespace = bootstrap;
+    }
+    if (bootstrapNamespace) {
+      const tabInstance = bootstrapNamespace.Tab.getOrCreateInstance(button);
+      if (tabInstance && typeof tabInstance.show === 'function') {
+        tabInstance.show();
+        return true;
+      }
+    }
+    if (typeof button.click === 'function') {
+      button.click();
+      return true;
+    }
+    return false;
+  }
+
   if (calendarTabButtons.length > 0) {
-    calendarTabButtons.forEach((button) => {
+    const calendarTabButtonsArray = Array.prototype.slice.call(calendarTabButtons);
+    const storedCalendarTabTarget = getStoredCalendarActiveTab();
+
+    calendarTabButtonsArray.forEach((button) => {
       button.addEventListener('shown.bs.tab', (event) => {
-        const target = event.target
+        const target = event && event.target
           ? event.target.getAttribute('data-bs-target')
           : '';
-        updateCalendarSummaryVisibilityFromTarget(target);
+        const normalizedTarget = normalizeCalendarTabTarget(target);
+        updateCalendarSummaryVisibilityFromTarget(normalizedTarget);
+        storeCalendarActiveTab(normalizedTarget);
       });
     });
+
+    if (storedCalendarTabTarget) {
+      const storedButton = calendarTabButtonsArray.find((button) => {
+        return normalizeCalendarTabTarget(button.getAttribute('data-bs-target')) === storedCalendarTabTarget;
+      });
+      if (storedButton) {
+        if (!storedButton.classList.contains('active')) {
+          const wasShown = showCalendarTab(storedButton);
+          if (!wasShown) {
+            updateCalendarSummaryVisibilityFromTarget(storedCalendarTabTarget);
+          }
+        } else {
+          updateCalendarSummaryVisibilityFromTarget(storedCalendarTabTarget);
+        }
+      } else {
+        storeCalendarActiveTab('');
+      }
+    }
   }
 
   const activeCalendarTab = document.querySelector('#appointments-calendar-tabs .nav-link.active[data-bs-target]');


### PR DESCRIPTION
## Summary
- move the calendar tab to the left and make it the default visible panel
- remember the last opened tab in localStorage and restore it on reload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2b922e388832eae4a656756c0eafd