### PR TITLE
Add label to calendar summary toggle button

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -49,13 +49,14 @@
                 </button>
                 <button
                   type="button"
-                  class="btn btn-outline-secondary"
+                  class="btn btn-outline-secondary d-flex align-items-center gap-1"
                   data-calendar-summary-toggle
                   data-show-label="{{ calendar_summary_toggle_show_label }}"
                   data-hide-label="{{ calendar_summary_toggle_hide_label }}"
                   aria-pressed="false"
                 >
                   <i class="bi bi-layout-sidebar-inset" data-calendar-summary-toggle-icon aria-hidden="true"></i>
+                  <span class="fw-semibold" aria-hidden="true">Profissional</span>
                   <span class="visually-hidden" data-calendar-summary-toggle-label>{{ calendar_summary_toggle_hide_label }}</span>
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- add a visible "Profissional" label to the calendar summary toggle button in the tutor calendar header
- maintain accessible text updates so assistive technologies still announce the show/hide state

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dff2c0ee4c832eaaac653f37515894