### PR TITLE
Move vet calendar toggle into schedule header

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -96,13 +96,35 @@
   {% set schedule_toggle_clinic_id = veterinario.clinica_id %}
   {% set schedule_toggle_calendar_redirect_url = url_for('appointments', view_as='veterinario', veterinario_id=veterinario.id) %}
   {% set schedule_toggle_prefer_user_vet_source = True %}
-  {% include 'partials/calendar_layout.html' %}
+  {% set calendar_overview_id = 'vet-calendar-overview-' ~ veterinario.id %}
+  {% set calendar_tabs_id = 'vet-calendar-tabs-' ~ veterinario.id %}
+  {% set calendar_content_id = 'vet-calendar-content-' ~ veterinario.id %}
+  {% set calendar_experimental_tab_id = 'vet-calendar-tab-experimental-' ~ veterinario.id %}
+  {% set calendar_experimental_pane_id = 'vet-calendar-pane-experimental-' ~ veterinario.id %}
+  {% set calendar_full_tab_id = 'vet-calendar-tab-full-' ~ veterinario.id %}
+  {% set calendar_full_pane_id = 'vet-calendar-pane-full-' ~ veterinario.id %}
+  {% set calendar_hide_experimental_tab = True %}
+  {% set vet_calendar_collapse_id = 'vet-calendar-collapse-' ~ veterinario.id %}
+  <div class="collapse" id="{{ vet_calendar_collapse_id }}" data-calendar-collapse>
+    {% include 'partials/calendar_layout.html' %}
+  </div>
 
   <!-- Gerenciar horários e agendamento -->
   <div class="card border-0 shadow-lg rounded-4 mb-5">
     <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
       <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
       <div class="d-flex align-items-center gap-2">
+        <button
+          class="btn btn-light btn-sm collapsed"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#{{ vet_calendar_collapse_id }}"
+          aria-expanded="false"
+          aria-controls="{{ vet_calendar_collapse_id }}"
+          data-calendar-tab-target="#{{ calendar_experimental_tab_id }}"
+        >
+          <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
+        </button>
         <button id="openScheduleModal" class="btn btn-light btn-sm" type="button">
           <i class="bi bi-pencil"></i> Editar Horário
         </button>
@@ -786,6 +808,41 @@
   {{ super() }}
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      const calendarToggleButtons = document.querySelectorAll('[data-calendar-tab-target]');
+
+      calendarToggleButtons.forEach((button) => {
+        const collapseSelector = button.dataset.bsTarget;
+        const tabSelector = button.dataset.calendarTabTarget;
+
+        if (!collapseSelector || !tabSelector) {
+          return;
+        }
+
+        const collapseElement = document.querySelector(collapseSelector);
+        const tabElement = document.querySelector(tabSelector);
+
+        if (!collapseElement || !tabElement) {
+          return;
+        }
+
+        const ensureCalendarTab = () => {
+          if (typeof bootstrap === 'undefined' || !bootstrap.Tab) {
+            return;
+          }
+
+          const tabInstance = bootstrap.Tab.getOrCreateInstance(tabElement);
+          tabInstance.show();
+        };
+
+        collapseElement.addEventListener('show.bs.collapse', ensureCalendarTab);
+
+        button.addEventListener('click', () => {
+          if (!collapseElement.classList.contains('show')) {
+            ensureCalendarTab();
+          }
+        });
+      });
+
       const form = document.getElementById('agenda-filter-form');
       if (!form) return;
 

--- a/templates/partials/calendar_layout.html
+++ b/templates/partials/calendar_layout.html
@@ -6,6 +6,7 @@
 {% set calendar_experimental_tab_id = calendar_experimental_tab_id|default('calendar-tab-experimental') %}
 {% set calendar_full_tab_id = calendar_full_tab_id|default('calendar-tab-full') %}
 {% set calendar_inline_component_id = calendar_inline_component_id|default('tutor-calendar-inline') %}
+{% set calendar_hide_experimental_tab = calendar_hide_experimental_tab|default(False) %}
 {% set calendar_pets_endpoint = calendar_pets_endpoint|default(url_for('api_my_pets')) %}
 {% set calendar_summary_toggle_show_label = calendar_summary_toggle_show_label|default('Mostrar resumo') %}
 {% set calendar_summary_toggle_hide_label = calendar_summary_toggle_hide_label|default('Ocultar resumo') %}
@@ -25,7 +26,7 @@
         aria-label="Alternar entre o calendário e o agendamento"
         data-calendar-tabs
       >
-        <li class="nav-item" role="presentation">
+        <li class="nav-item{% if calendar_hide_experimental_tab %} d-none{% endif %}" role="presentation">
           <button
             class="nav-link active"
             id="{{ calendar_experimental_tab_id }}"


### PR DESCRIPTION
## Summary
- collapse the veterinarian calendar layout by default and move the calendar toggle button into the manage schedule header
- hide the original calendar tab within the shared partial while keeping calendar activation hooked to the new toggle

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d60213b7f0832eb4688f83b219b083