### PR TITLE
Enable vets to manage pending exam requests

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -463,7 +463,21 @@
           </div>
           {% for item in exams_waiting_other_vets %}
             {% set exam = item.exam %}
-            <div class="list-group-item d-flex justify-content-between align-items-center">
+            <div
+              class="list-group-item d-flex justify-content-between align-items-center"
+              data-exam-requester-row
+              data-exam-id="{{ exam.id }}"
+              data-exam-status="{{ exam.status }}"
+              data-exam-status-label="{{ item.status_label }}"
+              data-exam-badge-class="{{ item.badge_class }}"
+              data-exam-icon-class="{{ item.icon_class }}"
+              data-exam-confirm-by="{{ exam.confirm_by|format_datetime_brazil('%Y-%m-%dT%H:%M') if exam.confirm_by else '' }}"
+              data-exam-confirm-by-display="{{ exam.confirm_by|format_datetime_brazil('%d/%m/%Y %H:%M') if exam.confirm_by else '' }}"
+              data-exam-scheduled="{{ exam.scheduled_at|format_datetime_brazil('%Y-%m-%dT%H:%M') }}"
+              data-exam-scheduled-display="{{ exam.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }}"
+              data-exam-animal="{{ exam.animal.name }}"
+              data-exam-specialist="{{ exam.specialist.user.name if exam.specialist and exam.specialist.user else '' }}"
+            >
               <div class="d-flex align-items-center">
                 <div class="me-3">
                   <i class="fas fa-flask fa-2x {{ item.icon_class }}"></i>
@@ -911,6 +925,48 @@
         </div>
       </div>
     </div>
+</div>
+
+  <div class="modal fade" id="examRequesterModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Gerenciar solicitação de exame</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-danger d-none" id="exam-requester-feedback" role="alert"></div>
+          <dl class="row mb-4">
+            <dt class="col-sm-4">Paciente</dt>
+            <dd class="col-sm-8" id="exam-requester-animal">—</dd>
+            <dt class="col-sm-4">Especialista</dt>
+            <dd class="col-sm-8" id="exam-requester-specialist">—</dd>
+            <dt class="col-sm-4">Agendado para</dt>
+            <dd class="col-sm-8" id="exam-requester-scheduled">—</dd>
+            <dt class="col-sm-4">Status atual</dt>
+            <dd class="col-sm-8"><span class="badge bg-secondary" id="exam-requester-status-label">—</span></dd>
+          </dl>
+          <input type="hidden" id="exam-requester-id">
+          <div class="mb-3">
+            <label for="exam-requester-confirm-by" class="form-label">Prazo para confirmação</label>
+            <input type="datetime-local" class="form-control" id="exam-requester-confirm-by">
+            <div class="form-text">Defina até quando o especialista deve responder.</div>
+          </div>
+          <div class="mb-3">
+            <label for="exam-requester-status" class="form-label">Status da solicitação</label>
+            <select class="form-select" id="exam-requester-status">
+              <option value="pending">Aguardando confirmação</option>
+              <option value="confirmed" disabled>Confirmado</option>
+              <option value="canceled">Cancelar solicitação</option>
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Fechar</button>
+          <button type="button" class="btn btn-primary" id="exam-requester-save">Salvar alterações</button>
+        </div>
+      </div>
+    </div>
   </div>
 
 </div>
@@ -927,6 +983,14 @@
   .appointment-item:hover {
     background-color: #f8f9fa !important;
     transform: translateX(5px);
+  }
+
+  [data-exam-requester-row] {
+    cursor: pointer;
+  }
+
+  [data-exam-requester-row]:hover {
+    background-color: #f8f9fa;
   }
   
   .btn {

--- a/tests/test_schedule_exam.py
+++ b/tests/test_schedule_exam.py
@@ -5,9 +5,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 import flask_login.utils as login_utils
-from app import app as flask_app, db
+from app import app as flask_app, db, BR_TZ
 from models import User, Clinica, Animal, Veterinario, Specialty, VetSchedule, ExamAppointment, AgendaEvento, Message
-from datetime import datetime, time, date
+from datetime import datetime, time, date, timezone
 from helpers import get_available_times
 
 
@@ -251,3 +251,83 @@ def test_update_exam_appointment_blocks_overlap(client, monkeypatch):
     assert resp.status_code == 400
     data = resp.get_json()
     assert not data['success']
+
+
+def test_requester_can_update_exam_confirm_by(client, monkeypatch):
+    with flask_app.app_context():
+        tutor_id, vet_user_id, animal_id, vet_id = setup_data()
+    requester = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
+    login(monkeypatch, requester)
+    client.post(
+        f'/animal/{animal_id}/schedule_exam',
+        json={'specialist_id': vet_id, 'date': '2024-05-20', 'time': '09:00'},
+        headers={'Accept': 'application/json'}
+    )
+    resp = client.post(
+        '/exam_appointment/1/requester_update',
+        json={'confirm_by': '2024-05-21T12:30', 'status': 'pending'},
+        headers={'Accept': 'application/json'}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success']
+    with flask_app.app_context():
+        appt = ExamAppointment.query.get(1)
+        expected = datetime(2024, 5, 21, 12, 30, tzinfo=BR_TZ).astimezone(timezone.utc).replace(tzinfo=None)
+        assert appt.confirm_by == expected
+        assert appt.status == 'pending'
+
+
+def test_requester_can_cancel_pending_exam(client, monkeypatch):
+    with flask_app.app_context():
+        tutor_id, vet_user_id, animal_id, vet_id = setup_data()
+    requester = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
+    login(monkeypatch, requester)
+    client.post(
+        f'/animal/{animal_id}/schedule_exam',
+        json={'specialist_id': vet_id, 'date': '2024-05-20', 'time': '09:00'},
+        headers={'Accept': 'application/json'}
+    )
+    resp = client.post(
+        '/exam_appointment/1/requester_update',
+        json={'status': 'canceled'},
+        headers={'Accept': 'application/json'}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success']
+    with flask_app.app_context():
+        appt = ExamAppointment.query.get(1)
+        assert appt.status == 'canceled'
+
+
+def test_non_requester_cannot_update_exam_request(client, monkeypatch):
+    with flask_app.app_context():
+        tutor_id, vet_user_id, animal_id, vet_id = setup_data()
+        vet_obj = Veterinario.query.get(vet_id)
+    requester = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
+    login(monkeypatch, requester)
+    client.post(
+        f'/animal/{animal_id}/schedule_exam',
+        json={'specialist_id': vet_id, 'date': '2024-05-20', 'time': '09:00'},
+        headers={'Accept': 'application/json'}
+    )
+    specialist_user = type(
+        'U',
+        (),
+        {
+            'id': vet_user_id,
+            'worker': 'veterinario',
+            'role': None,
+            'is_authenticated': True,
+            'name': 'Vet',
+            'veterinario': vet_obj,
+        }
+    )()
+    login(monkeypatch, specialist_user)
+    resp = client.post(
+        '/exam_appointment/1/requester_update',
+        json={'status': 'canceled'},
+        headers={'Accept': 'application/json'}
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- mark pending exam rows with metadata and add a requester management modal in the vet schedule view
- bind frontend behaviour to open the modal, adjust confirmation deadlines, and call the new requester update API
- implement the requester_update endpoint for exam appointments and cover the flow with backend tests

## Testing
- pytest tests/test_schedule_exam.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c095c578832ebcbb2bd8f504d14e