### PR TITLE
Show confirmed requested exams in vet pending queue

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -461,12 +461,12 @@
           <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
             <i class="fas fa-user-clock me-2"></i>Exames aguardando outros profissionais
           </div>
-          {% for exam in exams_waiting_other_vets %}
-            {% set can_respond = exam.time_left.total_seconds() > 0 %}
+          {% for item in exams_waiting_other_vets %}
+            {% set exam = item.exam %}
             <div class="list-group-item d-flex justify-content-between align-items-center">
               <div class="d-flex align-items-center">
                 <div class="me-3">
-                  <i class="fas fa-flask text-warning fa-2x"></i>
+                  <i class="fas fa-flask fa-2x {{ item.icon_class }}"></i>
                 </div>
                 <div>
                   <h6 class="mb-0">{{ exam.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ exam.animal.name }}</h6>
@@ -478,16 +478,16 @@
                     {% endif %}
                   </small>
                   <div class="mt-1">
-                    {% if can_respond %}
+                    {% if item.show_time_left %}
                       <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Tempo restante: {{ exam.time_left|format_timedelta }}</small>
-                    {% else %}
-                      <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
+                    {% elif exam.status == 'confirmed' %}
+                      <small class="text-muted"><i class="fas fa-check-circle text-success me-1"></i>Confirmado pelo especialista</small>
                     {% endif %}
                   </div>
                 </div>
               </div>
               <div class="text-end">
-                <span class="badge bg-warning text-dark">Aguardando confirmação</span>
+                <span class="badge {{ item.badge_class }}">{{ item.status_label }}</span>
               </div>
             </div>
           {% endfor %}

--- a/tests/test_vet_pending_exam_status.py
+++ b/tests/test_vet_pending_exam_status.py
@@ -1,0 +1,142 @@
+import os
+import sys
+
+os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+import flask_login.utils as login_utils
+from datetime import datetime, timedelta
+
+from app import app as flask_app, db
+from models import User, Veterinario, Clinica, Animal, ExamAppointment
+
+
+@pytest.fixture
+def client():
+    flask_app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            db.create_all()
+        yield client
+        with flask_app.app_context():
+            db.drop_all()
+
+
+def login(monkeypatch, user):
+    monkeypatch.setattr(login_utils, '_get_user', lambda: user)
+
+
+def test_confirmed_requested_exam_visible_with_status_badge(client, monkeypatch):
+    with flask_app.app_context():
+        clinic = Clinica(id=1, nome='Clinica')
+        requester_user = User(
+            id=1,
+            name='Dr. Requester',
+            email='requester@test',
+            worker='veterinario',
+            role='adotante',
+        )
+        requester_user.set_password('x')
+        requester_vet = Veterinario(
+            id=1,
+            user=requester_user,
+            crmv='REQ123',
+            clinica=clinic,
+        )
+
+        specialist_user = User(
+            id=2,
+            name='Dr. Specialist',
+            email='specialist@test',
+            worker='veterinario',
+        )
+        specialist_user.set_password('y')
+        specialist_vet = Veterinario(
+            id=2,
+            user=specialist_user,
+            crmv='SPEC456',
+            clinica=clinic,
+        )
+
+        tutor_user = User(
+            id=3,
+            name='Tutor',
+            email='tutor@test',
+            worker='adotante',
+            role='adotante',
+        )
+        tutor_user.set_password('z')
+
+        animal = Animal(
+            id=1,
+            name='Rex',
+            status='available',
+            user_id=tutor_user.id,
+            clinica=clinic,
+        )
+
+        exam = ExamAppointment(
+            id=1,
+            animal=animal,
+            specialist=specialist_vet,
+            requester=requester_user,
+            scheduled_at=datetime.utcnow() + timedelta(days=1),
+            status='confirmed',
+        )
+
+        db.session.add_all(
+            [
+                clinic,
+                requester_user,
+                requester_vet,
+                specialist_user,
+                specialist_vet,
+                tutor_user,
+                animal,
+                exam,
+            ]
+        )
+        db.session.commit()
+
+        requester_vet_id = requester_vet.id
+        requester_user_id = requester_user.id
+        requester_user_name = requester_user.name
+        clinic_id = clinic.id
+
+    fake_user = type(
+        'U',
+        (),
+        {
+            'id': requester_user_id,
+            'worker': 'veterinario',
+            'role': 'adotante',
+            'name': requester_user_name,
+            'is_authenticated': True,
+            'veterinario': type(
+                'V',
+                (),
+                {
+                    'id': requester_vet_id,
+                    'user_id': requester_user_id,
+                    'user': type('WU', (), {'name': requester_user_name})(),
+                    'clinica_id': clinic_id,
+                },
+            )(),
+        },
+    )()
+
+    login(monkeypatch, fake_user)
+
+    response = client.get('/appointments')
+    assert response.status_code == 200
+    html = response.data.decode()
+    assert 'Exames aguardando outros profissionais' in html
+    assert 'Rex' in html
+    assert 'Confirmado' in html
+    assert 'Confirmado pelo especialista' in html


### PR DESCRIPTION
## Summary
- include confirmed exam appointments requested by the current veterinarian in the pending query while preparing display metadata for status badges
- update the vet schedule template to render pending and confirmed exam requests with distinct icons and labels
- add a regression test covering the confirmed exam scenario on the veterinarian schedule page

## Testing
- pytest tests/test_vet_pending_exam_status.py

------
https://chatgpt.com/codex/tasks/task_e_68e3bdc9341c832e8a96b816ebe589ad