### PR TITLE
Fix exam requester update helper usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -10088,8 +10088,6 @@ def update_exam_appointment_requester(appointment_id):
         time_left = appt.confirm_by - now
         time_left_seconds = time_left.total_seconds()
         if time_left_seconds > 0 and style.get('show_time_left'):
-            from helpers import format_timedelta
-
             time_left_display = format_timedelta(time_left)
 
     confirm_display = (

--- a/tests/test_schedule_exam.py
+++ b/tests/test_schedule_exam.py
@@ -85,6 +85,29 @@ def test_schedule_exam_message_and_confirm_by(client, monkeypatch):
         assert 'Confirme' in msg.content
 
 
+def test_exam_requester_update_includes_time_left_display(client, monkeypatch):
+    with flask_app.app_context():
+        tutor_id, vet_user_id, animal_id, vet_id = setup_data()
+    fake_user = type('U', (), {'id': tutor_id, 'worker': None, 'role': 'adotante', 'is_authenticated': True, 'name': 'Tutor'})()
+    login(monkeypatch, fake_user)
+    schedule_resp = client.post(
+        f'/animal/{animal_id}/schedule_exam',
+        json={'specialist_id': vet_id, 'date': '2024-05-20', 'time': '09:00'},
+        headers={'Accept': 'application/json'}
+    )
+    assert schedule_resp.status_code == 200
+
+    resp = client.post(
+        '/exam_appointment/1/requester_update',
+        json={},
+        headers={'Accept': 'application/json'}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success']
+    assert data['exam']['time_left_display']
+
+
 def test_schedule_exam_rejects_outside_schedule(client, monkeypatch):
     with flask_app.app_context():
         tutor_id, vet_user_id, animal_id, vet_id = setup_data()


### PR DESCRIPTION
## Summary
- invoke the module-level `format_timedelta` helper in `update_exam_appointment_requester`
- add a regression test ensuring the requester update endpoint returns `time_left_display`

## Testing
- pytest tests/test_schedule_exam.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c68b091c832ea60b64805a8398e9