### PR TITLE
Add vet filter integration for calendar summary buttons

### DIFF
--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -335,6 +335,20 @@ document.addEventListener('DOMContentLoaded', function() {
   let userButtonPrefersVet = preferUserVetSourceFlag && (initialVetId !== null);
   let calendar;
 
+  function dispatchVetSelectionChange(vetValue) {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const normalizedVet = normalizeVetColorKey(vetValue);
+    document.dispatchEvent(new CustomEvent('calendarVetFilterChange', {
+      detail: { vetId: normalizedVet },
+    }));
+  }
+
+  function notifyVetSelectionChange() {
+    dispatchVetSelectionChange(selectedVetId);
+  }
+
   if (adminInitialView === 'veterinario') {
     source = 'vet';
   } else if (adminInitialView === 'colaborador') {
@@ -345,6 +359,8 @@ document.addEventListener('DOMContentLoaded', function() {
   if (source === 'user' && selectedVetId !== null) {
     source = 'vet';
   }
+
+  notifyVetSelectionChange();
 
   function eventUrl() {
     if (source === 'clinic') {
@@ -559,6 +575,9 @@ document.addEventListener('DOMContentLoaded', function() {
       updateCollaboratorPickerValue(source);
     }
     const vetChanged = previousVetId !== numericVetId;
+    if (vetChanged) {
+      notifyVetSelectionChange();
+    }
     if (vetChanged && (shouldActivate || source === 'vet')) {
       addEvents({ refetch: false });
       if (shouldRefetch && calendar && typeof calendar.refetchEvents === 'function') {
@@ -711,6 +730,7 @@ document.addEventListener('DOMContentLoaded', function() {
           }
           source = 'user';
           selectedVetId = null;
+          notifyVetSelectionChange();
           if (preferUserVetSourceFlag) {
             const fallbackVet = lastKnownVetId !== null ? lastKnownVetId : initialVetId;
             userButtonPrefersVet = fallbackVet !== null;
@@ -718,6 +738,7 @@ document.addEventListener('DOMContentLoaded', function() {
         } else if (target === 'clinic') {
           source = 'clinic';
           selectedVetId = null;
+          notifyVetSelectionChange();
           if (preferUserVetSourceFlag) {
             const fallbackVet = lastKnownVetId !== null ? lastKnownVetId : initialVetId;
             userButtonPrefersVet = fallbackVet !== null;
@@ -736,6 +757,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const rawValue = this.value;
       if (rawValue === 'clinic') {
         selectedVetId = null;
+        notifyVetSelectionChange();
         source = 'clinic';
         setActiveButton(source);
         addEvents({ refetch: true });
@@ -743,6 +765,7 @@ document.addEventListener('DOMContentLoaded', function() {
       }
       if (rawValue === 'user' || rawValue === '') {
         selectedVetId = null;
+        notifyVetSelectionChange();
         source = 'user';
         setActiveButton(source);
         addEvents({ refetch: true });
@@ -756,6 +779,7 @@ document.addEventListener('DOMContentLoaded', function() {
       }
       source = defaultSource;
       selectedVetId = null;
+      notifyVetSelectionChange();
       setActiveButton(source);
       addEvents({ refetch: true });
     });
@@ -770,6 +794,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
       }
       selectedVetId = null;
+      notifyVetSelectionChange();
       if (selection && selection.id !== null) {
         selectedUserId = selection.id;
       } else {

--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -1488,6 +1488,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
   let pets = [];
   let events = [];
+  let allEvents = [];
+  let activeVetFilterId = null;
   let viewDate = new Date();
   let currentViewMode = 'month';
   let currentFilter = 'all';
@@ -1910,29 +1912,34 @@ document.addEventListener('DOMContentLoaded', function() {
       return;
     }
     const targetId = String(recordId);
-    let matched = false;
-    events.forEach(function(eventItem) {
-      if (!eventItem) {
-        return;
-      }
-      const ext = eventItem.raw && eventItem.raw.extendedProps ? eventItem.raw.extendedProps : null;
-      const eventRecordId = eventItem.recordId !== undefined && eventItem.recordId !== null
-        ? String(eventItem.recordId)
-        : (ext && ext.recordId !== undefined && ext.recordId !== null ? String(ext.recordId) : null);
-      if (!eventRecordId || eventRecordId !== targetId) {
-        return;
-      }
-      matched = true;
-      const typeKey = getEventBaseType(eventItem) || 'appointment';
-      const nextStatus = resolveStatusKey(statusValue, typeKey);
-      eventItem.status = nextStatus;
-      if (ext) {
-        ext.status = nextStatus;
-      }
-    });
-    if (matched) {
-      renderCalendar();
-      refreshSharedEventsFromLocal();
+    const applyStatusUpdate = function(list) {
+      let listMatched = false;
+      (Array.isArray(list) ? list : []).forEach(function(eventItem) {
+        if (!eventItem) {
+          return;
+        }
+        const ext = eventItem.raw && eventItem.raw.extendedProps ? eventItem.raw.extendedProps : null;
+        const eventRecordId = eventItem.recordId !== undefined && eventItem.recordId !== null
+          ? String(eventItem.recordId)
+          : (ext && ext.recordId !== undefined && ext.recordId !== null ? String(ext.recordId) : null);
+        if (!eventRecordId || eventRecordId !== targetId) {
+          return;
+        }
+        listMatched = true;
+        const typeKey = getEventBaseType(eventItem) || 'appointment';
+        const nextStatus = resolveStatusKey(statusValue, typeKey);
+        eventItem.status = nextStatus;
+        if (ext) {
+          ext.status = nextStatus;
+        }
+      });
+      return listMatched;
+    };
+
+    const matchedInEvents = applyStatusUpdate(events);
+    const matchedInAllEvents = applyStatusUpdate(allEvents);
+    if (matchedInEvents || matchedInAllEvents) {
+      refreshEventsView();
     }
   }
 
@@ -2131,6 +2138,60 @@ document.addEventListener('DOMContentLoaded', function() {
       normalized = normalized.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
     }
     return normalized;
+  }
+
+  function normalizeVetFilterId(value) {
+    if (typeof window !== 'undefined'
+      && window.calendarVetColorManager
+      && typeof window.calendarVetColorManager.normalize === 'function') {
+      return window.calendarVetColorManager.normalize(value);
+    }
+    if (value === undefined || value === null) {
+      return null;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return String(value);
+    }
+    const normalized = String(value).trim();
+    return normalized || null;
+  }
+
+  function getEventVetId(eventData) {
+    if (!eventData) {
+      return null;
+    }
+    const raw = eventData.raw || {};
+    const ext = raw.extendedProps || {};
+    const candidate = ext.veterinarioId
+      || ext.veterinario_id
+      || ext.vetId
+      || ext.vet_id
+      || ext.veterinarianId
+      || ext.veterinarian_id
+      || ext.specialistId
+      || ext.specialist_id
+      || raw.veterinarioId
+      || raw.veterinario_id
+      || raw.vetId
+      || raw.vet_id
+      || raw.veterinarianId
+      || raw.veterinarian_id
+      || eventData.vetId
+      || eventData.veterinarioId
+      || eventData.veterinario_id
+      || null;
+    return normalizeVetFilterId(candidate);
+  }
+
+  function filterEventsByVet(list, vetId) {
+    const collection = Array.isArray(list) ? list : [];
+    const normalizedVetId = normalizeVetFilterId(vetId);
+    if (!normalizedVetId) {
+      return collection.slice();
+    }
+    return collection.filter(function(item) {
+      return getEventVetId(item) === normalizedVetId;
+    });
   }
 
   function canonicalizeEventTypeKey(value) {
@@ -3871,21 +3932,34 @@ document.addEventListener('DOMContentLoaded', function() {
     }).filter(Boolean);
   }
 
-  function refreshSharedEventsFromLocal() {
-    if (usingSharedCalendar) {
-      return;
-    }
+  function broadcastCurrentEvents() {
     const rawEvents = collectCurrentRawEvents();
     dispatchLocalSharedEvents(rawEvents);
   }
 
-  function updateEvents(newEvents) {
+  function refreshSharedEventsFromLocal() {
+    if (usingSharedCalendar) {
+      return;
+    }
+    broadcastCurrentEvents();
+  }
+
+  function refreshEventsView(options = {}) {
+    const shouldBroadcast = options.broadcast !== false;
+    events = filterEventsByVet(allEvents, activeVetFilterId);
+    renderCalendar();
+    renderPetList();
+    if (shouldBroadcast) {
+      broadcastCurrentEvents();
+    }
+  }
+
+  function updateEvents(newEvents, options = {}) {
     const normalized = (newEvents || []).map(normalizeEvent).filter(function(ev) {
       return ev && ev.date;
     });
-    events = normalized;
-    renderCalendar();
-    renderPetList();
+    allEvents = normalized;
+    refreshEventsView(options);
   }
 
   async function fetchEventsFromApi() {
@@ -3909,7 +3983,6 @@ document.addEventListener('DOMContentLoaded', function() {
       }
       const data = await response.json();
       if (Array.isArray(data) && !usingSharedCalendar) {
-        dispatchLocalSharedEvents(data);
         updateEvents(data);
       }
     } catch (error) {
@@ -4279,6 +4352,21 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   updateDayDetailControls();
+
+  function handleVetFilterChange(event) {
+    if (!event) {
+      return;
+    }
+    const detail = event.detail || {};
+    const normalized = normalizeVetFilterId(detail.vetId);
+    if (normalized === activeVetFilterId) {
+      return;
+    }
+    activeVetFilterId = normalized;
+    refreshEventsView();
+  }
+
+  document.addEventListener('calendarVetFilterChange', handleVetFilterChange);
 
   function handleSharedEvents(event) {
     if (!event || !event.detail) {


### PR DESCRIPTION
## Summary
- dispatch a `calendarVetFilterChange` event from the schedule toggle whenever the selected veterinarian changes
- listen for that custom event inside the tutor calendar to keep an active vet filter, re-render visible events, and rebroadcast the filtered list
- share helper utilities so calendar summaries, colors, and other components stay in sync while filtering

## Testing
- pytest *(fails: tests/test_admin_view_switch.py::test_admin_collaborator_post_preserves_query_and_lists_new_appointment, tests/test_appointment_timezone_filters.py::test_late_brt_appointment_survives_local_filters)*

------
https://chatgpt.com/codex/tasks/task_e_68d49cabf194832ebb838ac086331291