### PR TITLE
Allow veterinarians to schedule colleagues

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -3,7 +3,8 @@
 {% block main %}
 <div class="container mt-4"
      data-vet-schedule-root
-     data-vet-id="{{ veterinario.id }}"
+     data-vet-id="{{ appointment_form.veterinario_id.data or veterinario.id }}"
+     data-default-vet-id="{{ appointment_form.veterinario_id.data or veterinario.id }}"
      data-appointments-base-url="{{ url_for('appointments') }}"
      data-csrf-token="{{ csrf_token() if csrf_token is defined else '' }}">
   <!-- Cabeçalho melhorado -->
@@ -88,7 +89,7 @@
             </div>
             <div class="col-md-6">
               {{ appointment_form.veterinario_id.label(class="form-label fw-semibold") }}
-              {{ appointment_form.veterinario_id(class="form-select") }}
+              {{ appointment_form.veterinario_id(class="form-select", data_vet_select="true") }}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- load the selected veterinarian (or eligible colleagues from shared clinics) when a vet schedules an appointment
- surface the veterinarian selector in the vet agenda template and teach the JS to react to runtime vet changes
- cover the colleague scheduling flow with a dedicated unit test

## Testing
- pytest tests/test_appointment_vet.py

------
https://chatgpt.com/codex/tasks/task_e_68de5436e6e4832ea0ba5e4b78da9dfc