### PR TITLE
Add collaborator agenda tab for veterinarians

### DIFF
--- a/app.py
+++ b/app.py
@@ -7567,7 +7567,8 @@ def appointments():
     from models import ExamAppointment, Veterinario, Clinica, User
 
     view_as = request.args.get('view_as')
-    worker = current_user.worker
+    actual_worker = current_user.worker
+    worker = actual_worker
 
     def _redirect_to_current_appointments():
         query_args = request.args.to_dict(flat=False)
@@ -7579,11 +7580,14 @@ def appointments():
         if current_user.role == 'admin' and view_as in allowed_views:
             worker = view_as
         elif current_user.role != 'admin':
-            # Non-admin users can only request the view matching their own role.
-            user_view = worker if worker in allowed_views else 'tutor'
-            if view_as not in allowed_views or view_as != user_view:
+            user_allowed_views = {
+                'veterinario': {'veterinario', 'colaborador'},
+                'colaborador': {'colaborador'},
+            }.get(actual_worker, {'tutor'})
+            if view_as not in allowed_views or view_as not in user_allowed_views:
                 flash('Você não tem permissão para acessar essa visão de agenda.', 'warning')
                 return redirect(url_for('appointments'))
+            worker = view_as
 
     agenda_users = []
     agenda_veterinarios = []
@@ -8055,6 +8059,9 @@ def appointments():
         if worker in ['colaborador', 'admin']:
             appointment_form = AppointmentForm(prefix='appointment')
             clinica_id = current_user.clinica_id
+            if not clinica_id and actual_worker == 'veterinario':
+                veterinario_profile = getattr(current_user, 'veterinario', None)
+                clinica_id = getattr(veterinario_profile, 'clinica_id', None)
             if current_user.role == 'admin' and worker == 'colaborador':
                 colaborador_id_arg = request.args.get('colaborador_id', type=int)
                 if colaborador_id_arg:

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -1,6 +1,10 @@
 {% extends "layout.html" %}
 
 {% block main %}
+{% set requested_tab = request.args.get('tab') %}
+{% set show_collaborator_tab = form is not none %}
+{% set default_tab = 'colaborador' if show_collaborator_tab and (request.args.get('view_as') == 'colaborador' or current_user.worker == 'colaborador') else 'calendar' %}
+{% set active_tab = requested_tab if requested_tab in ['calendar', 'agendamento', 'colaborador'] else default_tab %}
 <section class="container py-4" aria-labelledby="appointments-calendar-title">
 
   <!-- Cabeçalho -->
@@ -39,32 +43,51 @@
         >
           <li class="nav-item" role="presentation">
             <button
-              class="nav-link active"
+              class="nav-link{% if active_tab == 'calendar' %} active{% endif %}"
               id="calendar-tab-experimental"
               data-bs-toggle="tab"
               data-bs-target="#calendar-pane-experimental"
               type="button"
               role="tab"
               aria-controls="calendar-pane-experimental"
-              aria-selected="true"
+              aria-selected="{{ 'true' if active_tab == 'calendar' else 'false' }}"
+              {% if active_tab != 'calendar' %}tabindex="-1"{% endif %}
             >
               <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
             </button>
           </li>
           <li class="nav-item" role="presentation">
             <button
-              class="nav-link"
+              class="nav-link{% if active_tab == 'agendamento' %} active{% endif %}"
               id="calendar-tab-full"
               data-bs-toggle="tab"
               data-bs-target="#calendar-pane-full"
               type="button"
               role="tab"
               aria-controls="calendar-pane-full"
-              aria-selected="false"
+              aria-selected="{{ 'true' if active_tab == 'agendamento' else 'false' }}"
+              {% if active_tab != 'agendamento' %}tabindex="-1"{% endif %}
             >
               <i class="bi bi-calendar3 me-1"></i> Agendamento
             </button>
           </li>
+          {% if show_collaborator_tab %}
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link{% if active_tab == 'colaborador' %} active{% endif %}"
+              id="calendar-tab-collaborator"
+              data-bs-toggle="tab"
+              data-bs-target="#calendar-pane-collaborator"
+              type="button"
+              role="tab"
+              aria-controls="calendar-pane-collaborator"
+              aria-selected="{{ 'true' if active_tab == 'colaborador' else 'false' }}"
+              {% if active_tab != 'colaborador' %}tabindex="-1"{% endif %}
+            >
+              <i class="bi bi-people-gear me-1"></i> Painel do Colaborador
+            </button>
+          </li>
+          {% endif %}
         </ul>
         <button
           type="button"
@@ -82,7 +105,7 @@
 
       <div class="tab-content mt-3" id="appointments-calendar-content">
         <div
-          class="tab-pane fade calendar-tab-pane show active pt-2"
+          class="tab-pane fade calendar-tab-pane pt-2{% if active_tab == 'calendar' %} show active{% endif %}"
           id="calendar-pane-experimental"
           role="tabpanel"
           aria-labelledby="calendar-tab-experimental"
@@ -103,7 +126,7 @@
           {% endwith %}
         </div>
         <div
-          class="tab-pane fade calendar-tab-pane pt-2"
+          class="tab-pane fade calendar-tab-pane pt-2{% if active_tab == 'agendamento' %} show active{% endif %}"
           id="calendar-pane-full"
           role="tabpanel"
           aria-labelledby="calendar-tab-full"
@@ -113,6 +136,182 @@
             {% include 'partials/schedule_toggle.html' %}
           {% endwith %}
         </div>
+        {% if show_collaborator_tab %}
+        <div
+          class="tab-pane fade calendar-tab-pane pt-2{% if active_tab == 'colaborador' %} show active{% endif %}"
+          id="calendar-pane-collaborator"
+          role="tabpanel"
+          aria-labelledby="calendar-tab-collaborator"
+          tabindex="0"
+        >
+          <!-- Gerenciar horários (novo + editar) -->
+          <div class="card border-0 shadow-lg rounded-4 mb-5">
+            <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
+              <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
+              <div>
+                <button id="openScheduleModal" class="btn btn-light btn-sm me-2" type="button">
+                  <i class="bi bi-pencil"></i> Editar Horário
+                </button>
+                <button class="btn btn-success btn-sm" data-bs-toggle="collapse" data-bs-target="#newAppointmentForm">
+                  <i class="bi bi-plus-circle"></i> Nova Consulta
+                </button>
+              </div>
+            </div>
+
+            <div class="collapse" id="newAppointmentForm">
+              <div class="card-body p-4">
+                {% if form %}
+                <form method="POST">
+                  {{ form.hidden_tag() }}
+                  <div class="row g-3">
+                    <div class="col-md-6">
+                      {{ form.animal_id.label(class="form-label fw-semibold") }}
+                      {{ form.animal_id(class="form-select") }}
+                    </div>
+                    <div class="col-md-6">
+                      {{ form.veterinario_id.label(class="form-label fw-semibold") }}
+                      {{ form.veterinario_id(class="form-select") }}
+                    </div>
+                  </div>
+
+                  <div class="row g-3 mt-2">
+                    <div class="col-md-6">
+                      {{ form.date.label(class="form-label fw-semibold") }}
+                      {{ form.date(class="form-control", type="date") }}
+                    </div>
+                    <div class="col-md-6">
+                      {{ form.time.label(class="form-label fw-semibold") }}
+                      <select
+                        id="{{ form.time.id }}"
+                        name="{{ form.time.name }}"
+                        class="form-select"
+                        data-placeholder="Selecione um horário"
+                        data-empty-text="Sem horários disponíveis"
+                        data-current-time="{{ form.time.data.strftime('%H:%M') if form.time.data else '' }}"
+                        {% if form.time.flags.required %}required{% endif %}
+                      >
+                        {% if form.time.data %}
+                          {% set current_time = form.time.data.strftime('%H:%M') %}
+                          <option value="{{ current_time }}" selected>{{ current_time }}</option>
+                        {% else %}
+                          <option value="" selected disabled>Selecione um horário</option>
+                        {% endif %}
+                      </select>
+                    </div>
+                  </div>
+
+                  <div class="mt-3">
+                    {{ form.kind.label(class="form-label fw-semibold") }}
+                    {{ form.kind(class="form-select") }}
+                  </div>
+
+                  <div class="mt-3">
+                    {{ form.reason.label(class="form-label fw-semibold") }}
+                    {{ form.reason(class="form-control", rows=3, placeholder="Motivo da consulta...") }}
+                  </div>
+
+                  <div class="d-grid mt-4">
+                    {{ form.submit(class="btn btn-success btn-lg rounded-pill") }}
+                  </div>
+                </form>
+                <div class="mt-4">
+                  <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3 mb-3">
+                    <div class="d-flex align-items-center flex-wrap gap-2">
+                      <h6 class="fw-bold mb-0">
+                        <i class="bi bi-calendar3 me-2"></i>Disponibilidade do Veterinário
+                      </h6>
+                      <span
+                        class="badge rounded-pill text-bg-light small fw-normal"
+                        data-schedule-summary
+                        aria-live="polite"
+                      >
+                        Selecione um profissional para visualizar a agenda.
+                      </span>
+                    </div>
+                    <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-auto">
+                      <div class="d-flex align-items-center gap-2 small text-muted" data-schedule-legend>
+                        <span class="d-inline-flex align-items-center gap-1">
+                          <i class="bi bi-check-circle-fill text-success"></i>
+                          Disponível
+                        </span>
+                        <span class="d-inline-flex align-items-center gap-1 ms-2">
+                          <i class="bi bi-x-circle-fill text-danger"></i>
+                          Indisponível
+                        </span>
+                        <span class="d-inline-flex align-items-center gap-1 ms-2">
+                          <i class="bi bi-slash-circle-fill text-secondary"></i>
+                          Fora do expediente
+                        </span>
+                      </div>
+                      <button
+                        class="btn btn-outline-primary btn-sm"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#scheduleOverviewCollapse"
+                        aria-expanded="true"
+                        aria-controls="scheduleOverviewCollapse"
+                        data-show-label="Mostrar agenda"
+                        data-hide-label="Ocultar agenda"
+                      >
+                        Ocultar agenda
+                      </button>
+                    </div>
+                  </div>
+                  <div class="d-flex flex-column flex-xl-row align-items-xl-center gap-3 mb-3">
+                    <div class="d-flex align-items-center gap-2 small text-muted">
+                      <i class="bi bi-calendar-week me-1"></i>
+                      <span data-schedule-week-label aria-live="polite">
+                        Aguardando seleção de profissional.
+                      </span>
+                    </div>
+                    <div class="d-flex flex-wrap align-items-center gap-2 ms-xl-auto">
+                      <div class="btn-group btn-group-sm" role="group" aria-label="Navegação da agenda semanal">
+                        <button type="button" class="btn btn-outline-secondary" data-schedule-week-prev>
+                          <i class="bi bi-chevron-left"></i>
+                          <span class="d-none d-sm-inline ms-1">Semana anterior</span>
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" data-schedule-week-today>
+                          Hoje
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" data-schedule-week-next>
+                          <span class="d-none d-sm-inline me-1">Próxima semana</span>
+                          <i class="bi bi-chevron-right"></i>
+                        </button>
+                      </div>
+                      <div class="d-flex align-items-center gap-2">
+                        <label for="schedulePeriodFilter" class="form-label small text-muted mb-0">Período</label>
+                        <select
+                          id="schedulePeriodFilter"
+                          class="form-select form-select-sm w-auto"
+                          data-schedule-period-filter
+                        >
+                          <option value="all">Todos</option>
+                          <option value="morning">Manhã</option>
+                          <option value="afternoon">Tarde</option>
+                          <option value="evening">Noite</option>
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="collapse show" id="scheduleOverviewCollapse">
+                    <div id="schedule-overview" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 small"></div>
+                  </div>
+                </div>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+
+          <div id="appointmentsList" data-appointments-container data-refresh-url="{{ request.url }}">
+            {% include 'partials/appointments_table.html' %}
+            <div class="visually-hidden" aria-hidden="true">
+              {% for appt in appointments %}
+                <span data-appointment-id="{{ appt.id }}"></span>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+        {% endif %}
       </div>
     </div>
     <div class="col-12 col-xl-4 col-xxl-3" data-calendar-summary-column>
@@ -189,169 +388,16 @@
       </div>
     </div>
   </div>
-
-  <!-- Gerenciar horários (novo + editar) -->
-  <div class="card border-0 shadow-lg rounded-4 mb-5">
-    <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
-      <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
-      <div>
-        <button id="openScheduleModal" class="btn btn-light btn-sm me-2" type="button">
-          <i class="bi bi-pencil"></i> Editar Horário
-        </button>
-        <button class="btn btn-success btn-sm" data-bs-toggle="collapse" data-bs-target="#newAppointmentForm">
-          <i class="bi bi-plus-circle"></i> Nova Consulta
-        </button>
-      </div>
-    </div>
-
-    <div class="collapse" id="newAppointmentForm">
-      <div class="card-body p-4">
-        {% if form %}
-        <form method="POST">
-          {{ form.hidden_tag() }}
-          <div class="row g-3">
-            <div class="col-md-6">
-              {{ form.animal_id.label(class="form-label fw-semibold") }}
-              {{ form.animal_id(class="form-select") }}
-            </div>
-            <div class="col-md-6">
-              {{ form.veterinario_id.label(class="form-label fw-semibold") }}
-              {{ form.veterinario_id(class="form-select") }}
-            </div>
-          </div>
-
-          <div class="row g-3 mt-2">
-            <div class="col-md-6">
-              {{ form.date.label(class="form-label fw-semibold") }}
-              {{ form.date(class="form-control", type="date") }}
-            </div>
-            <div class="col-md-6">
-              {{ form.time.label(class="form-label fw-semibold") }}
-              <select
-                id="{{ form.time.id }}"
-                name="{{ form.time.name }}"
-                class="form-select"
-                data-placeholder="Selecione um horário"
-                data-empty-text="Sem horários disponíveis"
-                data-current-time="{{ form.time.data.strftime('%H:%M') if form.time.data else '' }}"
-                {% if form.time.flags.required %}required{% endif %}
-              >
-                {% if form.time.data %}
-                  {% set current_time = form.time.data.strftime('%H:%M') %}
-                  <option value="{{ current_time }}" selected>{{ current_time }}</option>
-                {% else %}
-                  <option value="" selected disabled>Selecione um horário</option>
-                {% endif %}
-              </select>
-            </div>
-          </div>
-
-          <div class="mt-3">
-            {{ form.kind.label(class="form-label fw-semibold") }}
-            {{ form.kind(class="form-select") }}
-          </div>
-
-          <div class="mt-3">
-            {{ form.reason.label(class="form-label fw-semibold") }}
-            {{ form.reason(class="form-control", rows=3, placeholder="Motivo da consulta...") }}
-          </div>
-
-          <div class="d-grid mt-4">
-            {{ form.submit(class="btn btn-success btn-lg rounded-pill") }}
-          </div>
-        </form>
-        <div class="mt-4">
-          <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3 mb-3">
-            <div class="d-flex align-items-center flex-wrap gap-2">
-              <h6 class="fw-bold mb-0">
-                <i class="bi bi-calendar3 me-2"></i>Disponibilidade do Veterinário
-              </h6>
-              <span
-                class="badge rounded-pill text-bg-light small fw-normal"
-                data-schedule-summary
-                aria-live="polite"
-              >
-                Selecione um profissional para visualizar a agenda.
-              </span>
-            </div>
-            <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-auto">
-              <div class="d-flex align-items-center gap-2 small text-muted" data-schedule-legend>
-                <span class="d-inline-flex align-items-center gap-1">
-                  <i class="bi bi-check-circle-fill text-success"></i>
-                  Disponível
-                </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-x-circle-fill text-danger"></i>
-                  Indisponível
-                </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-slash-circle-fill text-secondary"></i>
-                  Fora do expediente
-                </span>
-              </div>
-              <button
-                class="btn btn-outline-primary btn-sm"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#scheduleOverviewCollapse"
-                aria-expanded="true"
-                aria-controls="scheduleOverviewCollapse"
-                data-show-label="Mostrar agenda"
-                data-hide-label="Ocultar agenda"
-              >
-                Ocultar agenda
-              </button>
-            </div>
-          </div>
-          <div class="d-flex flex-column flex-xl-row align-items-xl-center gap-3 mb-3">
-            <div class="d-flex align-items-center gap-2 small text-muted">
-              <i class="bi bi-calendar-week me-1"></i>
-              <span data-schedule-week-label aria-live="polite">
-                Aguardando seleção de profissional.
-              </span>
-            </div>
-            <div class="d-flex flex-wrap align-items-center gap-2 ms-xl-auto">
-              <div class="btn-group btn-group-sm" role="group" aria-label="Navegação da agenda semanal">
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-prev>
-                  <i class="bi bi-chevron-left"></i>
-                  <span class="d-none d-sm-inline ms-1">Semana anterior</span>
-                </button>
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-today>
-                  Hoje
-                </button>
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-next>
-                  <span class="d-none d-sm-inline me-1">Próxima semana</span>
-                  <i class="bi bi-chevron-right"></i>
-                </button>
-              </div>
-              <div class="d-flex align-items-center gap-2">
-                <label for="schedulePeriodFilter" class="form-label small text-muted mb-0">Período</label>
-                <select
-                  id="schedulePeriodFilter"
-                  class="form-select form-select-sm w-auto"
-                  data-schedule-period-filter
-                >
-                  <option value="all">Todos</option>
-                  <option value="morning">Manhã</option>
-                  <option value="afternoon">Tarde</option>
-                  <option value="evening">Noite</option>
-                </select>
-              </div>
-            </div>
-          </div>
-          <div class="collapse show" id="scheduleOverviewCollapse">
-            <div id="schedule-overview" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 small"></div>
-          </div>
-        </div>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-
+  {% if not show_collaborator_tab %}
   <div id="appointmentsList" data-appointments-container data-refresh-url="{{ request.url }}">
     {% include 'partials/appointments_table.html' %}
+    <div class="visually-hidden" aria-hidden="true">
+      {% for appt in appointments %}
+        <span data-appointment-id="{{ appt.id }}"></span>
+      {% endfor %}
+    </div>
   </div>
-
+  {% endif %}
 
 </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -92,7 +92,7 @@
                 </a>
 
                 {% if (current_user.worker == 'veterinario' and current_user.veterinario) or current_user.worker == 'colaborador' %}
-                <a href="{{ url_for('appointments') }}"
+                <a href="{{ url_for('appointments', view_as='colaborador', tab='colaborador') }}"
                    class="btn btn-outline-warning rounded-pill shadow-sm px-4 py-2"
                    data-bs-toggle="tooltip" title="Administre sua agenda de atendimentos.">
                     🗓️ Agenda


### PR DESCRIPTION
## Summary
- allow veterinarians to open the collaborator view by honoring `view_as=colaborador` and reusing their clinic context
- surface a dedicated “Painel do Colaborador” tab inside the appointments calendar with inline appointment identifiers for scripts
- make the home agenda shortcut for vets point to the collaborator experience by default

## Testing
- pytest tests/test_admin_view_switch.py tests/test_collaborator_appointment.py tests/test_colleague_schedule.py

------
https://chatgpt.com/codex/tasks/task_e_68d5c324df6c832eb010a3e28120f0f0