### PR TITLE
Enable toggling calendar and scheduling tabs

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -500,11 +500,58 @@ document.addEventListener('DOMContentLoaded', () => {
     return false;
   }
 
+  function getCalendarTabTarget(button) {
+    if (!button) {
+      return '';
+    }
+    const attributeTarget = button.getAttribute('data-bs-target');
+    if (attributeTarget && attributeTarget.trim()) {
+      return normalizeCalendarTabTarget(attributeTarget);
+    }
+    if (button.dataset && button.dataset.bsTarget) {
+      return normalizeCalendarTabTarget(button.dataset.bsTarget);
+    }
+    return '';
+  }
+
+  function hideCalendarTab(button) {
+    if (!button) {
+      return;
+    }
+
+    const targetSelector = getCalendarTabTarget(button);
+    const targetPane = targetSelector ? document.querySelector(targetSelector) : null;
+
+    button.classList.remove('active');
+    button.setAttribute('aria-selected', 'false');
+    button.setAttribute('tabindex', '0');
+
+    const parentNavItem = button.closest('.nav-item');
+    if (parentNavItem) {
+      parentNavItem.classList.remove('active');
+    }
+
+    if (targetPane) {
+      targetPane.classList.remove('show', 'active');
+    }
+
+    storeCalendarActiveTab('');
+    updateCalendarSummaryVisibilityFromTarget('');
+  }
+
   if (calendarTabButtons.length > 0) {
     const calendarTabButtonsArray = Array.prototype.slice.call(calendarTabButtons);
     const storedCalendarTabTarget = getStoredCalendarActiveTab();
 
     calendarTabButtonsArray.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        if (button.classList.contains('active')) {
+          event.preventDefault();
+          event.stopPropagation();
+          hideCalendarTab(button);
+        }
+      });
+
       button.addEventListener('shown.bs.tab', (event) => {
         const target = event && event.target
           ? event.target.getAttribute('data-bs-target')


### PR DESCRIPTION
## Summary
- add helper functions to identify and hide the active calendar tab buttons
- allow clicking the active tab to close it while clearing stored state and hiding the pane

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2be41bc5c832e9baf27cdc1677fe7