### PR TITLE
Improve tutor calendar close button visibility

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -96,7 +96,8 @@
                     data-close-day-detail
                     aria-label="Fechar detalhes do dia"
                   >
-                    <i class="bi bi-x-lg" aria-hidden="true"></i>
+                    <span class="visually-hidden">Fechar detalhes do dia</span>
+                    <span class="tutor-calendar__day-detail-close-icon" aria-hidden="true">&times;</span>
                   </button>
                 </div>
                 <div class="tutor-calendar__day-detail-content" data-day-detail-content>
@@ -655,6 +656,13 @@
   align-items: center;
   justify-content: center;
   transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+#{{ component_id }} .tutor-calendar__day-detail-close-icon {
+  display: block;
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-close:hover,


### PR DESCRIPTION
## Summary
- replace the close button icon with an accessible text-based glyph so it always renders
- add styling for the new glyph to keep the close control properly sized

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d60b419f54832e908eda56d2ec52bd