### PR TITLE
Adjust calendar controls layout

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -42,13 +42,10 @@
                 <button type="button" class="btn btn-outline-secondary" data-view-mode="week" aria-pressed="false">
                   Semanal
                 </button>
+                <button type="button" class="btn btn-outline-secondary" data-today>
+                  Hoje
+                </button>
               </div>
-            </div>
-            <div class="d-flex flex-wrap gap-2">
-              <button type="button" class="btn btn-outline-secondary btn-sm" data-today>Hoje</button>
-              <button type="button" class="btn btn-success btn-sm" data-new-event>
-                <i class="bi bi-plus-circle me-1"></i> Novo agendamento
-              </button>
             </div>
           </div>
           <h3 class="h6 mb-3 mt-4">Filtros rápidos</h3>


### PR DESCRIPTION
## Summary
- remove the new appointment quick action button from the tutor calendar header
- place the today shortcut alongside the monthly and weekly view toggle buttons for a tidier layout

## Testing
- pytest *(fails: existing appointment-related tests currently failing in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe8e358c0832e93387c2b65dedc74