### PR TITLE
Add specialist management to clinic staff view

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -320,6 +320,13 @@ class ClinicAddStaffForm(FlaskForm):
     submit = SubmitField('Adicionar')
 
 
+class ClinicAddSpecialistForm(FlaskForm):
+    """Form to associate an existing veterinarian as a clinic specialist."""
+
+    email = StringField('Email do especialista', validators=[DataRequired(), Email()])
+    submit = SubmitField('Adicionar especialista')
+
+
 class ClinicStaffPermissionForm(FlaskForm):
     can_manage_clients = BooleanField('Clientes')
     can_manage_animals = BooleanField('Animais')

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -200,6 +200,30 @@
     </div>
   </div>
 
+  <div class="card border-0 shadow-lg rounded-4 mb-5">
+    <div class="card-header bg-info text-white rounded-top-4 d-flex align-items-center">
+      <h5 class="mb-0"><i class="bi bi-clipboard-pulse me-2"></i> Agenda de Exames</h5>
+    </div>
+    <div class="card-body">
+      {% if exam_appointments %}
+      <ul class="list-group list-group-flush">
+        {% for exam in exam_appointments %}
+        <li class="list-group-item d-flex justify-content-between align-items-start gap-3">
+          <div>
+            <div class="fw-semibold">{{ exam.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</div>
+            <div class="small text-muted">Animal: {{ exam.animal.name if exam.animal else '—' }}</div>
+            <div class="small text-muted">Especialista: {{ exam.specialist.user.name if exam.specialist and exam.specialist.user else '—' }}</div>
+          </div>
+          <span class="badge align-self-center {% if exam.status_display == 'Aceito' %}bg-success{% elif exam.status_display == 'Cancelado' %}bg-danger{% elif exam.status_display == 'Prazo expirado' %}bg-secondary{% else %}bg-warning text-dark{% endif %}">{{ exam.status_display }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="text-muted mb-0">Nenhum exame agendado no momento.</p>
+      {% endif %}
+    </div>
+  </div>
+
   <div id="appointmentsList" data-appointments-container data-refresh-url="{{ request.url }}">
     {% include 'partials/appointments_table.html' %}
   </div>

--- a/templates/partials/clinic_veterinarios_tab.html
+++ b/templates/partials/clinic_veterinarios_tab.html
@@ -208,6 +208,138 @@
             </tbody>
           </table>
         </div>
+
+        <h4 class="mt-4" id="especialistas">Especialistas</h4>
+        {% if current_user.id == clinica.owner_id %}
+        <form method="post" class="mt-3 mb-4">
+          {{ specialist_form.hidden_tag() }}
+          <div class="input-group">
+            {{ specialist_form.email(class="form-control", placeholder="Email do especialista") }}
+            {{ specialist_form.submit(class="btn btn-primary") }}
+          </div>
+        </form>
+        {% endif %}
+        <div class="table-responsive mb-4">
+          <table class="table table-striped">
+            <tbody>
+              {% for s in specialists %}
+              <tr>
+                <td>
+                  <div class="d-flex justify-content-between align-items-center">
+                    <div>
+                      <strong>{{ s.user.name }}</strong>
+                      {% if s.specialties %}
+                      <div class="small text-muted">{{ ', '.join(spec.nome for spec in s.specialties) }}</div>
+                      {% endif %}
+                    </div>
+                    {% if pode_editar %}
+                    <div class="btn-group">
+                      <button class="btn btn-sm btn-outline-primary" onclick="toggleVetOptions({{ s.id }})">Horários</button>
+                      <button class="btn btn-sm btn-outline-secondary" onclick="toggleVetPerm({{ s.user.id }})">Permissões</button>
+                      <form method="post" action="{{ url_for('remove_specialist', clinica_id=clinica.id, veterinario_id=s.id) }}" class="d-inline">
+                        {{ vet_permission_forms[s.user.id].csrf_token }}
+                        <button type="submit" class="btn btn-sm btn-outline-danger">Remover</button>
+                      </form>
+                    </div>
+                    {% endif %}
+                  </div>
+                  <table class="table table-sm ms-3 mt-2">
+                    <tbody>
+                      {% for dia, horarios in grouped_vet_schedules.get(s.id, {}).items() %}
+                      <tr>
+                        <td>{{ dia }}: {{ ', '.join(horarios) }}</td>
+                      </tr>
+                      {% else %}
+                      <tr>
+                        <td>Sem horários cadastrados.</td>
+                      </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                  {% if pode_editar %}
+                  <div id="vet-perms-{{ s.user.id }}" style="display:none;" class="mt-2">
+                    <form method="post">
+                      {{ vet_permission_forms[s.user.id].hidden_tag() }}
+                      <div class="form-check">
+                        {{ vet_permission_forms[s.user.id].can_manage_clients(class="form-check-input") }}
+                        {{ vet_permission_forms[s.user.id].can_manage_clients.label(class="form-check-label") }}
+                      </div>
+                      <div class="form-check">
+                        {{ vet_permission_forms[s.user.id].can_manage_animals(class="form-check-input") }}
+                        {{ vet_permission_forms[s.user.id].can_manage_animals.label(class="form-check-label") }}
+                      </div>
+                      <div class="form-check">
+                        {{ vet_permission_forms[s.user.id].can_manage_staff(class="form-check-input") }}
+                        {{ vet_permission_forms[s.user.id].can_manage_staff.label(class="form-check-label") }}
+                      </div>
+                      <div class="form-check">
+                        {{ vet_permission_forms[s.user.id].can_manage_schedule(class="form-check-input") }}
+                        {{ vet_permission_forms[s.user.id].can_manage_schedule.label(class="form-check-label") }}
+                      </div>
+                      <div class="form-check">
+                        {{ vet_permission_forms[s.user.id].can_manage_inventory(class="form-check-input") }}
+                        {{ vet_permission_forms[s.user.id].can_manage_inventory.label(class="form-check-label") }}
+                      </div>
+                      {{ vet_permission_forms[s.user.id].submit(class="btn btn-primary btn-sm mt-2") }}
+                    </form>
+                  </div>
+                  <div id="vet-options-{{ s.id }}" style="display:none;" class="mt-2">
+                    <table class="table table-sm ms-3 mb-3">
+                      <tbody>
+                        {% for h in s.horarios %}
+                        <tr>
+                          <td>
+                            {{ h.dia_semana }}: {{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}
+                            <form method="post" action="{{ url_for('delete_vet_schedule_clinic', clinica_id=clinica.id, veterinario_id=s.id, horario_id=h.id) }}" class="d-inline">
+                              {{ vet_schedule_forms[s.id].csrf_token }}
+                              <button type="submit" class="btn btn-sm btn-outline-danger ms-2">Excluir</button>
+                            </form>
+                          </td>
+                        </tr>
+                        {% else %}
+                        <tr>
+                          <td>Sem horários cadastrados.</td>
+                        </tr>
+                        {% endfor %}
+                      </tbody>
+                    </table>
+                    <form method="post" class="ms-3 mb-3">
+                      {{ vet_schedule_forms[s.id].hidden_tag() }}
+                      <div style="display:none;">{{ vet_schedule_forms[s.id].veterinario_id() }}</div>
+                      <div class="mb-2">
+                        {{ vet_schedule_forms[s.id].dias_semana.label }}
+                        {{ vet_schedule_forms[s.id].dias_semana(class="form-select", multiple=True, size=7) }}
+                      </div>
+                      <div class="mb-2">
+                        {{ vet_schedule_forms[s.id].hora_inicio.label }}
+                        {{ vet_schedule_forms[s.id].hora_inicio(class="form-control") }}
+                      </div>
+                      <div class="mb-2">
+                        {{ vet_schedule_forms[s.id].hora_fim.label }}
+                        {{ vet_schedule_forms[s.id].hora_fim(class="form-control") }}
+                      </div>
+                      <div class="mb-2">
+                        {{ vet_schedule_forms[s.id].intervalo_inicio.label }}
+                        {{ vet_schedule_forms[s.id].intervalo_inicio(class="form-control") }}
+                      </div>
+                      <div class="mb-2">
+                        {{ vet_schedule_forms[s.id].intervalo_fim.label }}
+                        {{ vet_schedule_forms[s.id].intervalo_fim(class="form-control") }}
+                      </div>
+                      {{ vet_schedule_forms[s.id].submit(class="btn btn-primary btn-sm") }}
+                    </form>
+                  </div>
+                  {% endif %}
+                </td>
+              </tr>
+              {% else %}
+              <tr>
+                <td>Nenhum especialista associado.</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
         {% if pode_editar %}
         <div class="mt-4">
           <h5>Convites enviados</h5>


### PR DESCRIPTION
## Summary
- allow clinic owners to associate freelance specialists from their email and manage their permissions and schedules alongside regular veterinarians
- display the new specialists section inside the clinic staff tab with schedule controls and removal actions
- surface an "Agenda de Exames" card on the appointments page so exam bookings are always visible to tutors and staff

## Testing
- pytest tests/test_schedule_exam.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb0b35c20832e8d586cf1f8d089e0