### PR TITLE
Improve calendar summary panel UX

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -234,10 +234,46 @@
   background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
   border-radius: 1rem;
   border: 1px solid rgba(148, 163, 184, 0.2);
+  position: relative;
 }
 
 .calendar-summary-card .card-body {
   padding-top: 1.25rem;
+}
+
+.calendar-summary-loading {
+  display: none;
+  padding: 1rem 1.1rem;
+  background: rgba(59, 130, 246, 0.06);
+  border-radius: 0.9rem;
+  border-color: rgba(37, 99, 235, 0.35) !important;
+}
+
+.border-dashed {
+  border-style: dashed !important;
+}
+
+.calendar-summary-loading .spinner-border {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-width: 0.2rem;
+}
+
+.calendar-summary-card.is-loading .calendar-summary-loading {
+  display: flex;
+}
+
+.calendar-summary-card.is-loading .calendar-summary-list,
+.calendar-summary-card.is-loading .calendar-summary-overview {
+  opacity: 0.45;
+  filter: saturate(0.85) contrast(0.95);
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.calendar-summary-list.is-disabled,
+.calendar-summary-overview.is-disabled {
+  pointer-events: none;
 }
 
 .calendar-summary-card.has-data [data-calendar-summary-empty] {
@@ -260,6 +296,72 @@
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.calendar-summary-overview {
+  margin-top: 0.75rem;
+}
+
+.calendar-summary-overview-card {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(59, 130, 246, 0.02));
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 12px 24px -24px rgba(15, 23, 42, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  height: 100%;
+}
+
+.calendar-summary-overview-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 32px -30px rgba(37, 99, 235, 0.55);
+}
+
+.calendar-summary-overview-icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.35rem;
+  color: #1d4ed8;
+  background: rgba(37, 99, 235, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.12);
+}
+
+.calendar-summary-overview-card.is-week .calendar-summary-overview-icon {
+  background: rgba(16, 185, 129, 0.16);
+  color: #047857;
+  box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.18);
+}
+
+.calendar-summary-overview-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.calendar-summary-overview-body .label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #475569;
+}
+
+.calendar-summary-overview-body .value {
+  font-size: 1.75rem;
+  line-height: 1;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.calendar-summary-overview-body .description {
+  font-size: 0.78rem;
 }
 
 .calendar-summary-item {

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -102,7 +102,7 @@
       </div>
     </div>
     <div class="col-12 col-xl-4 col-xxl-3" data-calendar-summary-column>
-      <div class="card calendar-summary-card border-0 shadow-sm h-100" data-calendar-summary-panel>
+      <div class="card calendar-summary-card border-0 shadow-sm h-100 is-loading" data-calendar-summary-panel>
         <div class="card-header bg-white border-0 pb-0">
           <div class="d-flex align-items-center justify-content-between gap-2">
             <h5 class="mb-0 fw-semibold">
@@ -115,12 +115,50 @@
           </p>
         </div>
         <div class="card-body">
-          <div class="text-muted small" data-calendar-summary-empty aria-live="polite">
-            Carregando estatísticas da agenda...
+          <div
+            class="calendar-summary-loading d-flex align-items-center gap-3 rounded-4 border border-dashed"
+            data-calendar-summary-loading
+            role="status"
+            aria-live="polite"
+          >
+            <div class="spinner-border text-primary" role="presentation" aria-hidden="true"></div>
+            <div>
+              <p class="mb-0 fw-semibold text-primary">Atualizando estatísticas</p>
+              <small class="text-muted">Aguarde enquanto buscamos as consultas desta visão.</small>
+            </div>
+          </div>
+          <div class="calendar-summary-overview row g-3 mt-1" data-calendar-summary-overview hidden>
+            <div class="col-12 col-sm-6">
+              <div class="calendar-summary-overview-card is-today">
+                <div class="calendar-summary-overview-icon" aria-hidden="true">
+                  <i class="bi bi-brightness-alt-high-fill"></i>
+                </div>
+                <div class="calendar-summary-overview-body">
+                  <span class="label">Hoje</span>
+                  <strong class="value" data-calendar-summary-overview-today>0</strong>
+                  <small class="description text-muted">Consultas previstas</small>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-sm-6">
+              <div class="calendar-summary-overview-card is-week">
+                <div class="calendar-summary-overview-icon" aria-hidden="true">
+                  <i class="bi bi-calendar-week"></i>
+                </div>
+                <div class="calendar-summary-overview-body">
+                  <span class="label">Semana</span>
+                  <strong class="value" data-calendar-summary-overview-week>0</strong>
+                  <small class="description text-muted">Compromissos na semana</small>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="text-muted small mt-3" data-calendar-summary-empty aria-live="polite" role="status">
+            Nenhum compromisso encontrado para o período atual.
           </div>
           <ul
             role="list"
-            class="calendar-summary-list d-flex flex-column gap-3 mt-2"
+            class="calendar-summary-list d-flex flex-column gap-3 mt-3"
             data-calendar-summary-list
           ></ul>
         </div>
@@ -349,6 +387,18 @@ document.addEventListener('DOMContentLoaded', () => {
     : null;
   const calendarSummaryTotalBadge = calendarSummaryPanel
     ? calendarSummaryPanel.querySelector('[data-calendar-summary-total]')
+    : null;
+  const calendarSummaryOverview = calendarSummaryPanel
+    ? calendarSummaryPanel.querySelector('[data-calendar-summary-overview]')
+    : null;
+  const calendarSummaryOverviewToday = calendarSummaryPanel
+    ? calendarSummaryPanel.querySelector('[data-calendar-summary-overview-today]')
+    : null;
+  const calendarSummaryOverviewWeek = calendarSummaryPanel
+    ? calendarSummaryPanel.querySelector('[data-calendar-summary-overview-week]')
+    : null;
+  const calendarSummaryLoading = calendarSummaryPanel
+    ? calendarSummaryPanel.querySelector('[data-calendar-summary-loading]')
     : null;
   const calendarSummaryColumn = document.querySelector('[data-calendar-summary-column]');
   const calendarMainColumn = document.querySelector('[data-calendar-main-column]');
@@ -703,9 +753,23 @@ document.addEventListener('DOMContentLoaded', () => {
       return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: 'base' });
     });
 
-    const totalEvents = rows.reduce((acc, item) => acc + item.total, 0);
+    const totals = rows.reduce((accumulator, item) => {
+      accumulator.totalEvents += item.total;
+      accumulator.totalToday += item.today;
+      accumulator.totalThisWeek += item.thisWeek;
+      return accumulator;
+    }, {
+      totalEvents: 0,
+      totalToday: 0,
+      totalThisWeek: 0,
+    });
 
-    return { rows, totalEvents };
+    return {
+      rows,
+      totalEvents: totals.totalEvents,
+      totalToday: totals.totalToday,
+      totalThisWeek: totals.totalThisWeek,
+    };
   }
 
   function getUpcomingSummaryDays(entry, limit = 4) {
@@ -743,11 +807,33 @@ document.addEventListener('DOMContentLoaded', () => {
     refreshCalendarSummaryActiveState();
   }
 
+  function setCalendarSummaryLoadingState(isLoading) {
+    if (!calendarSummaryPanel) {
+      return;
+    }
+    const shouldActivate = !!isLoading;
+    calendarSummaryPanel.classList.toggle('is-loading', shouldActivate);
+    calendarSummaryPanel.setAttribute('aria-busy', shouldActivate ? 'true' : 'false');
+    if (calendarSummaryLoading) {
+      calendarSummaryLoading.classList.toggle('d-none', !shouldActivate);
+    }
+    if (calendarSummaryList) {
+      calendarSummaryList.classList.toggle('is-disabled', shouldActivate);
+    }
+    if (calendarSummaryOverview) {
+      calendarSummaryOverview.classList.toggle('is-disabled', shouldActivate);
+    }
+    if (shouldActivate && calendarSummaryEmpty) {
+      calendarSummaryEmpty.classList.add('d-none');
+    }
+  }
+
   function renderCalendarSummary(events) {
     if (!calendarSummaryPanel || !calendarSummaryList) {
       return;
     }
-    const { rows, totalEvents } = computeSummaryMetrics(events);
+    const { rows, totalEvents, totalToday, totalThisWeek } = computeSummaryMetrics(events);
+    setCalendarSummaryLoadingState(false);
     if (calendarSummaryTotalBadge) {
       calendarSummaryTotalBadge.textContent = String(totalEvents);
     }
@@ -757,11 +843,23 @@ document.addEventListener('DOMContentLoaded', () => {
         calendarSummaryEmpty.classList.remove('d-none');
       }
       calendarSummaryPanel.classList.remove('has-data');
+      if (calendarSummaryOverview) {
+        calendarSummaryOverview.setAttribute('hidden', 'hidden');
+      }
       return;
     }
     calendarSummaryPanel.classList.add('has-data');
     if (calendarSummaryEmpty) {
       calendarSummaryEmpty.classList.add('d-none');
+    }
+    if (calendarSummaryOverview) {
+      calendarSummaryOverview.removeAttribute('hidden');
+      if (calendarSummaryOverviewToday) {
+        calendarSummaryOverviewToday.textContent = String(totalToday);
+      }
+      if (calendarSummaryOverviewWeek) {
+        calendarSummaryOverviewWeek.textContent = String(totalThisWeek);
+      }
     }
 
     rows.forEach(entry => {
@@ -845,13 +943,20 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (calendarSummaryPanel) {
+    setCalendarSummaryLoadingState(true);
     const initialEvents = Array.isArray(window.sharedCalendarEvents)
       ? window.sharedCalendarEvents
       : [];
-    renderCalendarSummary(initialEvents);
+    if (initialEvents.length) {
+      renderCalendarSummary(initialEvents);
+    }
     document.addEventListener('sharedCalendarEvents', event => {
       const items = (event && event.detail && event.detail.events) || [];
       renderCalendarSummary(items);
+    });
+    document.addEventListener('sharedCalendarEventsLoading', event => {
+      const isLoading = !!(event && event.detail && event.detail.loading);
+      setCalendarSummaryLoadingState(isLoading);
     });
   }
 

--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -385,6 +385,7 @@ document.addEventListener('DOMContentLoaded', function() {
       calendar.addEventSource(url);
     }
     if (options.refetch && typeof calendar.refetchEvents === 'function') {
+      dispatchSharedCalendarLoading(true);
       calendar.refetchEvents();
     }
   }
@@ -520,6 +521,15 @@ document.addEventListener('DOMContentLoaded', function() {
     }));
   }
 
+  function dispatchSharedCalendarLoading(isLoading) {
+    if (typeof window !== 'undefined') {
+      window.sharedCalendarIsLoading = !!isLoading;
+    }
+    document.dispatchEvent(new CustomEvent('sharedCalendarEventsLoading', {
+      detail: { loading: !!isLoading },
+    }));
+  }
+
   function announceSharedCalendarReady(instance) {
     document.dispatchEvent(new CustomEvent('sharedCalendarReady', {
       detail: { calendar: instance },
@@ -626,6 +636,9 @@ document.addEventListener('DOMContentLoaded', function() {
     selectMirror: true,
     editable: true,
     eventDurationEditable: true,
+    loading: function(isLoading) {
+      dispatchSharedCalendarLoading(isLoading);
+    },
     select: function(info) {
       emitSlotChosen(info.start, info.allDay);
       calendar.unselect();
@@ -674,7 +687,11 @@ document.addEventListener('DOMContentLoaded', function() {
   window.sharedCalendar = calendar;
   addEvents();
   calendar.render();
-  dispatchSharedCalendarEvents(calendar.getEvents());
+  const initialCalendarEvents = calendar.getEvents();
+  dispatchSharedCalendarEvents(initialCalendarEvents);
+  if (initialCalendarEvents.length) {
+    dispatchSharedCalendarLoading(false);
+  }
   announceSharedCalendarReady(calendar);
 
   if (toggle) {


### PR DESCRIPTION
## Summary
- enrich the calendar summary panel with a live loading indicator, aggregate tiles, and refined empty-state copy for better UX
- compute daily and weekly totals across appointments and react to calendar loading events when updating the summary panel
- polish the summary card visuals with overview metrics styling and softer loading transitions

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68d45e6c7270832e9aac61d5cf062e16