### PR TITLE
Remove clinic invite navigation link

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -467,17 +467,6 @@
 
                             {% if current_user.worker == 'veterinario' %}
                                 <li class="nav-item position-relative">
-                                    <a class="nav-link" href="{{ url_for('clinic_invites') }}">
-                                        <i class="fas fa-envelope me-1 text-warning"></i> Convites
-                                        {% if pending_clinic_invites > 0 %}
-                                            <span class="badge rounded-pill bg-danger position-absolute top-0 start-100 translate-middle">{{ pending_clinic_invites }}</span>
-                                        {% endif %}
-                                    </a>
-                                </li>
-                            {% endif %}
-
-                            {% if current_user.worker == 'veterinario' %}
-                                <li class="nav-item position-relative">
                                     <a class="nav-link" href="{{ url_for('appointments') }}">
                                         <i class="fas fa-calendar-alt me-1 text-success"></i> Agenda
                                         {% set total_pending = pending_exam_count + pending_appointment_count + clinic_pending_appointment_count %}


### PR DESCRIPTION
## Summary
- remove the clinic invites navigation item and badge from the main layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de4fa70c48832ea2ee65b656d37e11