### PR TITLE
Prevent admin agenda switcher from auto switching without query

### DIFF
--- a/templates/partials/admin_agenda_switcher.html
+++ b/templates/partials/admin_agenda_switcher.html
@@ -139,16 +139,27 @@
             persistSelection(storedValue);
           }
           if (storedValue && storedValue !== select.value && findOptionByValue(storedValue)) {
+            let hasQuerySelection = false;
+            let paramView = '';
+            let paramVet = '';
+            let paramColab = '';
+            if (typeof window !== 'undefined') {
+              const params = new URLSearchParams(window.location.search || '');
+              paramView = params.get('view_as') || '';
+              paramVet = params.get('veterinario_id') || '';
+              paramColab = params.get('colaborador_id') || '';
+              hasQuerySelection = Boolean(paramView || paramVet || paramColab);
+            }
+            if (!hasQuerySelection) {
+              persistSelection(storedValue);
+              return;
+            }
             select.value = storedValue;
             updateHiddenInputs(storedValue);
             if (typeof window !== 'undefined') {
-              const params = new URLSearchParams(window.location.search || '');
               const targetView = viewInput.value || '';
               const targetVet = vetInput.value || '';
               const targetColab = colabInput.value || '';
-              const paramView = params.get('view_as') || '';
-              const paramVet = params.get('veterinario_id') || '';
-              const paramColab = params.get('colaborador_id') || '';
               if (paramView !== targetView || paramVet !== targetVet || paramColab !== targetColab) {
                 persistSelection(storedValue);
                 form.submit();


### PR DESCRIPTION
## Summary
- avoid auto-submitting the admin agenda switcher when the page is opened without any view-selection query parameters by checking the current URL before restoring the stored selection

## Testing
- pytest tests/test_admin_view_switch.py *(fails: known pre-existing assertion that agenda HTML lacks data-appointment-id for the collaborator view)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb15d4cd8832eb390cb6ecf52e30d