### PR TITLE
Add persistent calendar summary to vet view

### DIFF
--- a/app.py
+++ b/app.py
@@ -307,7 +307,7 @@ def ensure_clinic_access(clinica_id):
         return
     if not current_user.is_authenticated:
         abort(404)
-    if current_user.role == 'admin':
+    if current_user.is_authenticated and current_user.role == 'admin':
         return
     if current_user_clinic_id() != clinica_id:
         abort(404)
@@ -1302,7 +1302,7 @@ def conversa_admin(user_id=None):
 
     form = MessageForm()
 
-    if current_user.role == 'admin':
+    if current_user.is_authenticated and current_user.role == 'admin':
         if user_id is None:
             flash('Selecione um usuário para conversar.', 'warning')
             return redirect(url_for('mensagens_admin'))
@@ -3586,7 +3586,7 @@ def vet_detail(veterinario_id):
     appointment_form = AppointmentForm(is_veterinario=True, prefix='appointment')
     admin_default_selection_value = ''
 
-    if current_user.role == 'admin':
+    if current_user.is_authenticated and current_user.role == 'admin':
         agenda_veterinarios = (
             Veterinario.query.join(User).order_by(User.name).all()
         )

--- a/static/appointments_calendar_summary.js
+++ b/static/appointments_calendar_summary.js
@@ -43,7 +43,19 @@ export function setupAppointmentsCalendarSummary(options = {}) {
       ? calendarTabsElement.querySelectorAll('[data-bs-toggle="tab"]')
       : document.querySelectorAll('#appointments-calendar-tabs [data-bs-toggle="tab"]');
 
-    const calendarSummaryCollapsedStorageKey = 'appointmentsCalendarSummaryCollapsed';
+    const calendarSummaryCollapsedStorageKey = (() => {
+      if (!calendarSummaryPanel) {
+        return 'appointmentsCalendarSummaryCollapsed';
+      }
+      const rawKey = calendarSummaryPanel.getAttribute('data-calendar-summary-storage-key');
+      if (typeof rawKey === 'string') {
+        const trimmed = rawKey.trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+      return 'appointmentsCalendarSummaryCollapsed';
+    })();
     const calendarActiveTabStorageKey = 'appointmentsCalendarActiveTab';
     const calendarMainColumnVisibleClasses = ['col-xl-8', 'col-xxl-9'];
     const calendarMainColumnFullWidthClasses = ['col-xl-12', 'col-xxl-12'];

--- a/static/appointments_vet.js
+++ b/static/appointments_vet.js
@@ -1,4 +1,5 @@
 import { fetchAvailableTimes, submitAppointmentUpdate } from './appointments_shared.js';
+import { setupAppointmentsCalendarSummary } from './appointments_calendar_summary.js';
 
 const ROOT_SELECTOR = '[data-vet-schedule-root]';
 const DEFAULT_TIME_PLACEHOLDER = 'Selecione...';
@@ -1046,6 +1047,7 @@ function animateCards(root) {
 
 export function initVetSchedulePage(options = {}) {
   const root = getRootElement(options.root);
+  setupAppointmentsCalendarSummary({ waitForDomContentLoaded: false });
   if (!root || root.dataset.vetScheduleInitialized === 'true') {
     return root;
   }

--- a/templates/partials/calendar_layout.html
+++ b/templates/partials/calendar_layout.html
@@ -9,6 +9,8 @@
 {% set calendar_hide_experimental_tab = calendar_hide_experimental_tab|default(False) %}
 {% set calendar_show_summary_toggle = calendar_show_summary_toggle|default(True) %}
 {% set calendar_pets_endpoint = calendar_pets_endpoint|default(url_for('api_my_pets')) %}
+{% set calendar_events_endpoint = calendar_events_endpoint|default(url_for('api_my_appointments')) %}
+{% set calendar_new_pet_url = calendar_new_pet_url|default(url_for('novo_animal')) %}
 {% set calendar_summary_toggle_show_label = calendar_summary_toggle_show_label|default('Mostrar resumo') %}
 {% set calendar_summary_toggle_hide_label = calendar_summary_toggle_hide_label|default('Ocultar resumo') %}
 {% set summary_panel_template = summary_panel_template|default('partials/calendar_summary_panel.html') %}
@@ -88,7 +90,12 @@
         aria-labelledby="{{ calendar_experimental_tab_id }}"
         tabindex="0"
       >
-        {% with component_id = calendar_inline_component_id, pets_url = calendar_pets_endpoint %}
+        {% with
+          component_id = calendar_inline_component_id,
+          events_url = calendar_events_endpoint,
+          pets_url = calendar_pets_endpoint,
+          new_pet_url = calendar_new_pet_url
+        %}
           {% include 'partials/tutor_calendar.html' %}
         {% endwith %}
       </div>

--- a/templates/partials/calendar_summary_panel.html
+++ b/templates/partials/calendar_summary_panel.html
@@ -2,11 +2,15 @@
 {% set summary_description = summary_description|default('Totais diários e semanais por veterinário com base no calendário visível.') %}
 {% set summary_vets = calendar_summary_vets|default([], true) %}
 {% set summary_clinic_ids = calendar_summary_clinic_ids|default([], true) %}
+{% set summary_storage_key = calendar_summary_storage_key|default('', true) %}
 <div
   class="card calendar-summary-card border-0 shadow-sm h-100 is-loading"
   data-calendar-summary-panel
   data-calendar-summary-vets="{{ summary_vets|tojson }}"
   data-calendar-summary-clinic-ids="{{ summary_clinic_ids|tojson }}"
+  {% if summary_storage_key %}
+  data-calendar-summary-storage-key="{{ summary_storage_key }}"
+  {% endif %}
 >
   <div class="card-header bg-white border-0 pb-0">
     <div class="d-flex align-items-center justify-content-between gap-2">

--- a/templates/veterinarios/vet_detail.html
+++ b/templates/veterinarios/vet_detail.html
@@ -31,7 +31,7 @@
       </div>
     </div>
     <div class="ms-auto">
-      {% if current_user.role == 'admin' %}
+      {% if current_user.is_authenticated and current_user.role == 'admin' %}
         {% set preserve_params = ['start', 'end'] %}
         {% set switcher_select_id = 'vet-agenda-picker' %}
         {% set switcher_label_text = 'Pesquisar agenda' %}
@@ -78,77 +78,100 @@
           clinica_id=veterinario.clinica_id
         ) %}
 
-        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
-          <ul
-            class="nav nav-pills"
-            id="vet-agenda-tabs-{{ veterinario.id }}"
-            role="tablist"
-            aria-label="Alternar entre calendário e novo agendamento"
-          >
-            <li class="nav-item" role="presentation">
-              <button
-                class="nav-link active"
-                id="vet-agenda-tab-calendar-{{ veterinario.id }}"
-                data-bs-toggle="tab"
-                data-bs-target="#vet-agenda-pane-calendar-{{ veterinario.id }}"
-                type="button"
-                role="tab"
-                aria-controls="vet-agenda-pane-calendar-{{ veterinario.id }}"
-                aria-selected="true"
+        <div class="row g-4 align-items-stretch" id="vet-calendar-overview-{{ veterinario.id }}">
+          <div class="col-12 col-xl-8 col-xxl-9" data-calendar-main-column>
+            <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+              <ul
+                class="nav nav-pills mb-0"
+                id="vet-agenda-tabs-{{ veterinario.id }}"
+                role="tablist"
+                aria-label="Alternar entre calendário e novo agendamento"
+                data-calendar-tabs
               >
-                <i class="fas fa-calendar-week me-1"></i>Calendário
-              </button>
-            </li>
-            <li class="nav-item" role="presentation">
+                <li class="nav-item" role="presentation">
+                  <button
+                    class="nav-link active"
+                    id="vet-agenda-tab-calendar-{{ veterinario.id }}"
+                    data-bs-toggle="tab"
+                    data-bs-target="#vet-agenda-pane-calendar-{{ veterinario.id }}"
+                    type="button"
+                    role="tab"
+                    aria-controls="vet-agenda-pane-calendar-{{ veterinario.id }}"
+                    aria-selected="true"
+                  >
+                    <i class="fas fa-calendar-week me-1"></i>Calendário
+                  </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <button
+                    class="nav-link"
+                    id="vet-agenda-tab-schedule-{{ veterinario.id }}"
+                    data-bs-toggle="tab"
+                    data-bs-target="#vet-agenda-pane-schedule-{{ veterinario.id }}"
+                    type="button"
+                    role="tab"
+                    aria-controls="vet-agenda-pane-schedule-{{ veterinario.id }}"
+                    aria-selected="false"
+                  >
+                    <i class="fas fa-calendar-plus me-1"></i>Novo agendamento
+                  </button>
+                </li>
+              </ul>
               <button
-                class="nav-link"
-                id="vet-agenda-tab-schedule-{{ veterinario.id }}"
-                data-bs-toggle="tab"
-                data-bs-target="#vet-agenda-pane-schedule-{{ veterinario.id }}"
                 type="button"
-                role="tab"
-                aria-controls="vet-agenda-pane-schedule-{{ veterinario.id }}"
-                aria-selected="false"
+                class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2 calendar-summary-toggle"
+                data-calendar-summary-toggle
+                data-show-label="Mostrar resumo"
+                data-hide-label="Ocultar resumo"
+                aria-pressed="false"
+                aria-expanded="true"
               >
-                <i class="fas fa-calendar-plus me-1"></i>Novo agendamento
+                <i class="bi bi-layout-sidebar-inset" data-calendar-summary-toggle-icon aria-hidden="true"></i>
+                <span data-calendar-summary-toggle-label>Ocultar resumo</span>
               </button>
-            </li>
-          </ul>
-        </div>
+            </div>
 
-        <div class="tab-content" id="vet-agenda-tabs-content-{{ veterinario.id }}">
-          <div
-            class="tab-pane fade show active"
-            id="vet-agenda-pane-calendar-{{ veterinario.id }}"
-            role="tabpanel"
-            aria-labelledby="vet-agenda-tab-calendar-{{ veterinario.id }}"
-          >
-            {% with
-              component_id='vet-calendar-inline-' ~ veterinario.id,
-              events_url=vet_calendar_events_url,
-              pets_url=vet_calendar_pets_url,
-              new_pet_url=url_for('novo_animal') if current_user.worker in ['colaborador', 'veterinario'] or current_user.role == 'admin' else None
-            %}
-              {% include 'partials/tutor_calendar.html' %}
-            {% endwith %}
+            <div class="tab-content mt-3" id="vet-agenda-tabs-content-{{ veterinario.id }}">
+              <div
+                class="tab-pane fade show active"
+                id="vet-agenda-pane-calendar-{{ veterinario.id }}"
+                role="tabpanel"
+                aria-labelledby="vet-agenda-tab-calendar-{{ veterinario.id }}"
+              >
+                {% with
+                  component_id='vet-calendar-inline-' ~ veterinario.id,
+                  events_url=vet_calendar_events_url,
+                  pets_url=vet_calendar_pets_url,
+                  new_pet_url=url_for('novo_animal') if current_user.is_authenticated and (current_user.worker in ['colaborador', 'veterinario'] or current_user.role == 'admin') else None
+                %}
+                  {% include 'partials/tutor_calendar.html' %}
+                {% endwith %}
+              </div>
+              <div
+                class="tab-pane fade"
+                id="vet-agenda-pane-schedule-{{ veterinario.id }}"
+                role="tabpanel"
+                aria-labelledby="vet-agenda-tab-schedule-{{ veterinario.id }}"
+              >
+                <input type="hidden" value="{{ veterinario.id }}" data-switcher-vet class="d-none">
+                {% with
+                  calendar_id='vet-shared-calendar-' ~ veterinario.id,
+                  toggle_id='vet-agenda-toggle-' ~ veterinario.id,
+                  clinic_id=veterinario.clinica_id,
+                  calendar_redirect_url=calendar_redirect_url,
+                  admin_selected_view=admin_selected_view or 'veterinario',
+                  vets=[veterinario]
+                %}
+                  {% include 'partials/schedule_toggle.html' %}
+                {% endwith %}
+              </div>
+            </div>
           </div>
-          <div
-            class="tab-pane fade"
-            id="vet-agenda-pane-schedule-{{ veterinario.id }}"
-            role="tabpanel"
-            aria-labelledby="vet-agenda-tab-schedule-{{ veterinario.id }}"
-          >
-            <input type="hidden" value="{{ veterinario.id }}" data-switcher-vet class="d-none">
-            {% with
-              calendar_id='vet-shared-calendar-' ~ veterinario.id,
-              toggle_id='vet-agenda-toggle-' ~ veterinario.id,
-              clinic_id=veterinario.clinica_id,
-              calendar_redirect_url=calendar_redirect_url,
-              admin_selected_view=admin_selected_view or 'veterinario',
-              vets=[veterinario]
-            %}
-              {% include 'partials/schedule_toggle.html' %}
-            {% endwith %}
+          <div class="col-12 col-xl-4 col-xxl-3" data-calendar-summary-column>
+            {% set calendar_summary_vets = [{'id': veterinario.id, 'name': veterinario.user.name}] %}
+            {% set calendar_summary_clinic_ids = [veterinario.clinica_id] if veterinario.clinica_id else [] %}
+            {% set calendar_summary_storage_key = 'vetCalendarSummaryCollapsed-' ~ veterinario.id %}
+            {% include 'partials/calendar_summary_panel.html' %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add the calendar summary sidebar to the veterinarian agenda page with a collapse toggle
- persist the sidebar state per veterinarian using a configurable storage key and wire the vet view to the shared summary script
- harden admin-only checks to avoid attribute errors when anonymous visitors open veterinarian pages

## Testing
- `pytest` *(fails: existing appointment-related view assertions and vaccine appointment visibility checks)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe7cfe97c832ea5a3927f1088b29b