### PR TITLE
Add vaccine appointment scheduling option

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -445,6 +445,7 @@ class AppointmentForm(FlaskForm):
             ('retorno', 'Retorno'),
             ('exame', 'Exame'),
             ('banho_tosa', 'Banho e Tosa'),
+            ('vacina', 'Vacina'),
         ],
         validators=[DataRequired()],
         default='consulta',

--- a/helpers.py
+++ b/helpers.py
@@ -22,6 +22,7 @@ APPOINTMENT_KIND_DURATIONS = {
     'retorno': 30,
     'exame': 30,
     'banho_tosa': 30,
+    'vacina': 30,
 }
 
 DEFAULT_VACCINE_EVENT_START_TIME = time(9, 0)

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -224,11 +224,13 @@
               <div>
                 <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
                 <small class="text-muted">
-                  {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa'] else appt.animal.owner.name }}
+                  {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
                   {% if item.kind == 'exame' %}
                     <span class="badge bg-info ms-1">Exame</span>
                   {% elif item.kind == 'banho_tosa' %}
                     <span class="badge bg-primary ms-1">Banho e Tosa</span>
+                  {% elif item.kind == 'vacina' %}
+                    <span class="badge bg-success ms-1">Vacina</span>
                   {% elif item.kind == 'retorno' %}
                     <span class="badge bg-warning text-dark ms-1">Retorno</span>
                   {% endif %}
@@ -244,7 +246,7 @@
             </div>
             {% if can_respond %}
               <div class="d-flex gap-2">
-                {% if item.kind in ['consulta', 'retorno', 'banho_tosa'] %}
+                {% if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] %}
                 <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
                   <input type="hidden" name="status" value="accepted">
                   <button type="submit" class="btn btn-success btn-sm"><i class="fas fa-check me-1"></i>Aceitar</button>
@@ -326,11 +328,13 @@
                 </div>
                 <div>
                   <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                  <small class="text-muted">{{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa'] else appt.animal.owner.name }}
+                  <small class="text-muted">{{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
                     {% if item.kind == 'retorno' %}
                       <span class="badge bg-warning text-dark ms-1">Retorno</span>
                     {% elif item.kind == 'banho_tosa' %}
                       <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
+                    {% elif item.kind == 'vacina' %}
+                      <span class="badge bg-success text-white ms-1">Vacina</span>
                     {% endif %}
                   </small>
                 </div>

--- a/tests/test_appointment_vet.py
+++ b/tests/test_appointment_vet.py
@@ -137,7 +137,8 @@ def test_veterinarian_sees_all_animals_in_form(client):
         assert (animal2.id, animal2.name) in form.animal_id.choices
 
 
-def test_appointment_form_has_banho_tosa_choice(client):
+def test_appointment_form_has_extra_kind_choices(client):
     with flask_app.app_context():
         form = AppointmentForm()
         assert ('banho_tosa', 'Banho e Tosa') in form.kind.choices
+        assert ('vacina', 'Vacina') in form.kind.choices

--- a/tests/test_collaborator_appointment.py
+++ b/tests/test_collaborator_appointment.py
@@ -106,3 +106,36 @@ def test_collaborator_can_schedule_banho_tosa(client, monkeypatch):
         assert appt.kind == 'banho_tosa'
         assert appt.notes == 'Spa day'
         assert appt.status == 'scheduled'
+
+
+def test_collaborator_can_schedule_vacina(client, monkeypatch):
+    with flask_app.app_context():
+        clinic_id, animal_id, vet_id = setup_data()
+
+    collaborator = type('U', (), {
+        'id': 5,
+        'worker': 'colaborador',
+        'role': 'adotante',
+        'is_authenticated': True,
+        'clinica_id': clinic_id,
+    })()
+    login(monkeypatch, collaborator)
+
+    resp = client.post('/appointments', data={
+        'appointment-animal_id': str(animal_id),
+        'appointment-veterinario_id': str(vet_id),
+        'appointment-date': '2024-05-20',
+        'appointment-time': '11:00',
+        'appointment-kind': 'vacina',
+        'appointment-reason': 'Reforço anual',
+        'appointment-submit': True,
+    })
+
+    assert resp.status_code == 302
+
+    with flask_app.app_context():
+        appt = Appointment.query.order_by(Appointment.id.desc()).first()
+        assert appt is not None
+        assert appt.kind == 'vacina'
+        assert appt.notes == 'Reforço anual'
+        assert appt.status == 'scheduled'


### PR DESCRIPTION
## Summary
- add the "Vacina" option to appointment forms and durations
- display vaccine appointments alongside other types in the veterinarian agenda UI
- cover the new appointment type with collaborator and form tests

## Testing
- pytest tests/test_collaborator_appointment.py tests/test_appointment_vet.py

------
https://chatgpt.com/codex/tasks/task_e_68d448b2e818832ea3b253374c3ef35d