### PR TITLE
Fix overlapping day detail header controls

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -669,8 +669,15 @@
   box-shadow: 0 0 0 0.2rem rgba(99, 102, 241, 0.25);
 }
 
+#{{ component_id }} .tutor-calendar__day-detail-back {
+  max-width: min(220px, 60vw);
+}
+
 #{{ component_id }} .tutor-calendar__day-detail-back-text {
-  white-space: nowrap;
+  display: inline-block;
+  white-space: normal;
+  line-height: 1.2;
+  text-align: left;
 }
 
 #{{ component_id }} .tutor-calendar__day-detail-content {


### PR DESCRIPTION
## Summary
- limit the width of the day detail back button and allow its label to wrap so it no longer overlaps nearby content

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d60b76d0b4832ea7d9f4638d79f5c0