### PR TITLE
Improve vet collaboration workflow on schedule page

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -363,14 +363,14 @@
     <div class="card-header bg-warning text-dark">
       <h5 class="mb-0"><i class="fas fa-clock me-2"></i>Agendamentos Pendentes</h5>
     </div>
-  <div class="card-body p-0">
+    <div class="card-body p-0">
       <div class="list-group list-group-flush">
-        {% if appointments_pending_consults or exams_pending_to_accept or exams_waiting_other_vets %}
-          {% if appointments_pending_consults %}
+        {% if pending_consults_for_me or pending_consults_waiting_others or exams_pending_to_accept or exams_waiting_other_vets %}
+          {% if pending_consults_for_me %}
           <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
-            <i class="fas fa-stethoscope me-2"></i>Consultas e atendimentos
+            <i class="fas fa-stethoscope me-2"></i>Consultas aguardando sua resposta
           </div>
-          {% for item in appointments_pending_consults %}
+          {% for item in pending_consults_for_me %}
             {% set appt = item.appt %}
             {% set can_respond = appt.time_left.total_seconds() > 0 %}
             <div class="list-group-item d-flex justify-content-between align-items-center" data-appointment-id="{{ appt.id }}">
@@ -411,6 +411,51 @@
                 </form>
               </div>
               {% endif %}
+            </div>
+          {% endfor %}
+          {% endif %}
+
+          {% if pending_consults_waiting_others %}
+          <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+            <i class="fas fa-user-clock me-2"></i>Consultas aguardando outros profissionais
+          </div>
+          {% for item in pending_consults_waiting_others %}
+            {% set appt = item.appt %}
+            {% set can_respond = appt.time_left.total_seconds() > 0 %}
+            <div class="list-group-item d-flex justify-content-between align-items-center" data-appointment-id="{{ appt.id }}">
+              <div class="d-flex align-items-center">
+                <div class="me-3">
+                  <i class="fas fa-user-clock {% if can_respond %}text-warning{% else %}text-secondary{% endif %} fa-2x"></i>
+                </div>
+                <div>
+                  <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                  <small class="text-muted">
+                    {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
+                    {% if item.kind == 'banho_tosa' %}
+                      <span class="badge bg-primary ms-1">Banho e Tosa</span>
+                    {% elif item.kind == 'vacina' %}
+                      <span class="badge bg-success ms-1">Vacina</span>
+                    {% elif item.kind == 'retorno' %}
+                      <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                    {% endif %}
+                    <span class="badge bg-light text-dark border ms-1"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
+                  </small>
+                  <div class="mt-1">
+                    {% if can_respond %}
+                      <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Aguardando confirmação do profissional</small>
+                    {% else %}
+                      <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+              <div class="text-end">
+                {% if can_respond %}
+                  <span class="badge bg-warning text-dark"><i class="fas fa-user-clock me-1"></i>Aguardando confirmação</span>
+                {% else %}
+                  <span class="badge bg-secondary"><i class="fas fa-hourglass-end me-1"></i>Prazo expirado</span>
+                {% endif %}
+              </div>
             </div>
           {% endfor %}
           {% endif %}
@@ -526,86 +571,160 @@
     </div>
     <div class="card-body p-0">
       <div class="list-group list-group-flush">
-        {% for item in appointments_upcoming %}
-          {% set appt = item.appt %}
-          {% if item.kind == 'exame' %}
-          <div class="list-group-item list-group-item-action appointment-item" data-type="exame" data-appointment-id="{{ appt.id }}">
-            <div class="d-flex justify-content-between align-items-center">
-              <div class="d-flex align-items-center">
-                <div class="me-3">
-                  <i class="fas fa-flask fa-2x text-info"></i>
+        {% if appointments_upcoming_for_me or appointments_upcoming_requested %}
+          {% if appointments_upcoming_for_me %}
+          <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+            <i class="fas fa-stethoscope me-2"></i>Seus próximos atendimentos
+          </div>
+          {% for item in appointments_upcoming_for_me %}
+            {% set appt = item.appt %}
+            {% if item.kind == 'exame' %}
+            <div class="list-group-item list-group-item-action appointment-item" data-type="exame" data-appointment-id="{{ appt.id }}">
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="d-flex align-items-center">
+                  <div class="me-3">
+                    <i class="fas fa-flask fa-2x text-info"></i>
+                  </div>
+                  <div>
+                    <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                    <small class="text-muted">{{ appt.animal.owner.name }} <span class="badge bg-info ms-1">Exame</span></small>
+                  </div>
                 </div>
-                <div>
-                  <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                  <small class="text-muted">{{ appt.animal.owner.name }} <span class="badge bg-info ms-1">Exame</span></small>
+                <div class="btn-group">
+                  <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                  <a href="{{ url_for('ficha_tutor', tutor_id=appt.animal.owner.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
                 </div>
-              </div>
-              <div class="btn-group">
-                <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                <a href="{{ url_for('ficha_tutor', tutor_id=appt.animal.owner.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
               </div>
             </div>
-          </div>
-          {% else %}
-          <div class="list-group-item list-group-item-action appointment-item"
-              data-appointment-id="{{ appt.id }}"
-              data-id="{{ appt.id }}"
-              data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
-              data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
-              data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
-              data-vet="{{ appt.veterinario.user.name }}"
-              data-vet-id="{{ appt.veterinario_id }}"
-              data-tutor="{{ appt.tutor.name }}"
-              data-tutor-id="{{ appt.tutor_id }}"
-              data-animal="{{ appt.animal.name }}"
-              data-animal-id="{{ appt.animal_id }}"
-              data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
-              data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
-              data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
-              data-notes="{{ appt.notes or '' }}"
-              data-created-by="{{ appt.creator.name if appt.creator else '' }}"
-              data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
-              data-status="{{ appt.status }}"
-              data-status-label="{{ 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title }}"
-              data-type="{{ item.kind }}"
-              data-type-label="{{ {
-                'consulta': 'Consulta',
-                'retorno': 'Retorno',
-                'banho_tosa': 'Banho e Tosa',
-                'vacina': 'Vacina'
-              }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title }}">
-            <div class="d-flex justify-content-between align-items-center">
-              <div class="d-flex align-items-center">
-                <div class="me-3">
-                  <i class="fas fa-stethoscope fa-2x text-success"></i>
+            {% else %}
+            <div class="list-group-item list-group-item-action appointment-item"
+                data-appointment-id="{{ appt.id }}"
+                data-id="{{ appt.id }}"
+                data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+                data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
+                data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
+                data-vet="{{ appt.veterinario.user.name }}"
+                data-vet-id="{{ appt.veterinario_id }}"
+                data-tutor="{{ appt.tutor.name }}"
+                data-tutor-id="{{ appt.tutor_id }}"
+                data-animal="{{ appt.animal.name }}"
+                data-animal-id="{{ appt.animal_id }}"
+                data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
+                data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
+                data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
+                data-notes="{{ appt.notes or '' }}"
+                data-created-by="{{ appt.creator.name if appt.creator else '' }}"
+                data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
+                data-status="{{ appt.status }}"
+                data-status-label="{{ 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title }}"
+                data-type="{{ item.kind }}"
+                data-type-label="{{ {
+                  'consulta': 'Consulta',
+                  'retorno': 'Retorno',
+                  'banho_tosa': 'Banho e Tosa',
+                  'vacina': 'Vacina'
+                }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title }}">
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="d-flex align-items-center">
+                  <div class="me-3">
+                    <i class="fas fa-stethoscope fa-2x text-success"></i>
+                  </div>
+                  <div>
+                    <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                    <small class="text-muted">{{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
+                      {% if item.kind == 'retorno' %}
+                        <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                      {% elif item.kind == 'banho_tosa' %}
+                        <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
+                      {% elif item.kind == 'vacina' %}
+                        <span class="badge bg-success text-white ms-1">Vacina</span>
+                      {% endif %}
+                    </small>
+                  </div>
                 </div>
-                <div>
-                  <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                  <small class="text-muted">{{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
-                    {% if item.kind == 'retorno' %}
-                      <span class="badge bg-warning text-dark ms-1">Retorno</span>
-                    {% elif item.kind == 'banho_tosa' %}
-                      <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
-                    {% elif item.kind == 'vacina' %}
-                      <span class="badge bg-success text-white ms-1">Vacina</span>
-                    {% endif %}
-                  </small>
+                <div class="btn-group">
+                  <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                  <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                  <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
                 </div>
-              </div>
-              <div class="btn-group">
-                <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
-                <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
               </div>
             </div>
+            {% endif %}
+          {% endfor %}
+          {% endif %}
+
+          {% if appointments_upcoming_requested %}
+          <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+            <i class="fas fa-handshake me-2"></i>Acompanhando outros profissionais
           </div>
+          {% for item in appointments_upcoming_requested %}
+            {% set appt = item.appt %}
+            {% set status_label = 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title %}
+            {% set type_label = {
+              'consulta': 'Consulta',
+              'retorno': 'Retorno',
+              'banho_tosa': 'Banho e Tosa',
+              'vacina': 'Vacina'
+            }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title %}
+            <div class="list-group-item list-group-item-action appointment-item"
+                data-appointment-id="{{ appt.id }}"
+                data-id="{{ appt.id }}"
+                data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+                data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
+                data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
+                data-vet="{{ appt.veterinario.user.name }}"
+                data-vet-id="{{ appt.veterinario_id }}"
+                data-tutor="{{ appt.tutor.name }}"
+                data-tutor-id="{{ appt.tutor_id }}"
+                data-animal="{{ appt.animal.name }}"
+                data-animal-id="{{ appt.animal_id }}"
+                data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
+                data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
+                data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
+                data-notes="{{ appt.notes or '' }}"
+                data-created-by="{{ appt.creator.name if appt.creator else '' }}"
+                data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
+                data-status="{{ appt.status }}"
+                data-status-label="{{ status_label }}"
+                data-type="{{ item.kind }}"
+                data-type-label="{{ type_label }}">
+              <div class="d-flex justify-content-between align-items-start">
+                <div class="d-flex align-items-center">
+                  <div class="me-3">
+                    <i class="fas fa-handshake fa-2x text-info"></i>
+                  </div>
+                  <div>
+                    <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                    <small class="text-muted">
+                      {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
+                      {% if item.kind == 'retorno' %}
+                        <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                      {% elif item.kind == 'banho_tosa' %}
+                        <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
+                      {% elif item.kind == 'vacina' %}
+                        <span class="badge bg-success text-white ms-1">Vacina</span>
+                      {% endif %}
+                      <span class="badge bg-light text-dark border ms-1"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
+                    </small>
+                  </div>
+                </div>
+                <div class="d-flex flex-column align-items-end gap-2">
+                  <div class="btn-group">
+                    <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                    <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                  </div>
+                  <span class="badge bg-success"><i class="fas fa-check me-1"></i>{{ status_label }}</span>
+                </div>
+              </div>
+            </div>
+          {% endfor %}
           {% endif %}
         {% else %}
           <div class="list-group-item text-center py-4">
             <i class="fas fa-calendar-times fa-2x text-muted mb-2"></i>
             <p class="text-muted mb-0">Nenhum agendamento encontrado.</p>
           </div>
-        {% endfor %}
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- split pending appointment list so veterinarians only get action buttons on items assigned to them and add a watchlist for items awaiting other professionals
- show upcoming appointments in separate sections for the logged in veterinarian and those they scheduled for colleagues, with clearer responsibility indicators
- block non-responsible users from accepting an appointment through the status endpoint

## Testing
- pytest tests/test_clinic_collaboration.py *(fails: cannot reach remote database)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cbc20940832e86758678b4ee1757