### PR TITLE
Add collapsible calendar toggle on veterinarian detail page

### DIFF
--- a/templates/veterinarios/vet_detail.html
+++ b/templates/veterinarios/vet_detail.html
@@ -42,6 +42,16 @@
         {% include 'partials/admin_agenda_switcher.html' %}
       {% endif %}
       <div class="d-flex flex-wrap justify-content-end gap-2">
+        <button
+          class="btn btn-outline-info mb-1 collapsed"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#vet-calendar-section-{{ veterinario.id }}"
+          aria-expanded="false"
+          aria-controls="vet-calendar-section-{{ veterinario.id }}"
+        >
+          <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
+        </button>
         <button class="btn btn-primary mb-1" onclick="toggleScheduleForm()">
           <i class="fas fa-plus-circle me-1"></i>Adicionar Horário
         </button>
@@ -52,8 +62,12 @@
     </div>
   </div>
 
- 
-  <section class="mb-4" aria-labelledby="vet-calendar-title-{{ veterinario.id }}">
+
+  <section
+    class="mb-4 collapse"
+    id="vet-calendar-section-{{ veterinario.id }}"
+    aria-labelledby="vet-calendar-title-{{ veterinario.id }}"
+  >
     <div class="card shadow-sm border-0">
       <div class="card-header bg-primary bg-gradient text-white">
         <h3 id="vet-calendar-title-{{ veterinario.id }}" class="h5 mb-0">


### PR DESCRIPTION
## Summary
- add a calendar toggle button next to the schedule actions on the veterinarian page
- collapse the veterinarian calendar section by default and link it to the new toggle

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f4e1fb04832eaf93d3d7a2c9e6c8