### PR TITLE
Fix calendar summary visibility by tab

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -508,8 +508,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const normalized = typeof targetSelector === 'string'
       ? targetSelector.trim()
       : '';
-    const shouldShow = normalized === '#calendar-pane-full'
-      || normalized === 'calendar-pane-full'
+    const shouldShow = normalized === '#calendar-pane-experimental'
+      || normalized === 'calendar-pane-experimental'
       || normalized === '';
     setCalendarSummaryVisibility(shouldShow);
   }
@@ -617,7 +617,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (activeCalendarTab) {
     updateCalendarSummaryVisibilityFromTarget(activeCalendarTab.getAttribute('data-bs-target'));
   } else {
-    updateCalendarSummaryVisibilityFromTarget('#calendar-pane-full');
+    updateCalendarSummaryVisibilityFromTarget('#calendar-pane-experimental');
   }
 
   function padNumber(value) {


### PR DESCRIPTION
## Summary
- show the calendar summary column only when the calendar tab is active
- keep the summary hidden when switching to the scheduling tab for clearer separation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d464daf5cc832eb4fb14e83d8ddf8e