### PR TITLE
Adjust pet list layout for mobile

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -280,6 +280,18 @@
   padding-right: 0;
 }
 
+@media (max-width: 575.98px) {
+  #{{ component_id }} .tutor-calendar__pet-list {
+    max-height: none;
+    overflow-y: visible;
+    padding-right: 0;
+  }
+
+  #{{ component_id }} [data-toggle-pets] {
+    display: none !important;
+  }
+}
+
 #{{ component_id }} .tutor-calendar__pet {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- add a mobile-specific media query to let the pet list grow naturally without a scrollbar on small screens
- hide the "Ver mais pets" toggle when the mobile layout is active so the full list remains visible

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3df18c394832e8328693204e022a0