### PR TITLE
Fix JSON quoting for calendar summary data attributes

### DIFF
--- a/templates/partials/calendar_summary_panel.html
+++ b/templates/partials/calendar_summary_panel.html
@@ -6,8 +6,8 @@
 <div
   class="card calendar-summary-card border-0 shadow-sm h-100 is-loading"
   data-calendar-summary-panel
-  data-calendar-summary-vets="{{ summary_vets|tojson }}"
-  data-calendar-summary-clinic-ids="{{ summary_clinic_ids|tojson }}"
+  data-calendar-summary-vets='{{ summary_vets|tojson }}'
+  data-calendar-summary-clinic-ids='{{ summary_clinic_ids|tojson }}'
   {% if summary_storage_key %}
   data-calendar-summary-storage-key="{{ summary_storage_key }}"
   {% endif %}


### PR DESCRIPTION
## Summary
- wrap the calendar summary vet and clinic ID JSON payloads in single-quoted data attributes to keep the markup valid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d1c741ec832eb76703fbc1cbf37c