### PR TITLE
Update vet calendar summary toggle labeling and data

### DIFF
--- a/static/appointments_calendar_summary.js
+++ b/static/appointments_calendar_summary.js
@@ -93,10 +93,10 @@ export function setupAppointmentsCalendarSummary(options = {}) {
       calendarSummaryToggleButtons.forEach((button) => {
         const buttonShowLabel = (button.dataset && button.dataset.showLabel)
           || button.getAttribute('data-show-label')
-          || 'Mostrar resumo';
+          || 'Mostrar resumo por profissional';
         const buttonHideLabel = (button.dataset && button.dataset.hideLabel)
           || button.getAttribute('data-hide-label')
-          || 'Ocultar resumo';
+          || 'Ocultar resumo por profissional';
         const label = isCalendarSummaryCollapsed ? buttonShowLabel : buttonHideLabel;
         const labelElement = button.querySelector('[data-calendar-summary-toggle-label]');
         if (labelElement) {

--- a/templates/partials/calendar_layout.html
+++ b/templates/partials/calendar_layout.html
@@ -11,8 +11,8 @@
 {% set calendar_pets_endpoint = calendar_pets_endpoint|default(url_for('api_my_pets')) %}
 {% set calendar_events_endpoint = calendar_events_endpoint|default(url_for('api_my_appointments')) %}
 {% set calendar_new_pet_url = calendar_new_pet_url|default(url_for('novo_animal')) %}
-{% set calendar_summary_toggle_show_label = calendar_summary_toggle_show_label|default('Mostrar resumo') %}
-{% set calendar_summary_toggle_hide_label = calendar_summary_toggle_hide_label|default('Ocultar resumo') %}
+{% set calendar_summary_toggle_show_label = calendar_summary_toggle_show_label|default('Mostrar resumo por profissional') %}
+{% set calendar_summary_toggle_hide_label = calendar_summary_toggle_hide_label|default('Ocultar resumo por profissional') %}
 {% set summary_panel_template = summary_panel_template|default('partials/calendar_summary_panel.html') %}
 {% set schedule_toggle_clinic_id = schedule_toggle_clinic_id|default(none) %}
 {% set schedule_toggle_calendar_redirect_url = schedule_toggle_calendar_redirect_url|default('') %}

--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -2,6 +2,8 @@
 {% set events_url = events_url|default(url_for('api_my_appointments')) %}
 {% set pets_url = pets_url|default(url_for('api_my_pets')) %}
 {% set new_pet_url = new_pet_url|default(url_for('novo_animal')) %}
+{% set calendar_summary_toggle_show_label = calendar_summary_toggle_show_label|default('Mostrar resumo por profissional') %}
+{% set calendar_summary_toggle_hide_label = calendar_summary_toggle_hide_label|default('Ocultar resumo por profissional') %}
 
 <section
   id="{{ component_id }}"
@@ -49,12 +51,12 @@
                   type="button"
                   class="btn btn-outline-secondary"
                   data-calendar-summary-toggle
-                  data-show-label="Mostrar resumo"
-                  data-hide-label="Ocultar resumo"
+                  data-show-label="{{ calendar_summary_toggle_show_label }}"
+                  data-hide-label="{{ calendar_summary_toggle_hide_label }}"
                   aria-pressed="false"
                 >
                   <i class="bi bi-layout-sidebar-inset" data-calendar-summary-toggle-icon aria-hidden="true"></i>
-                  <span class="visually-hidden" data-calendar-summary-toggle-label>Ocultar resumo</span>
+                  <span class="visually-hidden" data-calendar-summary-toggle-label>{{ calendar_summary_toggle_hide_label }}</span>
                 </button>
               </div>
             </div>

--- a/templates/veterinarios/vet_detail.html
+++ b/templates/veterinarios/vet_detail.html
@@ -121,13 +121,13 @@
                 type="button"
                 class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2 calendar-summary-toggle"
                 data-calendar-summary-toggle
-                data-show-label="Mostrar resumo"
-                data-hide-label="Ocultar resumo"
+                data-show-label="Mostrar resumo por profissional"
+                data-hide-label="Ocultar resumo por profissional"
                 aria-pressed="false"
                 aria-expanded="true"
               >
                 <i class="bi bi-layout-sidebar-inset" data-calendar-summary-toggle-icon aria-hidden="true"></i>
-                <span data-calendar-summary-toggle-label>Ocultar resumo</span>
+                <span data-calendar-summary-toggle-label>Ocultar resumo por profissional</span>
               </button>
             </div>
 
@@ -168,8 +168,8 @@
             </div>
           </div>
           <div class="col-12 col-xl-4 col-xxl-3" data-calendar-summary-column>
-            {% set calendar_summary_vets = [{'id': veterinario.id, 'name': veterinario.user.name}] %}
-            {% set calendar_summary_clinic_ids = [veterinario.clinica_id] if veterinario.clinica_id else [] %}
+            {% set calendar_summary_vets = calendar_summary_vets if calendar_summary_vets else [{'id': veterinario.id, 'name': veterinario.user.name}] %}
+            {% set calendar_summary_clinic_ids = calendar_summary_clinic_ids if calendar_summary_clinic_ids else ([veterinario.clinica_id] if veterinario.clinica_id else []) %}
             {% set calendar_summary_storage_key = 'vetCalendarSummaryCollapsed-' ~ veterinario.id %}
             {% include 'partials/calendar_summary_panel.html' %}
           </div>


### PR DESCRIPTION
## Summary
- update calendar summary toggle labels to reference professionals across calendar views
- allow veterinarian detail summary panel to list colleagues from the same clinic
- adjust summary panel defaults and button fallbacks to align with the new labelling

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68dfefd0bd9c832e97803ec85466c76c