### PR TITLE
Fix tutor and animal list preference persistence

### DIFF
--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -97,11 +97,28 @@
 </div>
 
 <script>
-document.addEventListener('DOMContentLoaded', function() {
+(function() {
   const filterInput = document.getElementById('animal-filter');
   const sortSelect = document.getElementById('animal-sort');
   const container = document.getElementById('animal-cards');
+
+  if (!filterInput || !sortSelect || !container) {
+    return;
+  }
+
   const cards = Array.from(container.querySelectorAll('[data-name]'));
+  const sortStorageKey = 'animalSortPreference';
+  const filterStorageKey = 'animalFilterPreference';
+
+  const savedFilter = localStorage.getItem(filterStorageKey);
+  if (savedFilter !== null) {
+    filterInput.value = savedFilter;
+  }
+
+  const savedSort = localStorage.getItem(sortStorageKey);
+  if (savedSort && Array.from(sortSelect.options).some(option => option.value === savedSort)) {
+    sortSelect.value = savedSort;
+  }
 
   function getAge(card) {
     return parseInt(card.dataset.age) || 0;
@@ -140,8 +157,18 @@ document.addEventListener('DOMContentLoaded', function() {
     hidden.forEach(card => container.appendChild(card));
   }
 
-  filterInput.addEventListener('input', () => { applyFilter(); applySort(); });
-  sortSelect.addEventListener('change', applySort);
+  filterInput.addEventListener('input', () => {
+    localStorage.setItem(filterStorageKey, filterInput.value);
+    applyFilter();
+    applySort();
+  });
+
+  sortSelect.addEventListener('change', () => {
+    localStorage.setItem(sortStorageKey, sortSelect.value);
+    applySort();
+  });
+
+  applyFilter();
   applySort();
-});
+})();
 </script>

--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -104,12 +104,23 @@
 </div>
 
 <script>
-document.addEventListener('DOMContentLoaded', function() {
+(function() {
   const filterInput = document.getElementById('tutor-filter');
   const sortSelect = document.getElementById('tutor-sort');
   const container = document.getElementById('tutor-cards');
+
+  if (!filterInput || !sortSelect || !container) {
+    return;
+  }
+
   const cards = Array.from(container.querySelectorAll('[data-name]'));
   const sortStorageKey = 'tutorSortPreference';
+  const filterStorageKey = 'tutorFilterPreference';
+
+  const savedFilter = localStorage.getItem(filterStorageKey);
+  if (savedFilter !== null) {
+    filterInput.value = savedFilter;
+  }
 
   const savedSort = localStorage.getItem(sortStorageKey);
   if (savedSort && Array.from(sortSelect.options).some(option => option.value === savedSort)) {
@@ -120,7 +131,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!card.dataset.dob) return 0;
     const diff = Date.now() - new Date(card.dataset.dob).getTime();
     return Math.floor(diff / (365.25 * 24 * 60 * 60 * 1000));
-    }
+  }
 
   function applyFilter() {
     const term = filterInput.value.toLowerCase();
@@ -157,11 +168,18 @@ document.addEventListener('DOMContentLoaded', function() {
     hidden.forEach(card => container.appendChild(card));
   }
 
-  filterInput.addEventListener('input', () => { applyFilter(); applySort(); });
+  filterInput.addEventListener('input', () => {
+    localStorage.setItem(filterStorageKey, filterInput.value);
+    applyFilter();
+    applySort();
+  });
+
   sortSelect.addEventListener('change', () => {
     localStorage.setItem(sortStorageKey, sortSelect.value);
     applySort();
   });
+
+  applyFilter();
   applySort();
-});
+})();
 </script>


### PR DESCRIPTION
## Summary
- run tutor and animal list scripts immediately so they execute even when fragments are injected dynamically
- persist both the selected sort order and filter text for tutor and animal lists via localStorage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa77ef24c832ea81899d6fbfa56a2