### PR TITLE
Add modal metadata to pending vet consult cards

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -373,44 +373,81 @@
           {% for item in pending_consults_for_me %}
             {% set appt = item.appt %}
             {% set can_respond = appt.time_left.total_seconds() > 0 %}
-            <div class="list-group-item d-flex justify-content-between align-items-center" data-appointment-id="{{ appt.id }}">
-              <div class="d-flex align-items-center">
-                <div class="me-3">
-                  <i class="fas fa-clock {% if can_respond %}text-warning{% else %}text-secondary{% endif %} fa-2x"></i>
-                </div>
-                <div>
-                  <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                  <small class="text-muted">
-                    {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
-                    {% if item.kind == 'banho_tosa' %}
-                      <span class="badge bg-primary ms-1">Banho e Tosa</span>
-                    {% elif item.kind == 'vacina' %}
-                      <span class="badge bg-success ms-1">Vacina</span>
-                    {% elif item.kind == 'retorno' %}
-                      <span class="badge bg-warning text-dark ms-1">Retorno</span>
-                    {% endif %}
-                  </small>
-                  <div class="mt-1">
-                    {% if can_respond %}
-                      <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Tempo restante: {{ appt.time_left|format_timedelta }}</small>
-                    {% else %}
-                      <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
-                    {% endif %}
+            {% set display_tutor = appt.tutor if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner %}
+            {% set status_label = 'A fazer' if appt.status == 'scheduled'
+              else 'Realizada' if appt.status == 'completed'
+              else 'Cancelada' if appt.status == 'canceled'
+              else 'Aceita' if appt.status == 'accepted'
+              else 'Pendente' if appt.status == 'pending'
+              else 'Aguardando Confirmação' if appt.status == 'awaiting_confirmation'
+              else appt.status|replace('_', ' ')|title %}
+            {% set type_label = {
+              'consulta': 'Consulta',
+              'retorno': 'Retorno',
+              'banho_tosa': 'Banho e Tosa',
+              'vacina': 'Vacina'
+            }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title %}
+            <div class="list-group-item list-group-item-action appointment-item"
+                data-appointment-id="{{ appt.id }}"
+                data-id="{{ appt.id }}"
+                data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+                data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
+                data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
+                data-vet="{{ appt.veterinario.user.name }}"
+                data-vet-id="{{ appt.veterinario_id }}"
+                data-tutor="{{ display_tutor.name if display_tutor else '' }}"
+                data-tutor-id="{{ display_tutor.id if display_tutor else '' }}"
+                data-animal="{{ appt.animal.name }}"
+                data-animal-id="{{ appt.animal_id }}"
+                data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
+                data-tutor-url="{{ url_for('ficha_tutor', tutor_id=display_tutor.id) if display_tutor else '' }}"
+                data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
+                data-notes="{{ appt.notes or '' }}"
+                data-created-by="{{ appt.creator.name if appt.creator else '' }}"
+                data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
+                data-status="{{ appt.status }}"
+                data-status-label="{{ status_label }}"
+                data-type="{{ item.kind }}"
+                data-type-label="{{ type_label }}">
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="d-flex align-items-center">
+                  <div class="me-3">
+                    <i class="fas fa-clock {% if can_respond %}text-warning{% else %}text-secondary{% endif %} fa-2x"></i>
+                  </div>
+                  <div>
+                    <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                    <small class="text-muted">
+                      {{ display_tutor.name if display_tutor else '' }}
+                      {% if item.kind == 'banho_tosa' %}
+                        <span class="badge bg-primary ms-1">Banho e Tosa</span>
+                      {% elif item.kind == 'vacina' %}
+                        <span class="badge bg-success ms-1">Vacina</span>
+                      {% elif item.kind == 'retorno' %}
+                        <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                      {% endif %}
+                    </small>
+                    <div class="mt-1">
+                      {% if can_respond %}
+                        <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Tempo restante: {{ appt.time_left|format_timedelta }}</small>
+                      {% else %}
+                        <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
+                      {% endif %}
+                    </div>
                   </div>
                 </div>
+                {% if can_respond %}
+                <div class="d-flex gap-2">
+                  <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
+                    <input type="hidden" name="status" value="accepted">
+                    <button type="submit" class="btn btn-success btn-sm"><i class="fas fa-check me-1"></i>Aceitar</button>
+                  </form>
+                  <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
+                    <input type="hidden" name="status" value="canceled">
+                    <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-times me-1"></i>Recusar</button>
+                  </form>
+                </div>
+                {% endif %}
               </div>
-              {% if can_respond %}
-              <div class="d-flex gap-2">
-                <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
-                  <input type="hidden" name="status" value="accepted">
-                  <button type="submit" class="btn btn-success btn-sm"><i class="fas fa-check me-1"></i>Aceitar</button>
-                </form>
-                <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
-                  <input type="hidden" name="status" value="canceled">
-                  <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-times me-1"></i>Recusar</button>
-                </form>
-              </div>
-              {% endif %}
             </div>
           {% endfor %}
           {% endif %}


### PR DESCRIPTION
## Summary
- update the pending consultation cards so they include the modal-friendly metadata used elsewhere
- ensure the cards remain clickable while preserving the existing accept and decline actions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d74d9c20832e8433dca520a86019