### PR TITLE
Fix day detail card interactions

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -2876,7 +2876,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     card.addEventListener('click', function(evt) {
       if (evt) {
-        const interactiveSelector = 'a, button, input, textarea, select, [role="button"], [data-ignore-card-click]';
+        const interactiveSelector = 'a, button, input, textarea, select, [data-ignore-card-click], [role="button"]:not(.tutor-calendar__day-detail-card)';
         if (evt.target && evt.target.closest(interactiveSelector)) {
           return;
         }
@@ -3966,7 +3966,7 @@ document.addEventListener('DOMContentLoaded', function() {
       if (!card) {
         return;
       }
-      const interactiveSelector = 'a, button, input, textarea, select, [role="button"], [data-ignore-card-click]';
+      const interactiveSelector = 'a, button, input, textarea, select, [data-ignore-card-click], [role="button"]:not(.tutor-calendar__day-detail-card)';
       if (event.target && event.target.closest(interactiveSelector)) {
         return;
       }


### PR DESCRIPTION
## Summary
- allow day-detail cards to trigger the detailed view even when rendered server-side by excluding the cards themselves from the interactive selector safeguards
- keep quick-action access working by letting delegated click handlers run for articles with role="button"

## Testing
- `pytest` *(fails: existing suite has known failing scenarios unrelated to this change; see test summary for details)*

------
https://chatgpt.com/codex/tasks/task_e_68d45ef12104832ea65012482be6b8e5