### PR TITLE
Persist admin agenda selection between visits

### DIFF
--- a/app.py
+++ b/app.py
@@ -3472,6 +3472,7 @@ def vet_detail(veterinario_id):
 
     schedule_form = VetScheduleForm(prefix='schedule')
     appointment_form = AppointmentForm(is_veterinario=True, prefix='appointment')
+    admin_default_selection_value = ''
 
     if current_user.role == 'admin':
         agenda_veterinarios = (
@@ -3486,6 +3487,11 @@ def vet_detail(veterinario_id):
         admin_selected_view = 'veterinario'
         admin_selected_veterinario_id = veterinario.id
         admin_selected_colaborador_id = None
+        default_vet = getattr(current_user, 'veterinario', None)
+        if default_vet and getattr(default_vet, 'id', None):
+            admin_default_selection_value = f'veterinario:{default_vet.id}'
+        else:
+            admin_default_selection_value = f'veterinario:{veterinario.id}'
     else:
         agenda_veterinarios = []
         agenda_colaboradores = []
@@ -3544,6 +3550,7 @@ def vet_detail(veterinario_id):
         admin_selected_view=admin_selected_view,
         admin_selected_veterinario_id=admin_selected_veterinario_id,
         admin_selected_colaborador_id=admin_selected_colaborador_id,
+        admin_default_selection_value=admin_default_selection_value,
     )
 
 
@@ -7590,6 +7597,7 @@ def appointments():
     agenda_colaboradores = []
     admin_selected_veterinario_id = None
     admin_selected_colaborador_id = None
+    admin_default_selection_value = ''
     selected_colaborador = None
     calendar_summary_vets = []
     calendar_summary_clinic_ids = []
@@ -7605,6 +7613,9 @@ def appointments():
             .order_by(User.name)
             .all()
         )
+        default_vet = getattr(current_user, 'veterinario', None)
+        if default_vet and getattr(default_vet, 'id', None):
+            admin_default_selection_value = f'veterinario:{default_vet.id}'
 
     admin_selected_view = (
         worker
@@ -8301,6 +8312,7 @@ def appointments():
             admin_selected_view=admin_selected_view,
             admin_selected_veterinario_id=admin_selected_veterinario_id,
             admin_selected_colaborador_id=admin_selected_colaborador_id,
+            admin_default_selection_value=admin_default_selection_value,
             calendar_summary_vets=calendar_summary_vets,
             calendar_summary_clinic_ids=calendar_summary_clinic_ids,
         )

--- a/templates/partials/admin_agenda_switcher.html
+++ b/templates/partials/admin_agenda_switcher.html
@@ -8,7 +8,9 @@
   {% set _default_option_label = switcher_default_option_label|default('Minha agenda (admin)') %}
   {% set _select_id = switcher_select_id|default('admin-agenda-picker') %}
   {% set _preserve_params = preserve_params|default([]) %}
-  <form action="{{ url_for('appointments') }}" method="get" class="{{ _form_classes }}" data-admin-agenda-switcher>
+  {% set _default_selection_value = admin_default_selection_value|default('') %}
+  {% set _current_user_id = current_user.id if current_user.is_authenticated else '' %}
+  <form action="{{ url_for('appointments') }}" method="get" class="{{ _form_classes }}" data-admin-agenda-switcher data-admin-user-id="{{ _current_user_id }}"{% if _default_selection_value %} data-admin-default-selection="{{ _default_selection_value }}"{% endif %}>
     {% for param in _preserve_params %}
       {% set value = request.args.get(param) %}
       {% if value %}
@@ -78,9 +80,92 @@
             colabInput.value = id || '';
           }
         }
+        const formDataset = form.dataset || {};
+        const storageKey = (function() {
+          if (typeof window === 'undefined') {
+            return null;
+          }
+          const rawUserId = formDataset.adminUserId || '';
+          if (!rawUserId) {
+            return null;
+          }
+          return 'adminAgendaSelection:' + String(rawUserId);
+        })();
+        const defaultSelection = formDataset.adminDefaultSelection || '';
+
+        function findOptionByValue(value) {
+          if (value === undefined || value === null) {
+            return null;
+          }
+          const stringValue = String(value);
+          return Array.from(select.options || []).find(function(option) {
+            return option.value === stringValue;
+          }) || null;
+        }
+
+        function readStoredSelection() {
+          if (!storageKey || typeof window === 'undefined' || !window.localStorage) {
+            return null;
+          }
+          try {
+            return window.localStorage.getItem(storageKey);
+          } catch (error) {
+            return null;
+          }
+        }
+
+        function persistSelection(value) {
+          if (!storageKey || typeof window === 'undefined' || !window.localStorage) {
+            return;
+          }
+          try {
+            if (value) {
+              window.localStorage.setItem(storageKey, value);
+            } else {
+              window.localStorage.removeItem(storageKey);
+            }
+          } catch (error) {
+            /* Ignore storage errors. */
+          }
+        }
+
+        function applyInitialSelection() {
+          let storedValue = readStoredSelection();
+          const hasDefault = !!(defaultSelection && findOptionByValue(defaultSelection));
+          if (!storedValue && hasDefault) {
+            storedValue = defaultSelection;
+          } else if (storedValue && !findOptionByValue(storedValue)) {
+            storedValue = hasDefault ? defaultSelection : '';
+            persistSelection(storedValue);
+          }
+          if (storedValue && storedValue !== select.value && findOptionByValue(storedValue)) {
+            select.value = storedValue;
+            updateHiddenInputs(storedValue);
+            if (typeof window !== 'undefined') {
+              const params = new URLSearchParams(window.location.search || '');
+              const targetView = viewInput.value || '';
+              const targetVet = vetInput.value || '';
+              const targetColab = colabInput.value || '';
+              const paramView = params.get('view_as') || '';
+              const paramVet = params.get('veterinario_id') || '';
+              const paramColab = params.get('colaborador_id') || '';
+              if (paramView !== targetView || paramVet !== targetVet || paramColab !== targetColab) {
+                persistSelection(storedValue);
+                form.submit();
+                return;
+              }
+            }
+            persistSelection(storedValue);
+          } else if (hasDefault && storedValue !== defaultSelection) {
+            persistSelection(defaultSelection);
+          }
+        }
+
         updateHiddenInputs(select.value);
+        applyInitialSelection();
         select.addEventListener('change', function() {
           updateHiddenInputs(this.value);
+          persistSelection(this.value);
           if (window.handleVetChange) {
             window.handleVetChange();
           }


### PR DESCRIPTION
## Summary
- expose each admin user's default agenda option so the switcher can seed a preference value
- enhance the admin agenda switcher to read/write the last selection in localStorage and auto-apply it on load

## Testing
- pytest tests/test_admin_view_switch.py::test_admin_collaborator_post_preserves_query_and_lists_new_appointment -q *(fails: known existing assertion expecting data-appointment-id markup)*

------
https://chatgpt.com/codex/tasks/task_e_68daa71f52d8832e94dfbef9cd652abb