### PR TITLE
Fix vaccine filter normalization in tutor calendar

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -2045,7 +2045,11 @@ document.addEventListener('DOMContentLoaded', function() {
     if (value === undefined || value === null) {
       return '';
     }
-    return String(value).trim().toLowerCase();
+    let normalized = String(value).trim().toLowerCase();
+    if (typeof normalized.normalize === 'function') {
+      normalized = normalized.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    }
+    return normalized;
   }
 
   function canonicalizeEventTypeKey(value) {
@@ -2066,6 +2070,7 @@ document.addEventListener('DOMContentLoaded', function() {
       case 'vaccine':
       case 'vacina':
       case 'vacinas':
+      case 'vacinacao':
       case 'imunizacao':
         return 'vaccine';
       case 'grooming':


### PR DESCRIPTION
## Summary
- normalize calendar filter values to strip diacritics before matching
- accept the `vacinacao` alias so vaccine events map to the vaccine filter

## Testing
- pytest *(fails: existing functional tests unrelated to the change)*

------
https://chatgpt.com/codex/tasks/task_e_68d45640afcc832e92914e58f2c283ed