### PR TITLE
Improve printable documents and prescription history styling

### DIFF
--- a/static/print.css
+++ b/static/print.css
@@ -1,200 +1,399 @@
-/* Estilos Gerais para Documentos Profissionais */
+/*
+ * Estilos profissionais para impressão em A4
+ * ------------------------------------------------------------
+ */
+
+:root {
+  --primary-color: #1f3a56;
+  --secondary-color: #556b83;
+  --border-color: #d9e2ec;
+  --soft-border-color: #e6edf3;
+  --body-text: #2b2d33;
+  --muted-text: #687385;
+  --background: #f5f8fb;
+  --card-background: #ffffff;
+  --accent-color: #1f7a8c;
+}
+
+@page {
+  size: A4;
+  margin: 1.6cm;
+}
+
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  margin: 1.5cm;
-  color: #333;
+  margin: 0;
+  color: var(--body-text);
   font-size: 11pt;
   line-height: 1.6;
-  background: #fff;
+  background: var(--background);
 }
 
 .document {
-  border: 1px solid #e0e0e0;
-  padding: 25px 35px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  max-width: 19cm;
+  margin: 1.2cm auto 1.8cm;
+  background: var(--card-background);
+  border: 1px solid var(--soft-border-color);
+  padding: 30px 38px;
+  box-shadow: 0 8px 28px rgba(17, 24, 39, 0.08);
+  border-radius: 10px;
 }
 
 .header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5em;
-  padding-bottom: 1em;
-  border-bottom: 1px solid #e0e0e0;
+  gap: 24px;
+  padding-bottom: 18px;
+  margin-bottom: 24px;
+  border-bottom: 2px solid var(--soft-border-color);
+}
+
+.header-logo {
+  flex: 0 0 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .header img {
-  max-height: 70px;
+  max-height: 72px;
+  width: auto;
+}
+
+.header-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .clinica-nome {
-  text-align: center;
-  font-size: 16pt;
+  font-size: 17pt;
   font-weight: 600;
-  color: #2c3e50;
-  letter-spacing: 0.5px;
+  color: var(--primary-color);
+  letter-spacing: 0.3px;
 }
 
-h2 {
-  text-align: center;
-  font-size: 15pt;
-  margin: 0 0 25px;
-  border-bottom: 1px solid #2c3e50;
-  padding-bottom: 8px;
-  color: #2c3e50;
+.clinica-contato {
+  font-size: 9.5pt;
+  color: var(--muted-text);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+
+.clinica-contato span::before {
+  content: '•';
+  margin: 0 6px 0 0;
+  color: var(--soft-border-color);
+}
+
+.clinica-contato span:first-child::before {
+  content: '';
+  margin: 0;
+}
+
+.document-title {
+  font-size: 16pt;
+  color: var(--primary-color);
   font-weight: 600;
+  margin: 0;
+}
+
+.document-title-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.document-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: rgba(31, 58, 86, 0.08);
+  color: var(--primary-color);
+  border-radius: 999px;
+  font-size: 9.5pt;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.document-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  margin-bottom: 28px;
+  color: var(--muted-text);
+  font-size: 9.8pt;
+}
+
+.document-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.info-card {
+  background: rgba(248, 250, 252, 0.6);
+  border: 1px solid var(--soft-border-color);
+  border-radius: 10px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.info-card h3 {
+  font-size: 11pt;
+  font-weight: 600;
+  margin: 0;
+  color: var(--primary-color);
+}
+
+.info-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.info-list li {
+  display: flex;
+  gap: 6px;
+  font-size: 10.3pt;
+}
+
+.info-list li span:first-child {
+  font-weight: 600;
+  color: var(--secondary-color);
+  min-width: 70px;
 }
 
 .section-title {
   font-weight: 600;
-  margin-top: 1.5em;
-  margin-bottom: 0.6em;
-  color: #2c3e50;
+  margin: 24px 0 12px;
+  color: var(--primary-color);
   font-size: 12pt;
-}
-
-.assinatura {
-  margin-top: 80px;
-  text-align: center;
-  font-size: 11pt;
-}
-
-.assinatura span {
-  display: block;
-  margin-top: 5px;
-}
-
-.assinaturas {
   display: flex;
-  justify-content: space-between;
-  margin-top: 80px;
-  gap: 40px;
+  align-items: center;
+  gap: 8px;
 }
 
-.assinaturas > div {
+.section-title::after {
+  content: '';
   flex: 1;
-  text-align: center;
+  height: 1px;
+  background: var(--soft-border-color);
 }
 
-footer {
-  margin-top: 60px;
-  font-size: 9pt;
-  text-align: center;
-  border-top: 1px solid #e0e0e0;
-  padding-top: 10px;
-  color: #666;
-}
-
-/* Componentes Específicos */
-.top-info {
-  display: flex;
-  justify-content: space-between;
-  gap: 20px;
-  margin-bottom: 25px;
-}
-
-.info-box {
-  flex: 1;
-  border: 1px solid #e0e0e0;
-  padding: 12px 15px;
-  font-size: 10.5pt;
-  line-height: 1.5;
-  border-radius: 4px;
-  background-color: #f9f9f9;
-}
-
-.info-box strong {
-  color: #2c3e50;
-}
-
-.prescricao, .exames {
-  border: 1px solid #e0e0e0;
-  padding: 18px;
-  background-color: #f9f9f9;
+.prescricao,
+.exames,
+.note-block {
+  border: 1px solid var(--soft-border-color);
+  padding: 18px 20px;
+  background-color: rgba(255, 255, 255, 0.9);
   font-size: 11pt;
   line-height: 1.6;
   margin-bottom: 1.8em;
-  border-radius: 4px;
+  border-radius: 10px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
-.prescricao-item, .exame-item {
-  margin-bottom: 14px;
-  padding-bottom: 14px;
-  border-bottom: 1px dashed #e0e0e0;
+.prescricao-item,
+.exame-item {
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+  border-bottom: 1px dashed var(--soft-border-color);
 }
 
-.prescricao-item:last-child, .exame-item:last-child {
+.prescricao-item:last-child,
+.exame-item:last-child {
   margin-bottom: 0;
   padding-bottom: 0;
   border-bottom: none;
 }
 
-.prescricao-item strong, .exame-item strong {
+.prescricao-item strong,
+.exame-item strong {
   font-size: 11.5pt;
-  color: #2c3e50;
+  color: var(--primary-color);
 }
 
-/* Tabelas */
+.prescricao-posologia {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  font-size: 10.3pt;
+  color: var(--secondary-color);
+  margin: 8px 0 0;
+}
+
+.prescricao-posologia span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.prescricao-obs,
+.note-block {
+  font-size: 10.5pt;
+  color: var(--body-text);
+}
+
+.note-block {
+  background: rgba(233, 240, 248, 0.55);
+  border-left: 4px solid var(--accent-color);
+}
+
+.muted {
+  color: var(--muted-text);
+  font-size: 10pt;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
-  margin: 1em 0 2em;
+  margin: 18px 0 26px;
   font-size: 10.5pt;
+  border: 1px solid var(--soft-border-color);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+caption {
+  text-align: left;
+  font-weight: 600;
+  color: var(--primary-color);
+  padding-bottom: 8px;
 }
 
 th {
-  background-color: #f2f2f2;
-  color: #2c3e50;
+  background: rgba(31, 58, 86, 0.07);
+  color: var(--primary-color);
   font-weight: 600;
   text-align: left;
 }
 
-th, td {
-  border: 1px solid #e0e0e0;
-  padding: 8px 12px;
+th,
+td {
+  border: 1px solid var(--soft-border-color);
+  padding: 10px 12px;
 }
 
-tr:nth-child(even) {
-  background-color: #f9f9f9;
+tr:nth-child(even) td {
+  background-color: rgba(248, 250, 252, 0.6);
 }
 
-/* Botões de Ação */
-.no-print {
-  margin-bottom: 1.5em;
+.signature-block {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 60px;
+}
+
+.signature-block .signature {
+  min-width: 260px;
   text-align: center;
+  font-size: 10.5pt;
+  color: var(--secondary-color);
 }
 
-.no-print button, .no-print a {
-  background-color: #2c3e50;
-  color: white;
+.signature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 28px;
+  margin-top: 56px;
+}
+
+.signature-grid .signature {
+  text-align: center;
+  font-size: 10.5pt;
+  color: var(--secondary-color);
+}
+
+.signature-line {
+  width: 100%;
+  height: 1px;
+  background: var(--border-color);
+  margin-bottom: 10px;
+}
+
+.signature span {
+  display: block;
+  margin-top: 4px;
+}
+
+footer {
+  margin-top: 60px;
+  font-size: 9.5pt;
+  text-align: center;
+  border-top: 1px solid var(--soft-border-color);
+  padding-top: 14px;
+  color: var(--muted-text);
+}
+
+footer span + span::before {
+  content: '•';
+  margin: 0 6px;
+  color: var(--soft-border-color);
+}
+
+.no-print {
+  margin: 18px auto;
+  text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.no-print button,
+.no-print a {
+  background-color: var(--primary-color);
+  color: #fff;
   border: none;
-  padding: 8px 15px;
-  margin: 0 5px;
-  border-radius: 4px;
+  padding: 9px 18px;
+  border-radius: 999px;
   cursor: pointer;
   font-size: 11pt;
   text-decoration: none;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  box-shadow: 0 4px 12px rgba(31, 58, 86, 0.15);
 }
 
-.no-print button:hover, .no-print a:hover {
-  background-color: #1a252f;
+.no-print button:hover,
+.no-print a:hover {
+  background-color: #172b42;
 }
 
-/* Responsividade para Impressão */
 @media print {
-  .no-print {
-    display: none !important;
-  }
-  
   body {
-    margin: 0.5cm;
-    font-size: 10pt;
+    background: #fff;
+    font-size: 10.5pt;
   }
-  
+
   .document {
+    margin: 0;
     border: none;
     padding: 0;
     box-shadow: none;
+    border-radius: 0;
+  }
+
+  .no-print {
+    display: none !important;
   }
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -585,3 +585,154 @@
     top: 96px;
   }
 }
+
+/* ------------------------------------------------------------
+ * Histórico de prescrições
+ * ------------------------------------------------------------ */
+.prescricao-history__grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .prescricao-history__grid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+}
+
+.prescricao-card {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.85rem;
+  padding: 1.25rem 1.35rem;
+  background: #ffffff;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.prescricao-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
+}
+
+.prescricao-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.prescricao-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.15rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.prescricao-card__title {
+  margin: 0.35rem 0 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.prescricao-card__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: #6b7280;
+}
+
+.prescricao-card__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.prescricao-card__item {
+  padding-bottom: 0.95rem;
+  border-bottom: 1px dashed rgba(148, 163, 184, 0.6);
+}
+
+.prescricao-card__item:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.prescricao-card__item-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  color: #1f2937;
+}
+
+.prescricao-card__item-head strong {
+  font-size: 1rem;
+}
+
+.prescricao-card__pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.prescricao-card__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.prescricao-card__obs {
+  margin: 0.35rem 0 0;
+  color: #4b5563;
+  font-size: 0.92rem;
+}
+
+.prescricao-card__note {
+  margin-top: 1.25rem;
+  border-radius: 0.65rem;
+  background: rgba(37, 99, 235, 0.08);
+  padding: 0.85rem 1rem;
+  color: #1f2937;
+}
+
+.prescricao-card__note-label {
+  display: block;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #1d4ed8;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.prescricao-card__footer {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.prescricao-card__footer .btn {
+  min-width: 110px;
+}

--- a/templates/orcamentos/imprimir_bloco.html
+++ b/templates/orcamentos/imprimir_bloco.html
@@ -18,83 +18,110 @@
 
 {% from 'components/logo.html' import clinic_logo %}
 <div class="document">
-  <!-- Cabeçalho com logo -->
   {% if clinica %}
     <div class="header">
-      {{ clinic_logo(clinica) }}
-      <div class="clinica-nome">{{ clinica.nome }}</div>
-      {{ clinic_logo(clinica) }}
+      <div class="header-logo">
+        {{ clinic_logo(clinica) }}
+      </div>
+      <div class="header-info">
+        <div class="clinica-nome">{{ clinica.nome }}</div>
+        <div class="clinica-contato">
+          {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+          {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+          {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+          {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+        </div>
+      </div>
     </div>
   {% endif %}
 
-  <h2>Receita de Controle Especial</h2>
-
-  <!-- Informações -->
-  <div class="top-info">
-    <div class="info-box">
-      <strong>Veterinário Responsável</strong><br>
-      {{ veterinario.name if veterinario else '' }}<br>
-      CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}
-    </div>
-
-    <div class="info-box">
-      <strong>Paciente Animal</strong><br>
-      Nome: {{ bloco.animal.name }}<br>
-      Espécie: {{ bloco.animal.species }}<br>
-      {% if bloco.animal.breed %}Raça: {{ bloco.animal.breed }}<br>{% endif %}
-      {% if bloco.animal.sex %}Sexo: {{ bloco.animal.sex }}<br>{% endif %}
-      {% if bloco.animal.age_display %}Idade: {{ bloco.animal.age_display }}<br>{% endif %}
-      {% if bloco.animal.microchip_number %}Microchip: {{ bloco.animal.microchip_number }}{% endif %}
-    </div>
-
-    <div class="info-box">
-      <strong>Responsável Legal</strong><br>
-      Nome: {{ bloco.animal.owner.name }}<br>
-      {% if bloco.animal.owner.cpf %}CPF: {{ bloco.animal.owner.cpf }}<br>{% endif %}
-      {% if bloco.animal.owner.address %}Endereço: {{ bloco.animal.owner.address }}{% endif %}
-    </div>
+  <div class="document-title-group">
+    <h1 class="document-title">Receita Médico-Veterinária</h1>
+    <span class="document-tag">Controle Especial</span>
   </div>
 
-  <!-- Prescrições -->
+  <div class="document-meta">
+    {% if bloco.data_criacao %}
+      <span>Emitido em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</span>
+    {% endif %}
+    <span>Identificador da prescrição: #{{ bloco.id }}</span>
+  </div>
+
+  <div class="info-grid">
+    <section class="info-card">
+      <h3>Profissional Responsável</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ veterinario.name if veterinario else '—' }}</span></li>
+        <li><span>CRMV</span><span>{{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span></li>
+      </ul>
+    </section>
+    <section class="info-card">
+      <h3>Paciente</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ bloco.animal.name }}</span></li>
+        {% if bloco.animal.species %}<li><span>Espécie</span><span>{{ bloco.animal.species }}</span></li>{% endif %}
+        {% if bloco.animal.breed %}<li><span>Raça</span><span>{{ bloco.animal.breed }}</span></li>{% endif %}
+        {% if bloco.animal.sex %}<li><span>Sexo</span><span>{{ bloco.animal.sex }}</span></li>{% endif %}
+        {% if bloco.animal.age_display %}<li><span>Idade</span><span>{{ bloco.animal.age_display }}</span></li>{% endif %}
+        {% if bloco.animal.microchip_number %}<li><span>Microchip</span><span>{{ bloco.animal.microchip_number }}</span></li>{% endif %}
+      </ul>
+    </section>
+    <section class="info-card">
+      <h3>Responsável Legal</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ bloco.animal.owner.name }}</span></li>
+        {% if bloco.animal.owner.cpf %}<li><span>CPF</span><span>{{ bloco.animal.owner.cpf }}</span></li>{% endif %}
+        {% if bloco.animal.owner.address %}<li><span>Endereço</span><span>{{ bloco.animal.owner.address }}</span></li>{% endif %}
+        {% if bloco.animal.owner.phone %}<li><span>Contato</span><span>{{ bloco.animal.owner.phone }}</span></li>{% endif %}
+      </ul>
+    </section>
+  </div>
+
   <div class="section-title">Prescrição Médico-Veterinária</div>
   <div class="prescricao">
     {% for item in bloco.prescricoes %}
       <div class="prescricao-item">
-        <strong>{{ item.medicamento }}</strong><br>
-        <span style="color: #555;">
-          {% if item.dosagem or item.frequencia or item.duracao %}
-            {{ item.dosagem or '' }}{{ ', ' if item.dosagem and item.frequencia }}{{ item.frequencia or '' }}{{ ', por ' + item.duracao if item.duracao else '' }}
-          {% elif item.observacoes %}
-            {{ item.observacoes }}
-          {% endif %}
-        </span>
+        <strong>{{ item.medicamento }}</strong>
+        {% set tem_posologia = item.dosagem or item.frequencia or item.duracao %}
+        {% if tem_posologia %}
+          <div class="prescricao-posologia">
+            {% if item.dosagem %}<span><strong>Dosagem:</strong> {{ item.dosagem }}</span>{% endif %}
+            {% if item.frequencia %}<span><strong>Frequência:</strong> {{ item.frequencia }}</span>{% endif %}
+            {% if item.duracao %}<span><strong>Duração:</strong> {{ item.duracao }}</span>{% endif %}
+          </div>
+        {% endif %}
+        {% if item.observacoes %}
+          <p class="prescricao-obs">{{ item.observacoes }}</p>
+        {% elif not tem_posologia %}
+          <p class="prescricao-obs muted">Posologia informada em consulta.</p>
+        {% endif %}
       </div>
     {% endfor %}
   </div>
 
-  <!-- Instruções Gerais -->
   {% if bloco.instrucoes_gerais %}
     <div class="section-title">Orientações e Cuidados</div>
-    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6;">
+    <div class="note-block">
       {{ bloco.instrucoes_gerais }}
     </div>
   {% endif %}
 
-  <!-- Assinatura -->
-  <div class="assinaturas">
-    <div>
-      ___________________________________________<br>
+  <div class="signature-block">
+    <div class="signature">
+      <div class="signature-line"></div>
       <span>{{ veterinario.name if veterinario else '' }}</span>
-      <span>CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span>
+      <span>CRMV {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span>
     </div>
   </div>
 
-  <!-- Rodapé -->
   <footer>
-    {{ clinica.nome }} – {{ clinica.endereco }}<br>
-    {% if clinica.telefone %}Telefone: {{ clinica.telefone }} • {% endif %}
-    {% if clinica.email %}Email: {{ clinica.email }} • {% endif %}
-    {% if clinica.cnpj %}CNPJ: {{ clinica.cnpj }}{% endif %}
+    {% if clinica %}
+      <span>{{ clinica.nome }}</span>
+      {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+      {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+      {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+      {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+    {% endif %}
   </footer>
 </div>
 

--- a/templates/orcamentos/imprimir_consulta.html
+++ b/templates/orcamentos/imprimir_consulta.html
@@ -19,72 +19,97 @@
 <div class="document">
   {% if clinica %}
     <div class="header">
-      {{ clinic_logo(clinica) }}
-      <div class="clinica-nome">{{ clinica.nome }}</div>
-      {{ clinic_logo(clinica) }}
+      <div class="header-logo">
+        {{ clinic_logo(clinica) }}
+      </div>
+      <div class="header-info">
+        <div class="clinica-nome">{{ clinica.nome }}</div>
+        <div class="clinica-contato">
+          {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+          {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+          {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+          {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+        </div>
+      </div>
     </div>
   {% endif %}
 
-  <h2>Relatório de Atendimento Clínico</h2>
+  <div class="document-title-group">
+    <h1 class="document-title">Relatório de Atendimento Clínico</h1>
+    <span class="document-tag">Resumo da consulta</span>
+  </div>
 
-  <div class="top-info">
-    <div class="info-box">
-      <strong>Profissional Responsável</strong><br>
-      {{ veterinario.name }}<br>
-      CRMV: {{ veterinario.veterinario.crmv if veterinario.veterinario else '—' }}
-    </div>
+  <div class="document-meta">
+    {% if consulta.created_at %}<span>Consulta realizada em {{ consulta.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}</span>{% endif %}
+    <span>Paciente: {{ animal.name }}</span>
+    <span>Responsável: {{ tutor.name }}</span>
+  </div>
 
-    <div class="info-box">
-      <strong>Paciente</strong><br>
-      Nome: {{ animal.name }}<br>
-      Espécie: {{ animal.species }}<br>
-      Raça: {{ animal.breed or '—' }}<br>
-      Sexo: {{ animal.sex or '—' }}<br>
-      Peso: {{ animal.peso or '—' }} kg<br>
-      Microchip: {{ animal.microchip_number or '—' }}
-    </div>
-
-    <div class="info-box">
-      <strong>Responsável</strong><br>
-      Nome: {{ tutor.name }}<br>
-      CPF: {{ tutor.cpf or '—' }}<br>
-      Endereço: {{ tutor.address or '—' }}
-    </div>
+  <div class="info-grid">
+    <section class="info-card">
+      <h3>Profissional Responsável</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ veterinario.name }}</span></li>
+        <li><span>CRMV</span><span>{{ veterinario.veterinario.crmv if veterinario.veterinario else '—' }}</span></li>
+      </ul>
+    </section>
+    <section class="info-card">
+      <h3>Paciente</h3>
+      <ul class="info-list">
+        <li><span>Espécie</span><span>{{ animal.species or '—' }}</span></li>
+        <li><span>Raça</span><span>{{ animal.breed or '—' }}</span></li>
+        <li><span>Sexo</span><span>{{ animal.sex or '—' }}</span></li>
+        <li><span>Peso</span><span>{{ animal.peso or '—' }} kg</span></li>
+        {% if animal.microchip_number %}<li><span>Microchip</span><span>{{ animal.microchip_number }}</span></li>{% endif %}
+      </ul>
+    </section>
+    <section class="info-card">
+      <h3>Responsável</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ tutor.name }}</span></li>
+        <li><span>CPF</span><span>{{ tutor.cpf or '—' }}</span></li>
+        <li><span>Contato</span><span>{{ tutor.phone or '—' }}</span></li>
+        <li><span>Endereço</span><span>{{ tutor.address or '—' }}</span></li>
+      </ul>
+    </section>
   </div>
 
   <div class="section-title">Motivo da Consulta</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div class="note-block">
     {{ consulta.queixa_principal or '—' }}
   </div>
 
   <div class="section-title">Histórico Clínico</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div class="note-block">
     {{ consulta.historico_clinico or '—' }}
   </div>
 
   <div class="section-title">Exame Físico</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div class="note-block">
     {{ consulta.exame_fisico or '—' }}
   </div>
 
   <div class="section-title">Conduta Médica</div>
-  <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 1.5em; line-height: 1.6;">
+  <div class="note-block">
     {{ consulta.conduta or '—' }}
   </div>
 
-  <div class="assinatura">
-    ___________________________________________<br>
-    <span>{{ veterinario.name }}</span>
-    <span>CRMV: {{ veterinario.veterinario.crmv if veterinario.veterinario else '—' }}</span>
+  <div class="signature-block">
+    <div class="signature">
+      <div class="signature-line"></div>
+      <span>{{ veterinario.name }}</span>
+      <span>CRMV {{ veterinario.veterinario.crmv if veterinario.veterinario else '—' }}</span>
+    </div>
   </div>
 
   {% if clinica %}
-  <footer>
-    {{ clinica.nome }} – {{ clinica.endereco }}<br>
-    {% if clinica.telefone %}Telefone: {{ clinica.telefone }} • {% endif %}
-    {% if clinica.email %}Email: {{ clinica.email }} • {% endif %}
-    {% if clinica.cnpj %}CNPJ: {{ clinica.cnpj }}{% endif %}
-  </footer>
+    <footer>
+      <span>{{ clinica.nome }}</span>
+      {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+      {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+      {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+      {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+    </footer>
   {% endif %}
 </div>
 

--- a/templates/orcamentos/imprimir_exames.html
+++ b/templates/orcamentos/imprimir_exames.html
@@ -19,61 +19,66 @@
 <div class="document">
   {% if clinica %}
     <div class="header">
-      {{ clinic_logo(clinica) }}
-      <div class="clinica-nome">{{ clinica.nome }}</div>
-      {{ clinic_logo(clinica) }}
+      <div class="header-logo">
+        {{ clinic_logo(clinica) }}
+      </div>
+      <div class="header-info">
+        <div class="clinica-nome">{{ clinica.nome }}</div>
+        <div class="clinica-contato">
+          {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+          {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+          {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+          {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+        </div>
+      </div>
     </div>
   {% endif %}
 
-  <h2>Requisicao de Exames Complementares</h2>
+  <div class="document-title-group">
+    <h1 class="document-title">Requisição de Exames Complementares</h1>
+    <span class="document-tag">Diagnóstico</span>
+  </div>
 
-  <div class="top-info">
+  <div class="document-meta">
+    <span>Paciente: {{ animal.name }}</span>
+    {% if tutor and tutor.name %}<span>Responsável: {{ tutor.name }}</span>{% endif %}
+    {% if bloco.data_criacao %}<span>Solicitado em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</span>{% endif %}
+  </div>
+
+  <div class="info-grid">
     {% if veterinario and (veterinario.name or (veterinario.veterinario and veterinario.veterinario.crmv)) %}
-      <div class="info-box">
-        <strong>Médico Veterinário</strong><br>
-        {% if veterinario.name %}
-          {{ veterinario.name }}<br>
-        {% endif %}
-        {% if veterinario.veterinario and veterinario.veterinario.crmv %}
-          CRMV: {{ veterinario.veterinario.crmv }}
-        {% endif %}
-      </div>
+      <section class="info-card">
+        <h3>Médico Veterinário</h3>
+        <ul class="info-list">
+          <li><span>Nome</span><span>{{ veterinario.name or '—' }}</span></li>
+          <li><span>CRMV</span><span>{{ veterinario.veterinario.crmv if veterinario.veterinario and veterinario.veterinario.crmv else '—' }}</span></li>
+        </ul>
+      </section>
     {% endif %}
 
     {% if animal.name or animal.species or animal.breed or animal.sex or animal.microchip_number %}
-      <div class="info-box">
-        <strong>Paciente</strong><br>
-        {% if animal.name %}
-          Nome: {{ animal.name }}<br>
-        {% endif %}
-        {% if animal.species %}
-          Espécie: {{ animal.species }}<br>
-        {% endif %}
-        {% if animal.breed %}
-          Raça: {{ animal.breed }}<br>
-        {% endif %}
-        {% if animal.sex %}
-          Sexo: {{ animal.sex }}<br>
-        {% endif %}
-        {% if animal.microchip_number %}
-          Microchip: {{ animal.microchip_number }}
-        {% endif %}
-      </div>
+      <section class="info-card">
+        <h3>Paciente</h3>
+        <ul class="info-list">
+          <li><span>Nome</span><span>{{ animal.name }}</span></li>
+          {% if animal.species %}<li><span>Espécie</span><span>{{ animal.species }}</span></li>{% endif %}
+          {% if animal.breed %}<li><span>Raça</span><span>{{ animal.breed }}</span></li>{% endif %}
+          {% if animal.sex %}<li><span>Sexo</span><span>{{ animal.sex }}</span></li>{% endif %}
+          {% if animal.microchip_number %}<li><span>Microchip</span><span>{{ animal.microchip_number }}</span></li>{% endif %}
+        </ul>
+      </section>
     {% endif %}
 
-    {% if tutor.name or tutor.cpf or tutor.address %}
-      <div class="info-box">
-        <strong>Responsável</strong><br>
-        {% if tutor.name %}
-          Nome: {{ tutor.name }}<br>
-        {% endif %}
-        {% if tutor.cpf %}
-          CPF: {{ tutor.cpf }}<br>
-        {% endif %}
-        {% if tutor.address %}
-          Endereço: {{ tutor.address }}
-        {% endif %}
-      </div>
+    {% if tutor.name or tutor.cpf or tutor.address or tutor.phone %}
+      <section class="info-card">
+        <h3>Responsável</h3>
+        <ul class="info-list">
+          <li><span>Nome</span><span>{{ tutor.name }}</span></li>
+          {% if tutor.cpf %}<li><span>CPF</span><span>{{ tutor.cpf }}</span></li>{% endif %}
+          {% if tutor.phone %}<li><span>Contato</span><span>{{ tutor.phone }}</span></li>{% endif %}
+          {% if tutor.address %}<li><span>Endereço</span><span>{{ tutor.address }}</span></li>{% endif %}
+        </ul>
+      </section>
     {% endif %}
   </div>
 
@@ -81,30 +86,37 @@
   <div class="exames">
     {% for exame in bloco.exames %}
       <div class="exame-item">
-        <strong>{{ exame.nome }}</strong><br>
-        <em style="color: #555;">{{ exame.justificativa }}</em>
+        <strong>{{ exame.nome }}</strong>
+        {% if exame.justificativa %}
+          <p class="prescricao-obs">{{ exame.justificativa }}</p>
+        {% endif %}
       </div>
     {% endfor %}
   </div>
 
   {% if bloco.observacoes_gerais %}
     <div class="section-title">Observações</div>
-    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 4px; line-height: 1.6;">
+    <div class="note-block">
       {{ bloco.observacoes_gerais }}
     </div>
   {% endif %}
 
-  <div class="assinatura">
-    ___________________________________________<br>
-    <span>{{ veterinario.name if veterinario else '' }}</span>
-    <span>CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span>
+  <div class="signature-block">
+    <div class="signature">
+      <div class="signature-line"></div>
+      <span>{{ veterinario.name if veterinario else '' }}</span>
+      <span>CRMV {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span>
+    </div>
   </div>
 
   <footer>
-    {{ clinica.nome }} – {{ clinica.endereco }}<br>
-    {% if clinica.telefone %}Telefone: {{ clinica.telefone }} • {% endif %}
-    {% if clinica.email %}Email: {{ clinica.email }} • {% endif %}
-    {% if clinica.cnpj %}CNPJ: {{ clinica.cnpj }}{% endif %}
+    {% if clinica %}
+      <span>{{ clinica.nome }}</span>
+      {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+      {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+      {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+      {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+    {% endif %}
   </footer>
 </div>
 

--- a/templates/orcamentos/imprimir_orcamento.html
+++ b/templates/orcamentos/imprimir_orcamento.html
@@ -19,73 +19,104 @@
 <div class="document">
   {% if clinica %}
     <div class="header">
-      {{ clinic_logo(clinica) }}
-      <div class="clinica-nome">{{ clinica.nome }}</div>
-      {{ clinic_logo(clinica) }}
+      <div class="header-logo">
+        {{ clinic_logo(clinica) }}
+      </div>
+      <div class="header-info">
+        <div class="clinica-nome">{{ clinica.nome }}</div>
+        <div class="clinica-contato">
+          {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+          {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+          {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+          {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+        </div>
+      </div>
     </div>
   {% endif %}
 
-  <h2>Orçamento da Consulta</h2>
+  <div class="document-title-group">
+    <h1 class="document-title">Orçamento da Consulta</h1>
+    <span class="document-tag">Estimativa de custos</span>
+  </div>
 
-  <div class="top-info">
-    <div class="info-box">
-      <strong>Profissional Responsável</strong><br>
-      {{ veterinario.name }}<br>
-      CRMV: {{ veterinario.veterinario.crmv if veterinario.veterinario else '—' }}
-    </div>
+  <div class="document-meta">
+    <span>Paciente: {{ animal.name }}</span>
+    <span>Responsável: {{ tutor.name }}</span>
+    {% if veterinario and veterinario.name %}<span>Profissional: {{ veterinario.name }}</span>{% endif %}
+  </div>
 
-    <div class="info-box">
-      <strong>Paciente</strong><br>
-      Nome: {{ animal.name }}<br>
-      Espécie: {{ animal.species }}<br>
-      Raça: {{ animal.breed or '—' }}<br>
-      Sexo: {{ animal.sex or '—' }}<br>
-      Peso: {{ animal.peso or '—' }} kg<br>
-      Microchip: {{ animal.microchip_number or '—' }}
-    </div>
-
-    <div class="info-box">
-      <strong>Responsável</strong><br>
-      Nome: {{ tutor.name }}<br>
-      CPF: {{ tutor.cpf or '—' }}<br>
-      Endereço: {{ tutor.address or '—' }}
-    </div>
+  <div class="info-grid">
+    <section class="info-card">
+      <h3>Profissional Responsável</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ veterinario.name }}</span></li>
+        <li><span>CRMV</span><span>{{ veterinario.veterinario.crmv if veterinario.veterinario else '—' }}</span></li>
+      </ul>
+    </section>
+    <section class="info-card">
+      <h3>Paciente</h3>
+      <ul class="info-list">
+        <li><span>Espécie</span><span>{{ animal.species or '—' }}</span></li>
+        <li><span>Raça</span><span>{{ animal.breed or '—' }}</span></li>
+        <li><span>Sexo</span><span>{{ animal.sex or '—' }}</span></li>
+        <li><span>Peso</span><span>{{ animal.peso or '—' }} kg</span></li>
+        {% if animal.microchip_number %}<li><span>Microchip</span><span>{{ animal.microchip_number }}</span></li>{% endif %}
+      </ul>
+    </section>
+    <section class="info-card">
+      <h3>Responsável</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ tutor.name }}</span></li>
+        <li><span>CPF</span><span>{{ tutor.cpf or '—' }}</span></li>
+        <li><span>Contato</span><span>{{ tutor.phone or '—' }}</span></li>
+        <li><span>Endereço</span><span>{{ tutor.address or '—' }}</span></li>
+      </ul>
+    </section>
   </div>
 
   <table>
     <thead>
       <tr>
         <th>Descrição</th>
-        <th>Valor (R$)</th>
+        <th style="width: 140px; text-align: right;">Valor (R$)</th>
       </tr>
     </thead>
     <tbody>
       {% for item in itens %}
-      <tr>
-        <td>{{ item.descricao }}</td>
-        <td>{{ '%.2f'|format(item.valor) }}</td>
-      </tr>
+        <tr>
+          <td>{{ item.descricao }}</td>
+          <td style="text-align: right;">{{ '%.2f'|format(item.valor) }}</td>
+        </tr>
       {% endfor %}
+    </tbody>
+    <tfoot>
       <tr>
         <th>Total</th>
-        <th>{{ '%.2f'|format(total) }}</th>
+        <th style="text-align: right;">{{ '%.2f'|format(total) }}</th>
       </tr>
-    </tbody>
+    </tfoot>
   </table>
 
-  <div class="assinatura">
-    ___________________________________________<br>
-    <span>{{ veterinario.name }}</span>
-    <span>CRMV: {{ veterinario.veterinario.crmv if veterinario.veterinario else '—' }}</span>
+  <div class="note-block">
+    Este orçamento tem validade de 30 dias a partir da data de emissão e poderá sofrer ajustes conforme a evolução clínica do paciente.
+  </div>
+
+  <div class="signature-block">
+    <div class="signature">
+      <div class="signature-line"></div>
+      <span>{{ veterinario.name }}</span>
+      <span>CRMV {{ veterinario.veterinario.crmv if veterinario.veterinario else '—' }}</span>
+    </div>
   </div>
 
   {% if clinica %}
-  <footer>
-    {{ clinica.nome }} – {{ clinica.endereco }}<br>
-    {% if clinica.telefone %}Telefone: {{ clinica.telefone }} • {% endif %}
-    {% if clinica.email %}Email: {{ clinica.email }} • {% endif %}
-    {% if clinica.cnpj %}CNPJ: {{ clinica.cnpj }}{% endif %}
-  </footer>
+    <footer>
+      <span>{{ clinica.nome }}</span>
+      {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+      {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+      {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+      {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+    </footer>
   {% endif %}
 </div>
 

--- a/templates/orcamentos/imprimir_orcamento_padrao.html
+++ b/templates/orcamentos/imprimir_orcamento_padrao.html
@@ -15,46 +15,71 @@
 <div class="document">
   {% if clinica %}
     <div class="header">
-      {{ clinic_logo(clinica) }}
-      <div class="clinica-nome">{{ clinica.nome }}</div>
-      {{ clinic_logo(clinica) }}
+      <div class="header-logo">
+        {{ clinic_logo(clinica) }}
+      </div>
+      <div class="header-info">
+        <div class="clinica-nome">{{ clinica.nome }}</div>
+        <div class="clinica-contato">
+          {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+          {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+          {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+          {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+        </div>
+      </div>
     </div>
   {% endif %}
-  <h2>Orçamento</h2>
-  <div class="top-info">
-    <div class="info-box">
-      <strong>Profissional Responsável</strong><br>
-      {{ veterinario.name if veterinario else '' }}<br>
-      CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}
-    </div>
+
+  <div class="document-title-group">
+    <h1 class="document-title">Orçamento</h1>
+    <span class="document-tag">Proposta comercial</span>
   </div>
+
+  <div class="info-grid">
+    <section class="info-card">
+      <h3>Profissional Responsável</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ veterinario.name if veterinario else '—' }}</span></li>
+        <li><span>CRMV</span><span>{{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span></li>
+      </ul>
+    </section>
+  </div>
+
   <table>
     <thead>
       <tr>
         <th>Descrição</th>
-        <th>Valor (R$)</th>
+        <th style="width: 140px; text-align: right;">Valor (R$)</th>
       </tr>
     </thead>
     <tbody>
       {% for item in itens %}
-      <tr>
-        <td>{{ item.descricao }}</td>
-        <td>{{ '%.2f'|format(item.valor) }}</td>
-      </tr>
+        <tr>
+          <td>{{ item.descricao }}</td>
+          <td style="text-align: right;">{{ '%.2f'|format(item.valor) }}</td>
+        </tr>
       {% endfor %}
+    </tbody>
+    <tfoot>
       <tr>
         <th>Total</th>
-        <th>{{ '%.2f'|format(total) }}</th>
+        <th style="text-align: right;">{{ '%.2f'|format(total) }}</th>
       </tr>
-    </tbody>
+    </tfoot>
   </table>
+
+  <div class="note-block">
+    Valores válidos exclusivamente para os itens listados acima. Consulte a clínica para condições de pagamento e opções adicionais.
+  </div>
+
   {% if clinica %}
-  <footer>
-    {{ clinica.nome }} – {{ clinica.endereco }}<br>
-    {% if clinica.telefone %}Telefone: {{ clinica.telefone }} • {% endif %}
-    {% if clinica.email %}Email: {{ clinica.email }} • {% endif %}
-    {% if clinica.cnpj %}CNPJ: {{ clinica.cnpj }}{% endif %}
-  </footer>
+    <footer>
+      <span>{{ clinica.nome }}</span>
+      {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+      {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+      {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+      {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+    </footer>
   {% endif %}
 </div>
 </body>

--- a/templates/orcamentos/imprimir_vacinas.html
+++ b/templates/orcamentos/imprimir_vacinas.html
@@ -18,37 +18,60 @@
 <div class="document">
   {% if clinica %}
     <div class="header">
-      {{ clinic_logo(clinica) }}
-      <div class="clinica-nome">{{ clinica.nome }}</div>
-      {{ clinic_logo(clinica) }}
+      <div class="header-logo">
+        {{ clinic_logo(clinica) }}
+      </div>
+      <div class="header-info">
+        <div class="clinica-nome">{{ clinica.nome }}</div>
+        <div class="clinica-contato">
+          {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+          {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+          {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
+          {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
+        </div>
+      </div>
     </div>
   {% endif %}
 
-  <h2>Carteira de Vacinação</h2>
+  <div class="document-title-group">
+    <h1 class="document-title">Carteira de Vacinação</h1>
+    <span class="document-tag">Histórico de imunizações</span>
+  </div>
 
-  <div class="top-info">
-    <div class="info-box">
-      <strong>Paciente</strong><br>
-      Nome: {{ animal.name }}<br>
-      Espécie: {{ animal.species }}<br>
-      Raça: {{ animal.breed or '—' }}<br>
-      Nascimento: {{ animal.birth_date.strftime('%d/%m/%Y') if animal.birth_date else '—' }}
-    </div>
+  <div class="document-meta">
+    <span>Paciente: {{ animal.name }}</span>
+    <span>Responsável: {{ animal.owner.name }}</span>
+    {% if animal.birth_date %}<span>Nasc.: {{ animal.birth_date.strftime('%d/%m/%Y') }}</span>{% endif %}
+  </div>
 
-    <div class="info-box">
-      <strong>Responsável</strong><br>
-      Nome: {{ animal.owner.name }}<br>
-      CPF: {{ animal.owner.cpf or '—' }}<br>
-      Telefone: {{ animal.owner.phone or '—' }}
-    </div>
-
-    <div class="info-box">
-      <strong>Clínica</strong><br>
-      {{ clinica.nome if clinica else '—' }}<br>
-      Veterinário: {{ veterinario.name if veterinario else '—' }}<br>
-      CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}<br>
-      Telefone: {{ clinica.telefone if clinica and clinica.telefone else '—' }}
-    </div>
+  <div class="info-grid">
+    <section class="info-card">
+      <h3>Paciente</h3>
+      <ul class="info-list">
+        <li><span>Espécie</span><span>{{ animal.species or '—' }}</span></li>
+        <li><span>Raça</span><span>{{ animal.breed or '—' }}</span></li>
+        {% if animal.sex %}<li><span>Sexo</span><span>{{ animal.sex }}</span></li>{% endif %}
+        {% if animal.microchip_number %}<li><span>Microchip</span><span>{{ animal.microchip_number }}</span></li>{% endif %}
+      </ul>
+    </section>
+    <section class="info-card">
+      <h3>Responsável</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ animal.owner.name }}</span></li>
+        <li><span>CPF</span><span>{{ animal.owner.cpf or '—' }}</span></li>
+        <li><span>Contato</span><span>{{ animal.owner.phone or '—' }}</span></li>
+        <li><span>Endereço</span><span>{{ animal.owner.address or '—' }}</span></li>
+      </ul>
+    </section>
+    <section class="info-card">
+      <h3>Clínica</h3>
+      <ul class="info-list">
+        <li><span>Nome</span><span>{{ clinica.nome if clinica else '—' }}</span></li>
+        <li><span>Veterinário</span><span>{{ veterinario.name if veterinario else '—' }}</span></li>
+        <li><span>CRMV</span><span>{{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '—' }}</span></li>
+        <li><span>Telefone</span><span>{{ clinica.telefone if clinica and clinica.telefone else '—' }}</span></li>
+      </ul>
+    </section>
   </div>
 
   <table>
@@ -64,34 +87,37 @@
     </thead>
     <tbody>
       {% for vacina in animal.vacinas_ordenadas %}
-      <tr>
-        <td>{{ vacina.aplicada_em.strftime('%d/%m/%Y') if vacina.aplicada_em else '—' }}</td>
-        <td>{{ vacina.nome }}</td>
-        <td>{{ vacina.tipo or '—' }}</td>
-        <td>{{ vacina.lote or '—' }}</td>
-        <td>{{ vacina.veterinario or '—' }}</td>
-        <td>{{ vacina.proxima_dose.strftime('%d/%m/%Y') if vacina.proxima_dose else '—' }}</td>
-      </tr>
+        <tr>
+          <td>{{ vacina.aplicada_em.strftime('%d/%m/%Y') if vacina.aplicada_em else '—' }}</td>
+          <td>{{ vacina.nome }}</td>
+          <td>{{ vacina.tipo or '—' }}</td>
+          <td>{{ vacina.lote or '—' }}</td>
+          <td>{{ vacina.veterinario or '—' }}</td>
+          <td>{{ vacina.proxima_dose.strftime('%d/%m/%Y') if vacina.proxima_dose else '—' }}</td>
+        </tr>
       {% endfor %}
     </tbody>
   </table>
 
-  <div class="assinaturas">
-    <div>
-      ___________________________________________<br>
+  <div class="signature-grid">
+    <div class="signature">
+      <div class="signature-line"></div>
       <span>{{ veterinario.name if veterinario else 'Responsável pela Aplicação' }}</span>
-      <span>CRMV: {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '_________________________' }}</span>
+      <span>CRMV {{ veterinario.veterinario.crmv if veterinario and veterinario.veterinario else '_________________________' }}</span>
     </div>
-    <div>
-      ___________________________________________<br>
+    <div class="signature">
+      <div class="signature-line"></div>
       <span>Responsável pelo Animal</span>
     </div>
   </div>
 
   <footer>
-    Documento válido apenas com carimbo e assinatura do médico veterinário responsável.<br>
+    <span>Documento válido apenas com carimbo e assinatura do médico veterinário responsável.</span>
     {% if clinica %}
-      {{ clinica.nome }} • {{ clinica.endereco or '—' }} • {{ clinica.telefone or '—' }} • {{ clinica.email or '—' }}
+      <span>{{ clinica.nome }}</span>
+      {% if clinica.endereco %}<span>{{ clinica.endereco }}</span>{% endif %}
+      {% if clinica.telefone %}<span>Tel.: {{ clinica.telefone }}</span>{% endif %}
+      {% if clinica.email %}<span>{{ clinica.email }}</span>{% endif %}
     {% endif %}
   </footer>
 </div>

--- a/templates/partials/historico_prescricoes.html
+++ b/templates/partials/historico_prescricoes.html
@@ -1,56 +1,82 @@
 {% if animal.blocos_prescricao %}
-<div class="card mb-3">
+<div class="prescricao-history card mb-3">
   <div class="card-body">
-    <h5 class="card-title">📜 Histórico de Prescrições</h5>
-
-    {% for bloco in animal.blocos_prescricao|reverse %}
-    <div class="border rounded p-3 mb-3">
-      <h6 class="text-muted">Prescrição feita em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</h6>
-
-      <ul class="list-group list-group-flush mb-2">
-        {% for item in bloco.prescricoes %}
-        <li class="list-group-item">
-          <strong>{{ item.medicamento }}</strong> —
-          {% if item.dosagem or item.frequencia or item.duracao %}
-            {{ item.dosagem or '–' }}, {{ item.frequencia or '–' }}, por {{ item.duracao or '–' }}
-            {% if item.observacoes %}
-              <br><em>Obs:</em> {{ item.observacoes }}
-            {% endif %}
-          {% else %}
-            <em>{{ item.observacoes or '–' }}</em>
-          {% endif %}
-        </li>
-        {% endfor %}
-      </ul>
-
-      {% if bloco.instrucoes_gerais %}
-      <div class="alert alert-secondary py-2" role="alert">
-        <strong>Orientações e Cuidados:</strong> {{ bloco.instrucoes_gerais }}
-      </div>
-      {% endif %}
-
-      <!-- Botões de ação -->
-      <div class="d-flex flex-wrap gap-2">
-        <form method="POST"
-              action="{{ url_for('deletar_bloco_prescricao', bloco_id=bloco.id) }}"
-              class="d-inline delete-history-form" data-sync
-              data-target="historico-prescricoes"
-              data-confirm="Deseja mesmo excluir este bloco de prescrições?">
-          <button class="btn btn-danger btn-sm">🗑 Excluir</button>
-        </form>
-
-        <a href="{{ url_for('imprimir_bloco_prescricao', bloco_id=bloco.id) }}"
-           class="btn btn-outline-secondary btn-sm" target="_blank">
-          🖨 Imprimir
-        </a>
-
-        <a href="{{ url_for('editar_bloco_prescricao', bloco_id=bloco.id) }}"
-           class="btn btn-outline-primary btn-sm">
-          ✏️ Editar
-        </a>
-      </div>
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+      <h5 class="card-title mb-0">📜 Histórico de Prescrições</h5>
+      <span class="text-muted small">Visualize, imprima ou edite cada prescrição emitida para este paciente.</span>
     </div>
-    {% endfor %}
+
+    <div class="prescricao-history__grid">
+      {% for bloco in animal.blocos_prescricao|reverse %}
+        <article class="prescricao-card">
+          <header class="prescricao-card__header">
+            <div>
+              <span class="prescricao-card__tag">Prescrição</span>
+              <h6 class="prescricao-card__title">Emitida em {{ bloco.data_criacao|format_datetime_brazil('%d/%m/%Y %H:%M') }}</h6>
+            </div>
+            <div class="prescricao-card__meta">
+              <span>ID #{{ bloco.id }}</span>
+              {% if bloco.prescricoes and bloco.prescricoes[0].data_prescricao %}
+                <span>Atualizado em {{ bloco.prescricoes[0].data_prescricao|format_datetime_brazil('%d/%m/%Y') }}</span>
+              {% endif %}
+            </div>
+          </header>
+
+          <ul class="prescricao-card__list">
+            {% for item in bloco.prescricoes %}
+              <li class="prescricao-card__item">
+                <div class="prescricao-card__item-head">
+                  <strong>{{ item.medicamento }}</strong>
+                  {% if item.dosagem or item.frequencia or item.duracao %}
+                    <div class="prescricao-card__pill-group">
+                      {% if item.dosagem %}<span class="prescricao-card__pill">Dosagem: {{ item.dosagem }}</span>{% endif %}
+                      {% if item.frequencia %}<span class="prescricao-card__pill">Frequência: {{ item.frequencia }}</span>{% endif %}
+                      {% if item.duracao %}<span class="prescricao-card__pill">Duração: {{ item.duracao }}</span>{% endif %}
+                    </div>
+                  {% endif %}
+                </div>
+                {% set texto_livre = (not (item.dosagem or item.frequencia or item.duracao)) %}
+                {% if item.observacoes %}
+                  <p class="prescricao-card__obs">{{ item.observacoes }}</p>
+                {% elif texto_livre %}
+                  <p class="prescricao-card__obs text-muted">Posologia detalhada diretamente na consulta.</p>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+
+          {% if bloco.instrucoes_gerais %}
+            <div class="prescricao-card__note">
+              <span class="prescricao-card__note-label">Orientações gerais</span>
+              <p class="mb-0">{{ bloco.instrucoes_gerais }}</p>
+            </div>
+          {% endif %}
+
+          <footer class="prescricao-card__footer">
+            <form method="POST"
+                  action="{{ url_for('deletar_bloco_prescricao', bloco_id=bloco.id) }}"
+                  class="delete-history-form"
+                  data-sync
+                  data-target="historico-prescricoes"
+                  data-confirm="Deseja mesmo excluir este bloco de prescrições?">
+              <button class="btn btn-outline-danger btn-sm">
+                <i class="fas fa-trash-alt me-1"></i>Excluir
+              </button>
+            </form>
+            <div class="d-flex gap-2">
+              <a href="{{ url_for('imprimir_bloco_prescricao', bloco_id=bloco.id) }}"
+                 class="btn btn-outline-secondary btn-sm" target="_blank">
+                <i class="fas fa-print me-1"></i>Imprimir
+              </a>
+              <a href="{{ url_for('editar_bloco_prescricao', bloco_id=bloco.id) }}"
+                 class="btn btn-primary btn-sm">
+                <i class="fas fa-pen me-1"></i>Editar
+              </a>
+            </div>
+          </footer>
+        </article>
+      {% endfor %}
+    </div>
   </div>
 </div>
 {% else %}


### PR DESCRIPTION
## Summary
- refresh the shared print stylesheet with A4-aware spacing, refined typography, and reusable components for signatures and information grids
- rework printable prescription, consultation, exam, budget, and vaccine templates to use the new layout and clearer metadata blocks
- redesign the online prescription history cards with richer styling and actionable controls

## Testing
- pytest tests/test_imprimir_orcamento.py

------
https://chatgpt.com/codex/tasks/task_e_68e3b96c4ee8832e84f261c3d169a533