### PR TITLE
Ensure vet schedule toggle initializes after DOM is ready

### DIFF
--- a/static/appointments_vet.js
+++ b/static/appointments_vet.js
@@ -1207,7 +1207,15 @@ if (typeof window !== 'undefined') {
   window.initVetSchedulePage = (options) => initVetSchedulePage(options);
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function onDocumentReady(callback) {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', callback, { once: true });
+    return;
+  }
+  callback();
+}
+
+onDocumentReady(() => {
   initVetSchedulePage();
 });
 


### PR DESCRIPTION
## Summary
- ensure the vet schedule page initialization runs even when the document is already loaded
- add a helper that calls `initVetSchedulePage` immediately or after DOMContentLoaded as needed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfa6f1e8a0832e8e66b3c252cbacbf