### PR TITLE
Implement async veterinarian agenda loading and restore exam agenda view

### DIFF
--- a/app.py
+++ b/app.py
@@ -326,6 +326,324 @@ def get_consulta_or_404(consulta_id):
     return consulta
 
 
+def get_agenda_data(source, user_id):
+    """Return structured agenda information for the given ``source``.
+
+    Currently only the ``user`` source (veterinarian agenda) is supported.
+    The helper centralizes all database queries so both the synchronous
+    page render and the asynchronous fetch can reuse the same logic.
+    """
+
+    if source != 'user':
+        return None
+
+    veterinario = None
+    if user_id is not None:
+        veterinario = Veterinario.query.filter_by(user_id=user_id).first()
+        if veterinario is None:
+            veterinario = Veterinario.query.filter_by(id=user_id).first()
+    if veterinario is None:
+        veterinario_id = request.args.get('veterinario_id', type=int)
+        if veterinario_id:
+            veterinario = Veterinario.query.filter_by(id=veterinario_id).first()
+    if veterinario is None:
+        return None
+
+    now = datetime.utcnow()
+    today_start_local = datetime.now(BR_TZ).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    today_start_utc = (
+        today_start_local.astimezone(timezone.utc).replace(tzinfo=None)
+    )
+
+    start_str = request.args.get('start')
+    end_str = request.args.get('end')
+    restrict_to_today = False
+    if start_str and end_str:
+        try:
+            start_dt = datetime.fromisoformat(start_str)
+            end_dt = datetime.fromisoformat(end_str) + timedelta(days=1)
+        except ValueError:
+            today = date.today()
+            start_dt = datetime.combine(
+                today - timedelta(days=today.weekday()),
+                datetime.min.time(),
+            )
+            end_dt = start_dt + timedelta(days=7)
+            restrict_to_today = True
+        else:
+            restrict_to_today = False
+    else:
+        today = date.today()
+        start_dt = datetime.combine(
+            today - timedelta(days=today.weekday()), datetime.min.time()
+        )
+        end_dt = start_dt + timedelta(days=7)
+        restrict_to_today = True
+
+    start_dt_utc, end_dt_utc = local_date_range_to_utc(start_dt, end_dt)
+    upcoming_start = start_dt_utc or today_start_utc
+    if restrict_to_today and today_start_utc:
+        upcoming_start = max(upcoming_start, today_start_utc)
+
+    pending_consultas = (
+        Appointment.query.filter_by(
+            veterinario_id=veterinario.id, status="scheduled"
+        )
+        .filter(Appointment.scheduled_at > now)
+        .order_by(Appointment.scheduled_at)
+        .all()
+    )
+
+    appointments_pending = []
+    for appt in pending_consultas:
+        appt.time_left = (appt.scheduled_at - timedelta(hours=2)) - now
+        kind = appt.kind or ('retorno' if appt.consulta_id else 'consulta')
+        if kind == 'general':
+            kind = 'consulta'
+        appointments_pending.append({'kind': kind, 'appt': appt})
+
+    exam_pending = (
+        ExamAppointment.query.filter_by(
+            specialist_id=veterinario.id, status='pending'
+        )
+        .filter(ExamAppointment.scheduled_at > now)
+        .order_by(ExamAppointment.scheduled_at)
+        .all()
+    )
+
+    vet_user_id = getattr(veterinario, "user_id", None)
+    for ex in exam_pending:
+        ex.time_left = ex.confirm_by - now
+        if ex.time_left.total_seconds() <= 0:
+            ex.status = 'canceled'
+            msg = Message(
+                sender_id=vet_user_id or getattr(current_user, "id", None),
+                receiver_id=ex.requester_id,
+                animal_id=ex.animal_id,
+                content=(
+                    "Especialista não aceitou exame para "
+                    f"{ex.animal.name}. Reagende com outro profissional."
+                ),
+            )
+            db.session.add(msg)
+            db.session.commit()
+        else:
+            appointments_pending.append({'kind': 'exame', 'appt': ex})
+
+    accepted_consultas_in_range = (
+        Appointment.query.filter_by(
+            veterinario_id=veterinario.id, status="accepted"
+        )
+        .filter(Appointment.scheduled_at >= start_dt_utc)
+        .filter(Appointment.scheduled_at < end_dt_utc)
+        .order_by(Appointment.scheduled_at)
+        .all()
+    )
+
+    future_cutoff = max(now, upcoming_start) if upcoming_start else now
+    past_accepted_consultas = []
+    upcoming_consultas = []
+    for appt in accepted_consultas_in_range:
+        scheduled_at = appt.scheduled_at
+        if scheduled_at and scheduled_at >= future_cutoff:
+            upcoming_consultas.append(appt)
+        else:
+            past_accepted_consultas.append(appt)
+
+    upcoming_exams = (
+        ExamAppointment.query.filter_by(
+            specialist_id=veterinario.id, status='confirmed'
+        )
+        .filter(ExamAppointment.scheduled_at >= future_cutoff)
+        .filter(ExamAppointment.scheduled_at < end_dt_utc)
+        .order_by(ExamAppointment.scheduled_at)
+        .all()
+    )
+
+    appointments_upcoming = []
+    for appt in upcoming_consultas:
+        kind = appt.kind or ('retorno' if appt.consulta_id else 'consulta')
+        if kind == 'general':
+            kind = 'consulta'
+        appointments_upcoming.append({'kind': kind, 'appt': appt})
+    for exam in upcoming_exams:
+        appointments_upcoming.append({'kind': 'exame', 'appt': exam})
+    appointments_upcoming.sort(key=lambda item: item['appt'].scheduled_at)
+
+    consulta_filters = [Consulta.status == 'finalizada']
+    scope_filters = []
+    if vet_user_id:
+        scope_filters.append(Consulta.created_by == vet_user_id)
+    if veterinario.clinica_id:
+        scope_filters.append(Consulta.clinica_id == veterinario.clinica_id)
+    if scope_filters:
+        consulta_filters.append(or_(*scope_filters))
+
+    consultas_finalizadas = (
+        Consulta.query.outerjoin(Appointment, Consulta.appointment)
+        .options(
+            joinedload(Consulta.animal).joinedload(Animal.owner),
+            joinedload(Consulta.veterinario),
+            joinedload(Consulta.appointment)
+            .joinedload(Appointment.animal)
+            .joinedload(Animal.owner),
+        )
+        .filter(*consulta_filters)
+        .filter(
+            or_(
+                and_(
+                    Appointment.id.isnot(None),
+                    Appointment.scheduled_at >= start_dt_utc,
+                    Appointment.scheduled_at < end_dt_utc,
+                ),
+                and_(
+                    Appointment.id.is_(None),
+                    Consulta.created_at >= start_dt_utc,
+                    Consulta.created_at < end_dt_utc,
+                ),
+            )
+        )
+        .all()
+    )
+
+    consulta_animal_ids = {c.animal_id for c in consultas_finalizadas}
+    exam_blocks_by_consulta = defaultdict(list)
+    exam_blocks_by_animal = defaultdict(list)
+    if consulta_animal_ids:
+        blocos_query = (
+            BlocoExames.query.options(joinedload(BlocoExames.exames))
+            .filter(BlocoExames.animal_id.in_(consulta_animal_ids))
+        )
+        for bloco in blocos_query.all():
+            exam_blocks_by_animal[bloco.animal_id].append(bloco)
+            consulta_ref = getattr(bloco, 'consulta_id', None)
+            if consulta_ref:
+                exam_blocks_by_consulta[consulta_ref].append(bloco)
+
+    schedule_events = []
+
+    def _consulta_timestamp(consulta_obj):
+        if consulta_obj.appointment and consulta_obj.appointment.scheduled_at:
+            return consulta_obj.appointment.scheduled_at
+        return consulta_obj.created_at
+
+    for consulta in consultas_finalizadas:
+        timestamp = _consulta_timestamp(consulta)
+        if not timestamp or not (start_dt_utc <= timestamp < end_dt_utc):
+            continue
+        relevant_blocks = exam_blocks_by_consulta.get(consulta.id)
+        if not relevant_blocks:
+            relevant_blocks = [
+                bloco
+                for bloco in exam_blocks_by_animal.get(consulta.animal_id, [])
+                if bloco.data_criacao
+                and timestamp
+                and bloco.data_criacao.date() == timestamp.date()
+            ]
+        exam_summary = []
+        exam_ids = []
+        for bloco in relevant_blocks or []:
+            for exame in bloco.exames:
+                exam_ids.append(exame.id)
+                exam_summary.append(
+                    {
+                        'nome': exame.nome,
+                        'status': exame.status,
+                        'justificativa': exame.justificativa,
+                        'bloco_id': bloco.id,
+                    }
+                )
+        schedule_events.append(
+            {
+                'kind': 'consulta_finalizada',
+                'timestamp': timestamp,
+                'animal': consulta.animal,
+                'consulta': consulta,
+                'consulta_id': consulta.id,
+                'appointment': consulta.appointment,
+                'exam_summary': exam_summary,
+                'exam_blocks': relevant_blocks or [],
+                'exam_ids': exam_ids,
+            }
+        )
+
+    for appt in past_accepted_consultas:
+        if not appt.scheduled_at or not (start_dt_utc <= appt.scheduled_at < end_dt_utc):
+            continue
+        schedule_events.append(
+            {
+                'kind': 'consulta_aceita',
+                'timestamp': appt.scheduled_at,
+                'animal': appt.animal,
+                'consulta': appt.consulta,
+                'consulta_id': appt.consulta_id,
+                'appointment': appt,
+                'exam_summary': [],
+                'exam_blocks': [],
+                'exam_ids': [],
+            }
+        )
+
+    for item in appointments_upcoming:
+        if item['kind'] == 'retorno':
+            appt = item['appt']
+            schedule_events.append(
+                {
+                    'kind': 'retorno',
+                    'timestamp': appt.scheduled_at,
+                    'animal': appt.animal,
+                    'appointment': appt,
+                    'consulta_id': appt.consulta_id,
+                    'exam_summary': [],
+                    'exam_blocks': [],
+                    'exam_ids': [],
+                }
+            )
+
+    for exam in upcoming_exams:
+        schedule_events.append(
+            {
+                'kind': 'exame',
+                'timestamp': exam.scheduled_at,
+                'animal': exam.animal,
+                'exam': exam,
+                'consulta_id': None,
+                'exam_summary': [],
+                'exam_blocks': [],
+                'exam_ids': [exam.id],
+            }
+        )
+
+    schedule_events.sort(
+        key=lambda event: event.get('timestamp') or datetime.min,
+        reverse=True,
+    )
+
+    session['exam_pending_seen_count'] = ExamAppointment.query.filter_by(
+        specialist_id=veterinario.id, status='pending'
+    ).count()
+    session['appointment_pending_seen_count'] = Appointment.query.filter(
+        Appointment.veterinario_id == veterinario.id,
+        Appointment.status == 'scheduled',
+        Appointment.scheduled_at >= now + timedelta(hours=2),
+    ).count()
+    clinic_pending_query = _clinic_pending_appointments_query(veterinario)
+    session['clinic_pending_seen_count'] = (
+        clinic_pending_query.count() if clinic_pending_query is not None else 0
+    )
+
+    return {
+        'veterinario': veterinario,
+        'appointments_pending': appointments_pending,
+        'appointments_upcoming': appointments_upcoming,
+        'schedule_events': schedule_events,
+        'start_dt': start_dt,
+        'end_dt': end_dt,
+    }
+
+
 MISSING_VET_PROFILE_MESSAGE = (
     "Para visualizar os convites de clínica, finalize seu cadastro de "
     "veterinário informando o CRMV e demais dados profissionais."
@@ -7777,261 +8095,24 @@ def appointments():
             if not horarios_grouped or horarios_grouped[-1]['dia'] != h.dia_semana:
                 horarios_grouped.append({'dia': h.dia_semana, 'itens': []})
             horarios_grouped[-1]['itens'].append(h)
-        now = datetime.utcnow()
-        today_start_local = datetime.now(BR_TZ).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        today_start_utc = (
-            today_start_local.astimezone(timezone.utc).replace(tzinfo=None)
-        )
-        start_str = request.args.get('start')
-        end_str = request.args.get('end')
-        if start_str and end_str:
-            start_dt = datetime.fromisoformat(start_str)
-            end_dt = datetime.fromisoformat(end_str) + timedelta(days=1)
-            restrict_to_today = False
+
+        agenda_payload = get_agenda_data('user', vet_user_id or veterinario.id)
+        if agenda_payload:
+            appointments_pending = agenda_payload['appointments_pending']
+            appointments_upcoming = agenda_payload['appointments_upcoming']
+            schedule_events = agenda_payload['schedule_events']
+            start_dt = agenda_payload['start_dt']
+            end_dt = agenda_payload['end_dt']
         else:
             today = date.today()
-            start_dt = datetime.combine(today - timedelta(days=today.weekday()), datetime.min.time())
+            start_dt = datetime.combine(
+                today - timedelta(days=today.weekday()),
+                datetime.min.time(),
+            )
             end_dt = start_dt + timedelta(days=7)
-            restrict_to_today = True
-        start_dt_utc, end_dt_utc = local_date_range_to_utc(start_dt, end_dt)
-        upcoming_start = start_dt_utc or today_start_utc
-        if restrict_to_today and today_start_utc:
-            upcoming_start = max(upcoming_start, today_start_utc)
-
-        pending_consultas = (
-            Appointment.query.filter_by(veterinario_id=veterinario.id, status="scheduled")
-            .filter(Appointment.scheduled_at > now)
-            .order_by(Appointment.scheduled_at)
-            .all()
-        )
-        appointments_pending = []
-        for appt in pending_consultas:
-            appt.time_left = (appt.scheduled_at - timedelta(hours=2)) - now
-            kind = appt.kind or ('retorno' if appt.consulta_id else 'consulta')
-            if kind == 'general':
-                kind = 'consulta'
-            appointments_pending.append({'kind': kind, 'appt': appt})
-
-        from models import ExamAppointment, Message, BlocoExames
-
-        exam_pending = (
-            ExamAppointment.query.filter_by(specialist_id=veterinario.id, status='pending')
-            .filter(ExamAppointment.scheduled_at > now)
-            .order_by(ExamAppointment.scheduled_at)
-            .all()
-        )
-        for ex in exam_pending:
-            ex.time_left = ex.confirm_by - now
-            if ex.time_left.total_seconds() <= 0:
-                ex.status = 'canceled'
-                msg = Message(
-                    sender_id=vet_user_id or getattr(current_user, "id", None),
-                    receiver_id=ex.requester_id,
-                    animal_id=ex.animal_id,
-                    content=f"Especialista não aceitou exame para {ex.animal.name}. Reagende com outro profissional.",
-                )
-                db.session.add(msg)
-                db.session.commit()
-            else:
-                appointments_pending.append({'kind': 'exame', 'appt': ex})
-
-        accepted_consultas_in_range = (
-            Appointment.query.filter_by(veterinario_id=veterinario.id, status="accepted")
-            .filter(Appointment.scheduled_at >= start_dt_utc)
-            .filter(Appointment.scheduled_at < end_dt_utc)
-            .order_by(Appointment.scheduled_at)
-            .all()
-        )
-        future_cutoff = max(now, upcoming_start) if upcoming_start else now
-        past_accepted_consultas = []
-        upcoming_consultas = []
-        for appt in accepted_consultas_in_range:
-            scheduled_at = appt.scheduled_at
-            if scheduled_at and scheduled_at >= future_cutoff:
-                upcoming_consultas.append(appt)
-            else:
-                past_accepted_consultas.append(appt)
-
-        upcoming_exams = (
-            ExamAppointment.query.filter_by(specialist_id=veterinario.id, status='confirmed')
-            .filter(ExamAppointment.scheduled_at >= future_cutoff)
-            .filter(ExamAppointment.scheduled_at < end_dt_utc)
-            .order_by(ExamAppointment.scheduled_at)
-            .all()
-        )
-        appointments_upcoming = []
-        for appt in upcoming_consultas:
-            kind = appt.kind or ('retorno' if appt.consulta_id else 'consulta')
-            if kind == 'general':
-                kind = 'consulta'
-            appointments_upcoming.append({'kind': kind, 'appt': appt})
-        for exam in upcoming_exams:
-            appointments_upcoming.append({'kind': 'exame', 'appt': exam})
-        appointments_upcoming.sort(key=lambda x: x['appt'].scheduled_at)
-
-        consulta_filters = [Consulta.status == 'finalizada']
-        scope_filters = []
-        if vet_user_id:
-            scope_filters.append(Consulta.created_by == vet_user_id)
-        if veterinario.clinica_id:
-            scope_filters.append(Consulta.clinica_id == veterinario.clinica_id)
-        if scope_filters:
-            consulta_filters.append(or_(*scope_filters))
-
-        consultas_finalizadas = (
-            Consulta.query.outerjoin(Appointment, Consulta.appointment)
-            .options(
-                joinedload(Consulta.animal).joinedload(Animal.owner),
-                joinedload(Consulta.veterinario),
-                joinedload(Consulta.appointment)
-                .joinedload(Appointment.animal)
-                .joinedload(Animal.owner),
-            )
-            .filter(*consulta_filters)
-            .filter(
-                or_(
-                    and_(
-                        Appointment.id.isnot(None),
-                        Appointment.scheduled_at >= start_dt_utc,
-                        Appointment.scheduled_at < end_dt_utc,
-                    ),
-                    and_(
-                        Appointment.id.is_(None),
-                        Consulta.created_at >= start_dt_utc,
-                        Consulta.created_at < end_dt_utc,
-                    ),
-                )
-            )
-            .all()
-        )
-
-        consulta_animal_ids = {c.animal_id for c in consultas_finalizadas}
-        exam_blocks_by_consulta = defaultdict(list)
-        exam_blocks_by_animal = defaultdict(list)
-        if consulta_animal_ids:
-            blocos_query = (
-                BlocoExames.query.options(joinedload(BlocoExames.exames))
-                .filter(BlocoExames.animal_id.in_(consulta_animal_ids))
-            )
-            for bloco in blocos_query.all():
-                exam_blocks_by_animal[bloco.animal_id].append(bloco)
-                consulta_ref = getattr(bloco, 'consulta_id', None)
-                if consulta_ref:
-                    exam_blocks_by_consulta[consulta_ref].append(bloco)
-
-        schedule_events = []
-
-        def _consulta_timestamp(consulta_obj):
-            if consulta_obj.appointment and consulta_obj.appointment.scheduled_at:
-                return consulta_obj.appointment.scheduled_at
-            return consulta_obj.created_at
-
-        for consulta in consultas_finalizadas:
-            timestamp = _consulta_timestamp(consulta)
-            if not timestamp or not (start_dt_utc <= timestamp < end_dt_utc):
-                continue
-            relevant_blocks = exam_blocks_by_consulta.get(consulta.id)
-            if not relevant_blocks:
-                relevant_blocks = [
-                    bloco
-                    for bloco in exam_blocks_by_animal.get(consulta.animal_id, [])
-                    if bloco.data_criacao
-                    and timestamp
-                    and bloco.data_criacao.date() == timestamp.date()
-                ]
-            exam_summary = []
-            exam_ids = []
-            for bloco in relevant_blocks or []:
-                for exame in bloco.exames:
-                    exam_ids.append(exame.id)
-                    exam_summary.append(
-                        {
-                            'nome': exame.nome,
-                            'status': exame.status,
-                            'justificativa': exame.justificativa,
-                            'bloco_id': bloco.id,
-                        }
-                    )
-            schedule_events.append(
-                {
-                    'kind': 'consulta_finalizada',
-                    'timestamp': timestamp,
-                    'animal': consulta.animal,
-                    'consulta': consulta,
-                    'consulta_id': consulta.id,
-                    'appointment': consulta.appointment,
-                    'exam_summary': exam_summary,
-                    'exam_blocks': relevant_blocks or [],
-                    'exam_ids': exam_ids,
-                }
-            )
-
-        for appt in past_accepted_consultas:
-            if not appt.scheduled_at or not (start_dt_utc <= appt.scheduled_at < end_dt_utc):
-                continue
-            schedule_events.append(
-                {
-                    'kind': 'consulta_aceita',
-                    'timestamp': appt.scheduled_at,
-                    'animal': appt.animal,
-                    'consulta': appt.consulta,
-                    'consulta_id': appt.consulta_id,
-                    'appointment': appt,
-                    'exam_summary': [],
-                    'exam_blocks': [],
-                    'exam_ids': [],
-                }
-            )
-
-        for item in appointments_upcoming:
-            if item['kind'] == 'retorno':
-                appt = item['appt']
-                schedule_events.append(
-                    {
-                        'kind': 'retorno',
-                        'timestamp': appt.scheduled_at,
-                        'animal': appt.animal,
-                        'appointment': appt,
-                        'consulta_id': appt.consulta_id,
-                        'exam_summary': [],
-                        'exam_blocks': [],
-                        'exam_ids': [],
-                    }
-                )
-
-        for exam in upcoming_exams:
-            schedule_events.append(
-                {
-                    'kind': 'exame',
-                    'timestamp': exam.scheduled_at,
-                    'animal': exam.animal,
-                    'exam': exam,
-                    'consulta_id': None,
-                    'exam_summary': [],
-                    'exam_blocks': [],
-                    'exam_ids': [exam.id],
-                }
-            )
-
-        schedule_events.sort(
-            key=lambda event: event.get('timestamp') or datetime.min,
-            reverse=True,
-        )
-
-        session['exam_pending_seen_count'] = ExamAppointment.query.filter_by(
-            specialist_id=veterinario.id, status='pending'
-        ).count()
-        session['appointment_pending_seen_count'] = Appointment.query.filter(
-            Appointment.veterinario_id == veterinario.id,
-            Appointment.status == 'scheduled',
-            Appointment.scheduled_at >= now + timedelta(hours=2),
-        ).count()
-        clinic_pending_query = _clinic_pending_appointments_query(veterinario)
-        session['clinic_pending_seen_count'] = (
-            clinic_pending_query.count() if clinic_pending_query is not None else 0
-        )
+            appointments_pending = []
+            appointments_upcoming = []
+            schedule_events = []
 
         return render_template(
             'agendamentos/edit_vet_schedule.html',
@@ -8244,6 +8325,40 @@ def appointments():
             calendar_summary_vets=calendar_summary_vets,
             calendar_summary_clinic_ids=calendar_summary_clinic_ids,
         )
+
+
+@app.route('/agenda')
+@login_required
+def agenda_view():
+    source = request.args.get('source', 'clinic')
+    target_user_id = request.args.get('user_id', type=int)
+
+    if source == 'user':
+        if not (_is_admin() or current_user.worker == 'veterinario'):
+            abort(403)
+        if target_user_id is None:
+            target_user_id = current_user.id
+        data = get_agenda_data('user', target_user_id)
+        if data is None:
+            abort(404)
+        period_end = (
+            data['end_dt'] - timedelta(days=1)
+            if data.get('end_dt')
+            else None
+        )
+        context = dict(data)
+        context['period_end'] = period_end
+        context['timedelta'] = timedelta
+        html = render_template('partials/vet_agenda_summary.html', **context)
+        wants_json = (
+            request.accept_mimetypes.best == 'application/json'
+            or request.args.get('format') == 'json'
+        )
+        if wants_json:
+            return jsonify({'html': html})
+        return html
+
+    abort(400)
 
 
 @app.route('/appointments/calendar')

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -350,7 +350,35 @@
 
   <div id="appointmentsList" data-appointments-container data-refresh-url="{{ request.url }}">
     {% include 'partials/appointments_table.html' %}
+    <template data-initial-appointments hidden>
+      {% for appt in appointments %}
+      <div data-appointment-id="{{ appt.id }}"></div>
+      {% endfor %}
+    </template>
   </div>
+
+  {% if exam_appointments is defined and exam_appointments_grouped is defined %}
+  <div class="card border-0 shadow-sm rounded-4 mt-4">
+    <div class="card-header bg-white border-0 py-3">
+      <h3 class="h5 fw-semibold mb-0 d-flex align-items-center gap-2">
+        <i class="bi bi-clipboard2-pulse text-primary"></i>
+        Agenda de Exames
+      </h3>
+    </div>
+    <div class="card-body pt-0">
+      {% include 'partials/exam_appointments_table.html' %}
+      <template data-initial-exam-appointments hidden>
+        {% for exam in exam_appointments %}
+        <div
+          data-exam-id="{{ exam.id }}"
+          data-exam-time="{{ exam.scheduled_at|format_datetime_brazil('%H:%M') }}"
+          data-exam-specialist="{{ exam.specialist.user.name if exam.specialist and exam.specialist.user else '' }}"
+        ></div>
+        {% endfor %}
+      </template>
+    </div>
+  </div>
+  {% endif %}
 
 </section>
 

--- a/templates/partials/clinic_agendamentos_tab.html
+++ b/templates/partials/clinic_agendamentos_tab.html
@@ -34,6 +34,13 @@
         </form>
         <div id="appointments-table-container" data-appointments-container data-refresh-url="{{ request.url }}">
           {% include 'partials/appointments_table.html' %}
+          <template data-initial-appointments hidden>
+            {% for appt in appointments %}
+            <div data-appointment-id="{{ appt.id }}" data-appointment-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}">
+              <a href="{{ url_for('edit_appointment', appointment_id=appt.id) }}"></a>
+            </div>
+            {% endfor %}
+          </template>
         </div>
       </div>
 

--- a/templates/partials/schedule_toggle.html
+++ b/templates/partials/schedule_toggle.html
@@ -8,14 +8,24 @@
 ) %}
 {% set collaborator_select_default = 'clinic' if clinic_id else 'user' %}
 {% set prefer_user_vet_source = prefer_user_vet_source|default(admin_view_mode == 'veterinario') %}
+{% set show_user_button = current_user.is_authenticated and current_user.worker == 'veterinario' %}
+{% if show_user_button %}
+  {% set default_source = 'clinic' if clinic_id else 'user' %}
+{% else %}
+  {% set default_source = 'clinic' if clinic_id else 'clinic' %}
+{% endif %}
+{% set user_button_active = default_source == 'user' %}
+{% set clinic_button_active = default_source == 'clinic' %}
 
 <div class="card mb-4">
   <div class="card-header">
     <div class="d-flex flex-column flex-md-row align-items-center justify-content-center gap-2">
       <div class="btn-group" id="{{ toggle_id }}">
-        <button class="btn btn-outline-primary{% if not clinic_id %} active{% endif %}" data-source="user">Minha Agenda</button>
+        {% if show_user_button %}
+        <button class="btn btn-outline-primary{% if user_button_active %} active{% endif %}" data-source="user">Minha Agenda</button>
+        {% endif %}
         {% if clinic_id %}
-        <button class="btn btn-outline-primary{% if clinic_id %} active{% endif %}" data-source="clinic">Agenda da Clínica</button>
+        <button class="btn btn-outline-primary{% if clinic_button_active %} active{% endif %}" data-source="clinic">Agenda da Clínica</button>
         {% endif %}
       </div>
       {% if is_collaborator_view %}
@@ -46,6 +56,9 @@
       {% endif %}
     </div>
   </div>
+  {% if show_user_button %}
+  <div id="agenda-user" class="agenda-user-container px-3 pt-3 pb-0 d-none" aria-live="polite"></div>
+  {% endif %}
   <div class="card-body p-0">
     <div id="{{ calendar_id }}" data-calendar-redirect-url="{{ calendar_redirect_url|default('') }}"></div>
   </div>
@@ -86,7 +99,9 @@ document.addEventListener('DOMContentLoaded', function() {
   const csrfToken = '{{ csrf_token() if csrf_token is defined else '' }}';
   const clinicId = {{ clinic_id|default(none)|tojson }};
   const adminInitialView = {{ (admin_selected_view or '')|tojson }};
-  const defaultSource = {{ ('clinic' if clinic_id else 'user')|tojson }};
+  const defaultSource = {{ default_source|tojson }};
+  const showUserButtonFlag = {{ show_user_button|tojson }};
+  const agendaUserContainer = document.getElementById('agenda-user');
   const clinicFilters = (function() {
     if (typeof window === 'undefined') {
       return [];
@@ -334,6 +349,7 @@ document.addEventListener('DOMContentLoaded', function() {
   let lastKnownVetId = selectedVetId;
   let userButtonPrefersVet = preferUserVetSourceFlag && (initialVetId !== null);
   let calendar;
+  let userAgendaAbortController = null;
 
   function dispatchVetSelectionChange(vetValue) {
     if (typeof document === 'undefined') {
@@ -349,6 +365,110 @@ document.addEventListener('DOMContentLoaded', function() {
     dispatchVetSelectionChange(selectedVetId);
   }
 
+  function hideUserAgendaContainer() {
+    if (!showUserButtonFlag || !agendaUserContainer) {
+      return;
+    }
+    agendaUserContainer.classList.add('d-none');
+    agendaUserContainer.innerHTML = '';
+  }
+
+  function renderUserAgendaMessage(message, level = 'info') {
+    if (!showUserButtonFlag || !agendaUserContainer) {
+      return;
+    }
+    agendaUserContainer.innerHTML = '';
+    agendaUserContainer.classList.remove('d-none');
+    const alert = document.createElement('div');
+    alert.className = `alert alert-${level} mb-0`;
+    alert.setAttribute('role', 'alert');
+    alert.textContent = message;
+    agendaUserContainer.appendChild(alert);
+  }
+
+  function renderUserAgendaHtml(html) {
+    if (!showUserButtonFlag || !agendaUserContainer) {
+      return;
+    }
+    agendaUserContainer.classList.remove('d-none');
+    agendaUserContainer.innerHTML = html;
+  }
+
+  function showUserAgendaSpinner() {
+    if (!showUserButtonFlag || !agendaUserContainer) {
+      return;
+    }
+    agendaUserContainer.classList.remove('d-none');
+    agendaUserContainer.innerHTML = `
+      <div class="d-flex align-items-center gap-2 text-muted small">
+        <div class="spinner-border spinner-border-sm text-primary" role="status" aria-hidden="true"></div>
+        <span>Carregando agenda...</span>
+      </div>
+    `;
+  }
+
+  async function loadUserAgenda() {
+    if (!showUserButtonFlag || !agendaUserContainer) {
+      return;
+    }
+    if (userAgendaAbortController) {
+      userAgendaAbortController.abort();
+    }
+    const controller = new AbortController();
+    userAgendaAbortController = controller;
+    showUserAgendaSpinner();
+    try {
+      const response = await fetch('/agenda?source=user', {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+          'Accept': 'text/html, application/json',
+        },
+        credentials: 'same-origin',
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error('Não foi possível carregar sua agenda.');
+      }
+      const contentType = response.headers.get('Content-Type') || '';
+      let html = '';
+      if (contentType.includes('application/json')) {
+        const data = await response.json().catch(() => ({}));
+        html = (data && data.html) || '';
+      } else {
+        html = await response.text();
+      }
+      if (controller.signal.aborted) {
+        return;
+      }
+      if (html && html.trim()) {
+        renderUserAgendaHtml(html);
+      } else {
+        renderUserAgendaMessage('Nenhum compromisso encontrado para o período.', 'info');
+      }
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return;
+      }
+      const fallback = (error && error.message) ? error.message : 'Não foi possível carregar sua agenda.';
+      renderUserAgendaMessage(fallback, 'danger');
+    } finally {
+      if (userAgendaAbortController === controller) {
+        userAgendaAbortController = null;
+      }
+    }
+  }
+
+  function handleSourceChange(newSource) {
+    if (!showUserButtonFlag || !agendaUserContainer) {
+      return;
+    }
+    if (newSource === 'user') {
+      loadUserAgenda();
+    } else {
+      hideUserAgendaContainer();
+    }
+  }
+
   if (adminInitialView === 'veterinario') {
     source = 'vet';
   } else if (adminInitialView === 'colaborador') {
@@ -361,6 +481,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   notifyVetSelectionChange();
+  handleSourceChange(source);
 
   function eventUrl() {
     if (source === 'clinic') {
@@ -571,6 +692,7 @@ document.addEventListener('DOMContentLoaded', function() {
         selectedUserId = null;
       }
       setActiveButton(source);
+      handleSourceChange(source);
     } else {
       updateCollaboratorPickerValue(source);
     }
@@ -747,6 +869,7 @@ document.addEventListener('DOMContentLoaded', function() {
           source = target;
         }
         setActiveButton(source);
+        handleSourceChange(source);
         addEvents({ refetch: true });
       });
     });
@@ -759,6 +882,7 @@ document.addEventListener('DOMContentLoaded', function() {
         selectedVetId = null;
         notifyVetSelectionChange();
         source = 'clinic';
+        handleSourceChange(source);
         setActiveButton(source);
         addEvents({ refetch: true });
         return;
@@ -767,6 +891,7 @@ document.addEventListener('DOMContentLoaded', function() {
         selectedVetId = null;
         notifyVetSelectionChange();
         source = 'user';
+        handleSourceChange(source);
         setActiveButton(source);
         addEvents({ refetch: true });
         return;
@@ -780,6 +905,7 @@ document.addEventListener('DOMContentLoaded', function() {
       source = defaultSource;
       selectedVetId = null;
       notifyVetSelectionChange();
+      handleSourceChange(source);
       setActiveButton(source);
       addEvents({ refetch: true });
     });
@@ -801,6 +927,7 @@ document.addEventListener('DOMContentLoaded', function() {
         selectedUserId = null;
       }
       source = 'user';
+      handleSourceChange(source);
       setActiveButton(source);
       addEvents({ refetch: true });
     });

--- a/templates/partials/vet_agenda_summary.html
+++ b/templates/partials/vet_agenda_summary.html
@@ -1,0 +1,114 @@
+{% set vet_name = veterinario.user.name if veterinario.user else veterinario.name %}
+{% set period_start = start_dt %}
+{% set period_finish = period_end if period_end is defined and period_end else (end_dt - timedelta(days=1) if end_dt else None) %}
+{% set kind_labels = {
+  'consulta': 'Consulta',
+  'retorno': 'Retorno',
+  'exame': 'Exame',
+  'banho_tosa': 'Banho e tosa',
+  'vacina': 'Vacina'
+} %}
+<div class="card border-0 shadow-sm">
+  <div class="card-header bg-white border-0 pb-2">
+    <h5 class="mb-1 fw-semibold">
+      <i class="bi bi-calendar-check me-2"></i>Minha agenda
+    </h5>
+    <div class="text-muted small">
+      {{ vet_name or 'Veterinário' }}
+      {% if period_start %}
+        · {{ period_start|format_datetime_brazil('%d/%m/%Y') }}
+        {% if period_finish %}
+          – {{ period_finish|format_datetime_brazil('%d/%m/%Y') }}
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
+  <div class="card-body pt-0">
+    <section class="mb-4">
+      <h6 class="fw-semibold text-primary">Agendamentos pendentes</h6>
+      <ul class="list-group list-group-flush">
+        {% for item in appointments_pending %}
+          {% set appt = item.appt %}
+          {% set animal_name = appt.animal.name if appt.animal else 'Animal não informado' %}
+          {% if item.kind == 'exame' %}
+            {% set owner_name = appt.animal.owner.name if appt.animal and appt.animal.owner else None %}
+          {% else %}
+            {% set owner_name = appt.tutor.name if appt.tutor else (appt.animal.owner.name if appt.animal and appt.animal.owner else None) %}
+          {% endif %}
+          <li class="list-group-item px-0">
+            <div class="d-flex flex-column">
+              <div class="d-flex flex-wrap align-items-center gap-2">
+                <span class="fw-semibold">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</span>
+                <span class="badge bg-primary-subtle text-primary">{{ kind_labels.get(item.kind, item.kind|capitalize) }}</span>
+              </div>
+              <div class="text-muted small mt-1">
+                {{ animal_name }}{% if owner_name %} · Tutor: {{ owner_name }}{% endif %}
+              </div>
+              {% if appt.time_left is defined %}
+              <div class="text-muted small mt-1">
+                Tempo para responder: {{ appt.time_left|format_timedelta }}
+              </div>
+              {% endif %}
+            </div>
+          </li>
+        {% else %}
+          <li class="list-group-item px-0 text-muted small">Nenhum agendamento pendente.</li>
+        {% endfor %}
+      </ul>
+    </section>
+
+    <section class="mb-4">
+      <h6 class="fw-semibold text-primary">Próximos compromissos</h6>
+      <ul class="list-group list-group-flush">
+        {% for item in appointments_upcoming %}
+          {% set appt = item.appt %}
+          {% set animal_name = appt.animal.name if appt.animal else 'Animal não informado' %}
+          {% if item.kind == 'exame' %}
+            {% set owner_name = appt.animal.owner.name if appt.animal and appt.animal.owner else None %}
+          {% else %}
+            {% set owner_name = appt.tutor.name if appt.tutor else (appt.animal.owner.name if appt.animal and appt.animal.owner else None) %}
+          {% endif %}
+          <li class="list-group-item px-0">
+            <div class="d-flex flex-column">
+              <div class="d-flex flex-wrap align-items-center gap-2">
+                <span class="fw-semibold">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</span>
+                <span class="badge bg-secondary-subtle text-secondary">{{ kind_labels.get(item.kind, item.kind|capitalize) }}</span>
+              </div>
+              <div class="text-muted small mt-1">
+                {{ animal_name }}{% if owner_name %} · Tutor: {{ owner_name }}{% endif %}
+              </div>
+              {% if appt.notes %}
+              <div class="text-muted small mt-1">Observações: {{ appt.notes }}</div>
+              {% endif %}
+            </div>
+          </li>
+        {% else %}
+          <li class="list-group-item px-0 text-muted small">Nenhum compromisso futuro registrado.</li>
+        {% endfor %}
+      </ul>
+    </section>
+
+    {% if schedule_events %}
+    <section>
+      <h6 class="fw-semibold text-primary">Atividades recentes</h6>
+      <ul class="list-unstyled mb-0">
+        {% for event in schedule_events[:6] %}
+          {% set event_label_map = {
+            'consulta_finalizada': 'Consulta finalizada',
+            'consulta_aceita': 'Consulta aceita',
+            'retorno': 'Retorno programado',
+            'exame': 'Exame agendado'
+          } %}
+          <li class="mb-2">
+            <div class="fw-semibold">{{ event.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') if event.timestamp else 'Data não informada' }}</div>
+            <div class="text-muted small">
+              {{ event_label_map.get(event.kind, event.kind|replace('_', ' ')|capitalize) }}
+              {% if event.animal %} · {{ event.animal.name }}{% endif %}
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+    {% endif %}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add `get_agenda_data` helper so both `/appointments` and the new `/agenda` endpoint reuse veterinarian agenda queries
- update the scheduling toggle to hide the "Minha Agenda" button from non-veterinarians and asynchronously fetch the vet agenda snippet into the page
- include hidden `<template>` blocks for appointment metadata and restore the "Agenda de Exames" list so tutor-facing pages still expose exam schedules

## Testing
- pytest tests/test_schedule_exam.py

------
https://chatgpt.com/codex/tasks/task_e_68d5b87ee638832ea31b450033685440