### PR TITLE
Improve appointment header button responsiveness

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -8,6 +8,27 @@
   }
 }
 
+/* Botões responsivos na área de agendamentos */
+.button-action-group {
+  width: 100%;
+}
+
+.btn-stack-item {
+  width: 100%;
+  min-height: 44px;
+}
+
+@media (min-width: 768px) {
+  .button-action-group {
+    width: auto;
+    align-items: center;
+  }
+
+  .btn-stack-item {
+    width: auto;
+  }
+}
+
 /* Garante que tabelas sempre possam rolar em telas pequenas */
 .table-responsive {
   overflow-x: auto;

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -46,11 +46,11 @@
   <div class="card border-0 shadow-lg rounded-4 mb-5">
     <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
       <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
-      <div>
-        <button id="openScheduleModal" class="btn btn-light btn-sm me-2" type="button">
+      <div class="button-action-group d-flex flex-column flex-md-row gap-2 w-100 justify-content-md-end ms-lg-auto">
+        <button id="openScheduleModal" class="btn btn-light btn-stack-item" type="button">
           <i class="bi bi-pencil"></i> Editar Horário
         </button>
-        <button class="btn btn-success btn-sm" data-bs-toggle="collapse" data-bs-target="#newAppointmentForm">
+        <button class="btn btn-success btn-stack-item" data-bs-toggle="collapse" data-bs-target="#newAppointmentForm">
           <i class="bi bi-plus-circle"></i> Nova Consulta
         </button>
       </div>


### PR DESCRIPTION
## Summary
- make the "Editar Horário" and "Nova Consulta" buttons stack vertically on small screens while keeping a horizontal layout for larger viewports
- add responsive utility classes to give the buttons full-width sizing on mobile and maintain a minimum 44px touch target height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d1ade8c8832eacbfbd7367f5d3d7