### PR TITLE
Reorganize vet calendar collapse layout

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -105,9 +105,6 @@
   {% set calendar_full_pane_id = 'vet-calendar-pane-full-' ~ veterinario.id %}
   {% set calendar_hide_experimental_tab = True %}
   {% set vet_calendar_collapse_id = 'vet-calendar-collapse-' ~ veterinario.id %}
-  <div class="collapse" id="{{ vet_calendar_collapse_id }}" data-calendar-collapse>
-    {% include 'partials/calendar_layout.html' %}
-  </div>
 
   <!-- Gerenciar horários e agendamento -->
   <div class="card border-0 shadow-lg rounded-4 mb-5">
@@ -137,6 +134,11 @@
         >
           <i class="bi bi-plus-circle"></i> Nova Consulta
         </button>
+      </div>
+    </div>
+    <div class="collapse" id="{{ vet_calendar_collapse_id }}" data-calendar-collapse>
+      <div class="card-body border-top p-4">
+        {% include 'partials/calendar_layout.html' %}
       </div>
     </div>
     <div class="collapse" id="newAppointmentForm">


### PR DESCRIPTION
## Summary
- move the veterinary calendar collapse container inside the schedule management card so it appears directly beneath the header
- wrap the calendar layout include in a card body section to keep styling consistent while using the existing toggle button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60af94d24832e93d8147c793751cd