### PR TITLE
Add inline tutor and pet registration to vet schedule workspace

### DIFF
--- a/app.py
+++ b/app.py
@@ -8421,6 +8421,9 @@ def appointments():
             clinic_pending_query.count() if clinic_pending_query is not None else 0
         )
 
+        species_list = list_species()
+        breed_list = list_breeds()
+
         return render_template(
             'agendamentos/edit_vet_schedule.html',
             schedule_form=schedule_form,
@@ -8451,6 +8454,8 @@ def appointments():
                 'EXAM_CONFIRM_DEFAULT_HOURS',
                 2,
             ),
+            species_list=species_list,
+            breed_list=breed_list,
         )
     else:
         if worker in ['colaborador', 'admin']:

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -50,7 +50,7 @@
   <div class="card border-0 shadow-lg rounded-4 mb-5" id="{{ schedule_collapse_group_id }}">
     <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
       <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
-      <div class="d-flex align-items-center gap-2">
+      <div class="d-flex flex-wrap align-items-center gap-2 justify-content-end">
         <button
           class="btn btn-light btn-sm collapsed"
           type="button"
@@ -73,6 +73,26 @@
           aria-expanded="false"
         >
           <i class="bi bi-plus-circle"></i> Nova Consulta
+        </button>
+        <button
+          class="btn btn-light btn-sm collapsed"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#vetNewTutorForm"
+          aria-expanded="false"
+          aria-controls="vetNewTutorForm"
+        >
+          <i class="bi bi-person-plus"></i> Novo Tutor
+        </button>
+        <button
+          class="btn btn-primary btn-sm collapsed"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#vetNewPetForm"
+          aria-expanded="false"
+          aria-controls="vetNewPetForm"
+        >
+          <i class="bi bi-plus-circle"></i> Novo Pet
         </button>
       </div>
     </div>
@@ -231,6 +251,18 @@
             <div id="schedule-overview" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 small"></div>
           </div>
         </div>
+      </div>
+    </div>
+    <div class="collapse" id="vetNewTutorForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
+      <div class="card-body p-4">
+        {% include 'partials/calendar_quick_tutor_form.html' %}
+      </div>
+    </div>
+    <div class="collapse" id="vetNewPetForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
+      <div class="card-body p-4">
+        {% with species_list=species_list, breed_list=breed_list %}
+          {% include 'partials/animal_register_form.html' %}
+        {% endwith %}
       </div>
     </div>
   </div>

--- a/templates/partials/calendar_quick_tutor_form.html
+++ b/templates/partials/calendar_quick_tutor_form.html
@@ -1,0 +1,111 @@
+{% set form_id = form_id|default('calendar-quick-tutor-form') %}
+{% set heading_id = heading_id|default(form_id ~ '-heading') %}
+
+<form
+  id="{{ form_id }}"
+  method="POST"
+  action="{{ url_for('tutores') }}"
+  class="js-tutor-form"
+  data-sync="true"
+  aria-labelledby="{{ heading_id }}"
+>
+  <div class="d-flex flex-column flex-md-row align-items-md-center gap-2 mb-3">
+    <h5 id="{{ heading_id }}" class="mb-0">
+      <i class="bi bi-person-plus me-2"></i> Cadastro rápido de tutor
+    </h5>
+    <span class="text-muted small">
+      Preencha os dados essenciais para registrar um tutor sem sair da agenda.
+    </span>
+  </div>
+  <div class="row g-3">
+    <div class="col-md-6">
+      <label for="{{ form_id }}-name" class="form-label">Nome <span class="text-danger">*</span></label>
+      <input
+        type="text"
+        class="form-control"
+        id="{{ form_id }}-name"
+        name="tutor_name"
+        placeholder="Nome completo"
+        required
+      >
+    </div>
+    <div class="col-md-6">
+      <label for="{{ form_id }}-email" class="form-label">E-mail <span class="text-danger">*</span></label>
+      <input
+        type="email"
+        class="form-control"
+        id="{{ form_id }}-email"
+        name="tutor_email"
+        placeholder="nome@email.com"
+        required
+      >
+    </div>
+    <div class="col-md-4">
+      <label for="{{ form_id }}-phone" class="form-label">Telefone</label>
+      <input
+        type="tel"
+        class="form-control"
+        id="{{ form_id }}-phone"
+        name="tutor_phone"
+        placeholder="(00) 00000-0000"
+        inputmode="tel"
+      >
+    </div>
+    <div class="col-md-4">
+      <label for="{{ form_id }}-cpf" class="form-label">CPF</label>
+      <input
+        type="text"
+        class="form-control"
+        id="{{ form_id }}-cpf"
+        name="tutor_cpf"
+        placeholder="000.000.000-00"
+        inputmode="numeric"
+      >
+    </div>
+    <div class="col-md-4">
+      <label for="{{ form_id }}-dob" class="form-label">Data de nascimento</label>
+      <input
+        type="date"
+        class="form-control"
+        id="{{ form_id }}-dob"
+        name="tutor_date_of_birth"
+      >
+    </div>
+    <div class="col-12">
+      <label for="{{ form_id }}-notes" class="form-label">Observações</label>
+      <textarea
+        id="{{ form_id }}-notes"
+        class="form-control"
+        name="tutor_notes"
+        rows="2"
+        placeholder="Informações adicionais importantes para a equipe"
+      ></textarea>
+    </div>
+  </div>
+  <div class="d-flex flex-column flex-sm-row gap-2 justify-content-end mt-4">
+    <a class="btn btn-outline-secondary" href="{{ url_for('tutores') }}" target="_blank" rel="noopener">
+      <i class="bi bi-box-arrow-up-right me-1"></i> Abrir página completa
+    </a>
+    <button type="submit" class="btn btn-primary" data-submit-label>
+      <i class="bi bi-save me-1"></i> Salvar tutor
+    </button>
+  </div>
+</form>
+
+<script>
+(function() {
+  const form = document.getElementById('{{ form_id }}');
+  if (!form) {
+    return;
+  }
+  form.addEventListener('submit', function() {
+    const submitBtn = form.querySelector('[data-submit-label]');
+    if (submitBtn && !submitBtn.dataset.submitting) {
+      submitBtn.dataset.submitting = 'true';
+      submitBtn.dataset.original = submitBtn.innerHTML;
+      submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Salvando...';
+      submitBtn.disabled = true;
+    }
+  });
+})();
+</script>


### PR DESCRIPTION
## Summary
- add quick access buttons beside the schedule controls for opening inline tutor and pet panels
- embed collapsible quick forms for registering tutors and pets directly from the vet schedule view
- provide species and breed data to support the inline pet registration form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ecb1128c832ebeb89ad23b37fea4