### PR TITLE
Add aria labels to weekly schedule navigation buttons

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -169,14 +169,29 @@
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2 ms-xl-auto">
               <div class="btn-group btn-group-sm" role="group" aria-label="Navegação da agenda semanal">
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-prev>
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  data-schedule-week-prev
+                  aria-label="Semana anterior"
+                >
                   <i class="bi bi-chevron-left"></i>
                   <span class="d-none d-sm-inline ms-1">Semana anterior</span>
                 </button>
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-today>
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  data-schedule-week-today
+                  aria-label="Ir para semana atual"
+                >
                   Hoje
                 </button>
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-next>
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  data-schedule-week-next
+                  aria-label="Próxima semana"
+                >
                   <span class="d-none d-sm-inline me-1">Próxima semana</span>
                   <i class="bi bi-chevron-right"></i>
                 </button>


### PR DESCRIPTION
## Summary
- add accessible aria-label text to the weekly navigation buttons in the appointments calendar
- keep existing breakpoint-specific labels while ensuring descriptive names for assistive tech

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d1ae9554832eaf546776c4b8136c