### PR TITLE
Ensure new appointment form opens when scheduling

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -474,21 +474,30 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function ensureNewAppointmentVisible() {
-    if (!newAppointmentCollapseEl || !window.bootstrap || !bootstrap.Collapse) {
+    if (!newAppointmentCollapseEl) {
       return;
     }
-    if (!newAppointmentCollapseInstance) {
-      newAppointmentCollapseInstance = bootstrap.Collapse.getOrCreateInstance(
-        newAppointmentCollapseEl,
-        { toggle: false }
-      );
+
+    if (window.bootstrap && bootstrap.Collapse) {
+      if (!newAppointmentCollapseInstance) {
+        newAppointmentCollapseInstance = bootstrap.Collapse.getOrCreateInstance(
+          newAppointmentCollapseEl,
+          { toggle: false }
+        );
+      }
+      if (!newAppointmentCollapseEl.classList.contains('show')) {
+        newAppointmentCollapseInstance.show();
+      }
+    } else if (!newAppointmentCollapseEl.classList.contains('show')) {
+      newAppointmentCollapseEl.classList.add('show');
+      newAppointmentCollapseEl.style.height = 'auto';
+      newAppointmentCollapseEl.removeAttribute('aria-hidden');
     }
-    if (!newAppointmentCollapseEl.classList.contains('show')) {
-      newAppointmentCollapseInstance.show();
-    }
+
     if (newAppointmentToggleBtn) {
       newAppointmentToggleBtn.setAttribute('aria-expanded', 'true');
     }
+
     updateNewAppointmentToggleAria();
   }
 


### PR DESCRIPTION
## Summary
- ensure the "Nova Consulta" collapse opens when a calendar slot is chosen even if Bootstrap's Collapse JS is unavailable
- fall back to manually showing the collapse container and keeping ARIA attributes in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe4ee7154832ea0d5b7441c7e00e3