### PR TITLE
Remove CEP mask attribute to allow typing

### DIFF
--- a/templates/partials/endereco_form.html
+++ b/templates/partials/endereco_form.html
@@ -13,11 +13,11 @@
       </label>
       <div class="input-group">
         {% if addr_form %}
-          {{ addr_form.cep(class="form-control", id="cep", placeholder="00000-000", data_mask="00000-000", onblur="buscarCep()") }}
+          {{ addr_form.cep(class="form-control", id="cep", placeholder="00000-000", onblur="buscarCep()") }}
         {% else %}
           <input type="text" class="form-control" name="cep" id="cep"
                  value="{{ endereco.cep|default('', true) if endereco else '' }}"
-                 placeholder="00000-000" data-mask="00000-000" onblur="buscarCep()">
+                 placeholder="00000-000" onblur="buscarCep()">
         {% endif %}
         <button class="btn btn-outline-secondary" type="button" onclick="buscarCep()">
           <i class="bi bi-search"></i>


### PR DESCRIPTION
## Summary
- remove the `data-mask` attribute from the CEP input so the manual formatter can run without the Inputmask plugin blocking user input

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d418c7b3b0832e9b071ca4642d9dc3