### PR TITLE
Improve veterinarian agenda page

### DIFF
--- a/app.py
+++ b/app.py
@@ -3463,7 +3463,15 @@ def veterinarios():
 def vet_detail(veterinario_id):
     veterinario = Veterinario.query.get_or_404(veterinario_id)
     horarios = VetSchedule.query.filter_by(veterinario_id=veterinario_id).all()
-    return render_template('veterinarios/vet_detail.html', veterinario=veterinario, horarios=horarios)
+    calendar_redirect_url = url_for(
+        'appointments', view_as='veterinario', veterinario_id=veterinario.id
+    )
+    return render_template(
+        'veterinarios/vet_detail.html',
+        veterinario=veterinario,
+        horarios=horarios,
+        calendar_redirect_url=calendar_redirect_url,
+    )
 
 
 

--- a/templates/veterinarios/vet_detail.html
+++ b/templates/veterinarios/vet_detail.html
@@ -1,28 +1,73 @@
 {% extends "layout.html" %}
 
 {% block main %}
-<div class="container mt-4">
-  <h2>{{ veterinario.user.name }}</h2>
-  <p><strong>CRMV:</strong> {{ veterinario.crmv }}</p>
-  {% if veterinario.clinica %}<p><strong>Clínica:</strong> {{ veterinario.clinica.nome }}</p>{% endif %}
-  {% if veterinario.specialties %}<p><strong>Especialidades:</strong> {{ veterinario.specialty_list }}</p>{% endif %}
+<div class="container py-4">
+  <div class="mb-4">
+    <h2 class="fw-bold text-gradient mb-1">{{ veterinario.user.name }}</h2>
+    <div class="text-muted">
+      <span class="d-inline-flex align-items-center me-3">
+        <i class="bi bi-hash me-1"></i> <strong>CRMV:</strong> {{ veterinario.crmv or 'Não informado' }}
+      </span>
+      {% if veterinario.clinica %}
+      <span class="d-inline-flex align-items-center me-3">
+        <i class="bi bi-hospital me-1"></i> <strong>Clínica:</strong> {{ veterinario.clinica.nome }}
+      </span>
+      {% endif %}
+      {% if veterinario.specialties %}
+      <span class="d-inline-flex align-items-center">
+        <i class="bi bi-award me-1"></i> <strong>Especialidades:</strong> {{ veterinario.specialty_list }}
+      </span>
+      {% endif %}
+    </div>
+  </div>
 
-  <h3>Agenda</h3>
-  <table class="table">
-    <thead>
-      <tr><th>Dia</th><th>Início</th><th>Fim</th></tr>
-    </thead>
-    <tbody>
-      {% for h in horarios %}
-        <tr>
-          <td>{{ h.dia_semana }}</td>
-          <td>{{ h.hora_inicio.strftime('%H:%M') }}</td>
-          <td>{{ h.hora_fim.strftime('%H:%M') }}</td>
-        </tr>
-      {% else %}
-        <tr><td colspan="3">Nenhum horário cadastrado.</td></tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  <div class="row g-4 align-items-start">
+    <div class="col-12 col-xl-8">
+      <input type="hidden" value="{{ veterinario.id }}" data-switcher-vet class="d-none">
+      {% with
+        calendar_id='vet-shared-calendar-' ~ veterinario.id,
+        toggle_id='vet-agenda-toggle-' ~ veterinario.id,
+        clinic_id=veterinario.clinica_id,
+        calendar_redirect_url=calendar_redirect_url,
+        admin_selected_view='veterinario',
+        vets=[veterinario]
+      %}
+        {% include 'partials/schedule_toggle.html' %}
+      {% endwith %}
+    </div>
+    <div class="col-12 col-xl-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-primary text-white">
+          <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Horários fixos</h5>
+        </div>
+        <div class="card-body p-0">
+          <div class="table-responsive">
+            <table class="table table-striped mb-0">
+              <thead class="table-light">
+                <tr>
+                  <th scope="col">Dia</th>
+                  <th scope="col">Início</th>
+                  <th scope="col">Fim</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for h in horarios %}
+                <tr>
+                  <td>{{ h.dia_semana }}</td>
+                  <td>{{ h.hora_inicio.strftime('%H:%M') }}</td>
+                  <td>{{ h.hora_fim.strftime('%H:%M') }}</td>
+                </tr>
+                {% else %}
+                <tr>
+                  <td colspan="3" class="text-center py-4">Nenhum horário cadastrado.</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- embed the collaborator schedule toggle calendar on the veterinarian detail view so the "Minha Agenda" button loads the vet's events
- enhance the veterinarian profile layout with header metadata and keep fixed schedule slots inside a card alongside the interactive calendar
- pass a calendar redirect URL from the view so calendar slot selections can deep-link to the full appointments workflow

## Testing
- pytest *(fails: tests/test_admin_view_switch.py::test_admin_collaborator_post_preserves_query_and_lists_new_appointment,
  tests/test_appointment_timezone_filters.py::test_late_brt_appointment_survives_local_filters,
  tests/test_clinic_appointment_links.py::test_clinic_page_has_list_button_and_edit_link)*

------
https://chatgpt.com/codex/tasks/task_e_68d447b96224832e9c32756ac747e8d6