### PR TITLE
Ensure vet schedule collapses close siblings

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -44,7 +44,8 @@
   {% set vet_calendar_collapse_id = 'vet-calendar-collapse-' ~ veterinario.id %}
 
   <!-- Gerenciar horários e agendamento -->
-  <div class="card border-0 shadow-lg rounded-4 mb-5">
+  {% set schedule_collapse_group_id = 'vet-schedule-collapse-group-' ~ veterinario.id %}
+  <div class="card border-0 shadow-lg rounded-4 mb-5" id="{{ schedule_collapse_group_id }}">
     <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
       <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
       <div class="d-flex align-items-center gap-2">
@@ -73,12 +74,17 @@
         </button>
       </div>
     </div>
-    <div class="collapse" id="{{ vet_calendar_collapse_id }}" data-calendar-collapse>
+    <div
+      class="collapse"
+      id="{{ vet_calendar_collapse_id }}"
+      data-calendar-collapse
+      data-bs-parent="#{{ schedule_collapse_group_id }}"
+    >
       <div class="card-body border-top p-4">
         {% include 'partials/calendar_layout.html' %}
       </div>
     </div>
-    <div class="collapse" id="newAppointmentForm">
+    <div class="collapse" id="newAppointmentForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
       <div class="card-body p-4">
         <form method="POST" class="needs-validation" novalidate>
           {{ appointment_form.hidden_tag() }}


### PR DESCRIPTION
## Summary
- group the calendar and new appointment collapses under a shared parent container
- ensure opening one collapse hides the other for the vet schedule card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe60ee324832e8672e8b7759d4a35