### PR TITLE
Ajusta alternância entre calendário e agendamento no perfil do veterinário

### DIFF
--- a/templates/veterinarios/vet_detail.html
+++ b/templates/veterinarios/vet_detail.html
@@ -51,15 +51,23 @@
       </div>
     </div>
   </div>
-
- 
-  <section class="mb-4" aria-labelledby="vet-calendar-title-{{ veterinario.id }}">
+  <section class="mb-4" aria-labelledby="vet-agenda-title-{{ veterinario.id }}">
     <div class="card shadow-sm border-0">
-      <div class="card-header bg-primary bg-gradient text-white">
-        <h3 id="vet-calendar-title-{{ veterinario.id }}" class="h5 mb-0">
-          <i class="fas fa-calendar-alt me-2"></i>Calendário de consultas
-        </h3>
-        <small class="text-white-50">Visualize os compromissos e detalhes do dia.</small>
+      <div class="card-header bg-primary bg-gradient text-white d-flex flex-column flex-lg-row align-items-lg-center justify-content-between">
+        <div>
+          <h3 id="vet-agenda-title-{{ veterinario.id }}" class="h5 mb-1">
+            <i class="fas fa-calendar-alt me-2"></i>Agenda do veterinário
+          </h3>
+          <small class="text-white-50">Visualize os compromissos e alterne rapidamente para novos agendamentos.</small>
+        </div>
+        <div class="d-flex flex-wrap justify-content-end gap-2 mt-3 mt-lg-0">
+          <button class="btn btn-light mb-1" onclick="toggleScheduleForm()">
+            <i class="fas fa-plus-circle me-1"></i>Adicionar Horário
+          </button>
+          <button class="btn btn-outline-light mb-1" onclick="toggleAppointmentForm()">
+            <i class="fas fa-calendar-plus me-1"></i>Agendar Consulta
+          </button>
+        </div>
       </div>
       <div class="card-body">
         {% set vet_calendar_events_url = url_for('api_vet_appointments', veterinario_id=veterinario.id) %}
@@ -69,43 +77,80 @@
           veterinario_id=veterinario.id,
           clinica_id=veterinario.clinica_id
         ) %}
- 
-        {% with
-          component_id='vet-calendar-inline-' ~ veterinario.id,
-          events_url=vet_calendar_events_url,
-          pets_url=vet_calendar_pets_url,
-          new_pet_url=url_for('novo_animal') if current_user.worker in ['colaborador', 'veterinario'] or current_user.role == 'admin' else None
-        %}
-          {% include 'partials/tutor_calendar.html' %}
-        {% endwith %}
- 
-      </div>
- 
-    </div>
-  </section>
 
-  <section class="mb-4" aria-labelledby="vet-schedule-title-{{ veterinario.id }}">
-    <div class="card shadow-sm border-0">
-      <div class="card-header bg-light d-flex flex-column flex-md-row align-items-md-center justify-content-between">
-        <div>
-          <h3 id="vet-schedule-title-{{ veterinario.id }}" class="h5 mb-1 text-gradient">
-            <i class="fas fa-calendar-check me-2 text-primary"></i>Agendamento
-          </h3>
-          <small class="text-muted">Alterne entre a agenda pessoal e da clínica para criar novas consultas.</small>
+        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+          <ul
+            class="nav nav-pills"
+            id="vet-agenda-tabs-{{ veterinario.id }}"
+            role="tablist"
+            aria-label="Alternar entre calendário e novo agendamento"
+          >
+            <li class="nav-item" role="presentation">
+              <button
+                class="nav-link active"
+                id="vet-agenda-tab-calendar-{{ veterinario.id }}"
+                data-bs-toggle="tab"
+                data-bs-target="#vet-agenda-pane-calendar-{{ veterinario.id }}"
+                type="button"
+                role="tab"
+                aria-controls="vet-agenda-pane-calendar-{{ veterinario.id }}"
+                aria-selected="true"
+              >
+                <i class="fas fa-calendar-week me-1"></i>Calendário
+              </button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button
+                class="nav-link"
+                id="vet-agenda-tab-schedule-{{ veterinario.id }}"
+                data-bs-toggle="tab"
+                data-bs-target="#vet-agenda-pane-schedule-{{ veterinario.id }}"
+                type="button"
+                role="tab"
+                aria-controls="vet-agenda-pane-schedule-{{ veterinario.id }}"
+                aria-selected="false"
+              >
+                <i class="fas fa-calendar-plus me-1"></i>Novo agendamento
+              </button>
+            </li>
+          </ul>
         </div>
-      </div>
-      <div class="card-body">
-        <input type="hidden" value="{{ veterinario.id }}" data-switcher-vet class="d-none">
-        {% with
-          calendar_id='vet-shared-calendar-' ~ veterinario.id,
-          toggle_id='vet-agenda-toggle-' ~ veterinario.id,
-          clinic_id=veterinario.clinica_id,
-          calendar_redirect_url=calendar_redirect_url,
-          admin_selected_view=admin_selected_view or 'veterinario',
-          vets=[veterinario]
-        %}
-          {% include 'partials/schedule_toggle.html' %}
-        {% endwith %}
+
+        <div class="tab-content" id="vet-agenda-tabs-content-{{ veterinario.id }}">
+          <div
+            class="tab-pane fade show active"
+            id="vet-agenda-pane-calendar-{{ veterinario.id }}"
+            role="tabpanel"
+            aria-labelledby="vet-agenda-tab-calendar-{{ veterinario.id }}"
+          >
+            {% with
+              component_id='vet-calendar-inline-' ~ veterinario.id,
+              events_url=vet_calendar_events_url,
+              pets_url=vet_calendar_pets_url,
+              new_pet_url=url_for('novo_animal') if current_user.worker in ['colaborador', 'veterinario'] or current_user.role == 'admin' else None
+            %}
+              {% include 'partials/tutor_calendar.html' %}
+            {% endwith %}
+          </div>
+          <div
+            class="tab-pane fade"
+            id="vet-agenda-pane-schedule-{{ veterinario.id }}"
+            role="tabpanel"
+            aria-labelledby="vet-agenda-tab-schedule-{{ veterinario.id }}"
+          >
+            <input type="hidden" value="{{ veterinario.id }}" data-switcher-vet class="d-none">
+            {% with
+              calendar_id='vet-shared-calendar-' ~ veterinario.id,
+              toggle_id='vet-agenda-toggle-' ~ veterinario.id,
+              clinic_id=veterinario.clinica_id,
+              calendar_redirect_url=calendar_redirect_url,
+              admin_selected_view=admin_selected_view or 'veterinario',
+              vets=[veterinario]
+            %}
+              {% include 'partials/schedule_toggle.html' %}
+            {% endwith %}
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- reorganize the veterinarian agenda section to present calendar and scheduling tools in tabbed navigation
- reuse the existing calendar and scheduling components within the new tab panes to avoid stacking issues when switching views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe4384378832ebe603aa7732c9ef7