### PR TITLE
Improve new appointment button behavior

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -3941,7 +3941,31 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   newEventBtn && newEventBtn.addEventListener('click', function() {
-    dispatchSlot(viewDate, '09:00');
+    const todayKey = formatDateKey(new Date());
+    let targetDateKey = selectedDate || todayKey;
+    let targetDate = parseDateKey(targetDateKey);
+
+    if (!targetDate) {
+      targetDateKey = formatDateKey(viewDate instanceof Date ? viewDate : new Date());
+      targetDate = parseDateKey(targetDateKey) || new Date();
+    }
+
+    selectedDate = targetDateKey;
+
+    if (currentViewMode === 'week') {
+      viewDate = getStartOfWeek(targetDate);
+    } else {
+      viewDate = new Date(targetDate.getFullYear(), targetDate.getMonth(), 1);
+    }
+
+    renderCalendar();
+    renderDayDetail(targetDateKey, {
+      open: true,
+      focus: true,
+      trigger: newEventBtn,
+    });
+
+    dispatchSlot(targetDate, '09:00');
   });
 
   refreshPetsBtn && refreshPetsBtn.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- ensure the "Novo agendamento" button targets the currently selected or fallback date
- synchronize the calendar view/day detail before emitting the calendar slot event
- keep dispatching the slot event so the scheduling modal opens prefilled

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d46a755bd4832e83d83a934a0fe3eb