### PR TITLE
Integrate clinic invites into messages page

### DIFF
--- a/templates/mensagens/mensagens.html
+++ b/templates/mensagens/mensagens.html
@@ -1,5 +1,133 @@
 {% extends "layout.html" %}
 {% block main %}
+{% if show_clinic_invites %}
+<div id="convites-clinica" class="py-4">
+    <div class="row justify-content-center">
+        <div class="col-12 col-lg-10 col-xl-8">
+            <h2 class="h3 mb-4">Convites de Clínicas</h2>
+            {% if missing_vet_profile %}
+            <div class="card shadow-sm border-0">
+                <div class="card-body p-4 p-md-5" role="region" aria-labelledby="vet-profile-heading">
+                    <div class="row g-4 align-items-start">
+                        <div class="col-12 col-lg-5">
+                            <h3 id="vet-profile-heading" class="h5 mb-3">Complete seu cadastro de veterinário</h3>
+                            <p class="text-muted mb-3">{{ missing_vet_profile_message }}</p>
+                            <p class="text-muted small mb-0">Assim que finalizar, os convites das clínicas que chamaram você aparecerão aqui automaticamente.</p>
+                        </div>
+                        {% if vet_profile_form %}
+                        <div class="col-12 col-lg-7">
+                            <form id="vet-profile-form" method="post" action="{{ url_for('clinic_invites') }}" class="row g-3 needs-validation" novalidate>
+                                {{ vet_profile_form.hidden_tag() }}
+                                <div class="col-12 col-md-6">
+                                    <label for="{{ vet_profile_form.crmv.id }}" class="form-label">CRMV</label>
+                                    {{ vet_profile_form.crmv(class="form-control" + (' is-invalid' if vet_profile_form.crmv.errors else ''), placeholder="UF-00000") }}
+                                    {% if vet_profile_form.crmv.errors %}
+                                    <div class="invalid-feedback d-block">{{ vet_profile_form.crmv.errors[0] }}</div>
+                                    {% else %}
+                                    <div class="form-text">Informe o número completo, incluindo a UF quando houver.</div>
+                                    {% endif %}
+                                </div>
+                                <div class="col-12 col-md-6">
+                                    <label for="{{ vet_profile_form.phone.id }}" class="form-label">Telefone profissional <span class="text-muted">(opcional)</span></label>
+                                    {{ vet_profile_form.phone(class="form-control" + (' is-invalid' if vet_profile_form.phone.errors else ''), placeholder="(00) 00000-0000") }}
+                                    {% if vet_profile_form.phone.errors %}
+                                    <div class="invalid-feedback d-block">{{ vet_profile_form.phone.errors[0] }}</div>
+                                    {% else %}
+                                    <div class="form-text">Esse contato fica disponível para a clínica após a associação.</div>
+                                    {% endif %}
+                                </div>
+                                <div class="col-12">
+                                    <button type="submit" class="btn btn-primary">Salvar cadastro</button>
+                                </div>
+                            </form>
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            {% elif clinic_invites %}
+            <div class="row gy-4">
+                {% for invite in clinic_invites %}
+                <div class="col-12">
+                    <article class="card shadow-sm h-100" aria-labelledby="invite-title-{{ invite.id }}">
+                        <div class="card-body">
+                            <div class="d-flex flex-column flex-md-row align-items-start gap-3">
+                                <div class="flex-shrink-0">
+                                    {% if invite.clinica.logo_url %}
+                                    <img src="{{ invite.clinica.logo_url }}"
+                                         alt="Logo da clínica {{ invite.clinica.nome }}"
+                                         class="rounded border"
+                                         style="width: 96px; height: 96px; object-fit: cover;">
+                                    {% else %}
+                                    <div class="bg-light border rounded d-flex align-items-center justify-content-center"
+                                         style="width: 96px; height: 96px;">
+                                        <span class="text-muted fw-semibold small text-center">Sem logo</span>
+                                    </div>
+                                    {% endif %}
+                                </div>
+                                <div class="flex-grow-1 w-100">
+                                    <header class="mb-2">
+                                        <h3 id="invite-title-{{ invite.id }}" class="h5 mb-2">{{ invite.clinica.nome }}</h3>
+                                        {% if invite.clinica.endereco %}
+                                        <p class="mb-1 text-muted">
+                                            <span class="me-1" aria-hidden="true">📍</span>
+                                            <span>{{ invite.clinica.endereco }}</span>
+                                        </p>
+                                        {% endif %}
+                                        {% if invite.clinica.owner %}
+                                        <p class="mb-0 text-muted">
+                                            <span class="me-1" aria-hidden="true">👤</span>
+                                            Proprietário: <span class="fw-semibold">{{ invite.clinica.owner.name }}</span>
+                                        </p>
+                                        {% endif %}
+                                    </header>
+                                    <p class="text-muted mb-3">
+                                        A clínica convidou você para integrar a equipe e atender pacientes pela plataforma.
+                                        {% if invite.created_at %}
+                                        Convite enviado em <span class="fw-semibold">{{ invite.created_at|datetime_brazil }}</span>.
+                                        {% endif %}
+                                    </p>
+                                    <div class="mt-auto">
+                                        <div class="d-flex flex-column flex-sm-row gap-2" role="group" aria-label="Ações para o convite da clínica {{ invite.clinica.nome }}">
+                                            <form method="post"
+                                                  action="{{ url_for('respond_clinic_invite', invite_id=invite.id, action='accept') }}"
+                                                  class="d-inline"
+                                                  aria-label="Aceitar convite da clínica {{ invite.clinica.nome }}">
+                                                {{ clinic_invite_form.hidden_tag() }}
+                                                <button type="submit" class="btn btn-primary w-100">Aceitar</button>
+                                            </form>
+                                            <form method="post"
+                                                  action="{{ url_for('respond_clinic_invite', invite_id=invite.id, action='decline') }}"
+                                                  class="d-inline"
+                                                  aria-label="Recusar convite da clínica {{ invite.clinica.nome }}">
+                                                {{ clinic_invite_form.hidden_tag() }}
+                                                <button type="submit" class="btn btn-outline-secondary w-100">Recusar</button>
+                                            </form>
+                                        </div>
+                                        <p class="text-muted small mt-3 mb-0">
+                                            Aceitar adiciona esta clínica ao seu perfil e libera os recursos dela. Recusar mantém tudo como está.
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                </div>
+                {% endfor %}
+            </div>
+            {% else %}
+            <div class="card shadow-sm border-0">
+                <div class="card-body text-center py-5" role="status" aria-live="polite">
+                    <h3 class="h5">Nenhum convite por aqui</h3>
+                    <p class="text-muted mb-2">Quando uma clínica cadastrar seu e-mail para colaboração, você receberá um convite por e-mail e ele aparecerá aqui.</p>
+                    <p class="text-muted mb-0">Combine com a clínica qual endereço de e-mail você usa no PetOrlândia para que o convite chegue corretamente.</p>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endif %}
 <h2>Minhas Mensagens Recebidas 📥</h2>
 
 {% if mensagens %}


### PR DESCRIPTION
## Summary
- load pending clinic invites and veterinarian profile forms inside the messages view for veterinarians
- render the clinic invite cards and guidance directly on the messages page using the existing layout and forms
- redirect the legacy clinic invites endpoint to the messages anchor and extend tests to cover the new rendering and redirects

## Testing
- pytest tests/test_clinic_invites_template.py

------
https://chatgpt.com/codex/tasks/task_e_68de4fa85970832e982a9d452e8a3131