### PR TITLE
Mirror clinic logos across printable headers

### DIFF
--- a/static/print.css
+++ b/static/print.css
@@ -42,6 +42,7 @@ body {
 .header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 24px;
   padding-bottom: 18px;
   margin-bottom: 24px;
@@ -64,6 +65,8 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  text-align: center;
   gap: 6px;
 }
 
@@ -79,7 +82,12 @@ body {
   color: var(--muted-text);
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 8px 16px;
+}
+
+.header-logo--right {
+  justify-content: flex-end;
 }
 
 .clinica-contato span::before {

--- a/templates/orcamentos/imprimir_bloco.html
+++ b/templates/orcamentos/imprimir_bloco.html
@@ -32,6 +32,9 @@
           {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
         </div>
       </div>
+      <div class="header-logo header-logo--right">
+        {{ clinic_logo(clinica) }}
+      </div>
     </div>
   {% endif %}
 

--- a/templates/orcamentos/imprimir_consulta.html
+++ b/templates/orcamentos/imprimir_consulta.html
@@ -31,6 +31,9 @@
           {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
         </div>
       </div>
+      <div class="header-logo header-logo--right">
+        {{ clinic_logo(clinica) }}
+      </div>
     </div>
   {% endif %}
 

--- a/templates/orcamentos/imprimir_exames.html
+++ b/templates/orcamentos/imprimir_exames.html
@@ -31,6 +31,9 @@
           {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
         </div>
       </div>
+      <div class="header-logo header-logo--right">
+        {{ clinic_logo(clinica) }}
+      </div>
     </div>
   {% endif %}
 

--- a/templates/orcamentos/imprimir_orcamento.html
+++ b/templates/orcamentos/imprimir_orcamento.html
@@ -31,6 +31,9 @@
           {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
         </div>
       </div>
+      <div class="header-logo header-logo--right">
+        {{ clinic_logo(clinica) }}
+      </div>
     </div>
   {% endif %}
 

--- a/templates/orcamentos/imprimir_orcamento_padrao.html
+++ b/templates/orcamentos/imprimir_orcamento_padrao.html
@@ -27,6 +27,9 @@
           {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
         </div>
       </div>
+      <div class="header-logo header-logo--right">
+        {{ clinic_logo(clinica) }}
+      </div>
     </div>
   {% endif %}
 

--- a/templates/orcamentos/imprimir_vacinas.html
+++ b/templates/orcamentos/imprimir_vacinas.html
@@ -30,6 +30,9 @@
           {% if clinica.cnpj %}<span>CNPJ {{ clinica.cnpj }}</span>{% endif %}
         </div>
       </div>
+      <div class="header-logo header-logo--right">
+        {{ clinic_logo(clinica) }}
+      </div>
     </div>
   {% endif %}
 


### PR DESCRIPTION
## Summary
- center the clinic header details and balance spacing in the shared print stylesheet
- render the clinic logo on both sides of the header across all printable budget and record templates

## Testing
- not run (print-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3bfb0658c832e874a831f8e162d01