### PR TITLE
Persist tutor sort preference

### DIFF
--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -109,6 +109,12 @@ document.addEventListener('DOMContentLoaded', function() {
   const sortSelect = document.getElementById('tutor-sort');
   const container = document.getElementById('tutor-cards');
   const cards = Array.from(container.querySelectorAll('[data-name]'));
+  const sortStorageKey = 'tutorSortPreference';
+
+  const savedSort = localStorage.getItem(sortStorageKey);
+  if (savedSort && Array.from(sortSelect.options).some(option => option.value === savedSort)) {
+    sortSelect.value = savedSort;
+  }
 
   function getAge(card) {
     if (!card.dataset.dob) return 0;
@@ -152,7 +158,10 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   filterInput.addEventListener('input', () => { applyFilter(); applySort(); });
-  sortSelect.addEventListener('change', applySort);
+  sortSelect.addEventListener('change', () => {
+    localStorage.setItem(sortStorageKey, sortSelect.value);
+    applySort();
+  });
   applySort();
 });
 </script>


### PR DESCRIPTION
## Summary
- load the tutor sort selector using the last option stored in local storage
- persist newly chosen sort order preferences so the selection remains across visits

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df9f83e3f8832ebf06a32f39ec3612