### PR TITLE
Enhance vet calendar summary metadata and filters

### DIFF
--- a/app.py
+++ b/app.py
@@ -3654,7 +3654,30 @@ def vet_detail(veterinario_id):
     calendar_summary_vets = []
     calendar_summary_clinic_ids = []
 
-    def add_summary_vet(vet):
+    def build_calendar_summary_entry(vet, *, label=None, is_specialist=None):
+        """Return a serializable mapping with vet summary metadata."""
+        if not vet:
+            return None
+        vet_id = getattr(vet, 'id', None)
+        if not vet_id:
+            return None
+        vet_user = getattr(vet, 'user', None)
+        vet_name = getattr(vet_user, 'name', None)
+        specialty_list = getattr(vet, 'specialty_list', None)
+        entry = {
+            'id': vet_id,
+            'name': label if label is not None else vet_name,
+            'full_name': vet_name,
+            'specialty_list': specialty_list,
+        }
+        if label is not None:
+            entry['label'] = label
+        if is_specialist is None:
+            is_specialist = bool(specialty_list)
+        entry['is_specialist'] = bool(is_specialist)
+        return entry
+
+    def add_summary_vet(vet, *, label=None, is_specialist=None):
         if not vet:
             return
         vet_id = getattr(vet, 'id', None)
@@ -3662,11 +3685,9 @@ def vet_detail(veterinario_id):
             return
         if any(entry.get('id') == vet_id for entry in calendar_summary_vets):
             return
-        vet_name = None
-        vet_user = getattr(vet, 'user', None)
-        if vet_user is not None:
-            vet_name = getattr(vet_user, 'name', None)
-        calendar_summary_vets.append({'id': vet_id, 'name': vet_name})
+        entry = build_calendar_summary_entry(vet, label=label, is_specialist=is_specialist)
+        if entry:
+            calendar_summary_vets.append(entry)
 
     add_summary_vet(veterinario)
 
@@ -3690,7 +3711,7 @@ def vet_detail(veterinario_id):
         for colleague in getattr(clinic, 'veterinarios', []) or []:
             add_summary_vet(colleague)
         for colleague in getattr(clinic, 'veterinarios_associados', []) or []:
-            add_summary_vet(colleague)
+            add_summary_vet(colleague, is_specialist=True)
 
     if clinic_ids and len(calendar_summary_vets) == 1:
         colleagues = (
@@ -7831,6 +7852,9 @@ def appointments():
                     'name': veterinario.user.name
                     if getattr(veterinario, "user", None)
                     else None,
+                    'full_name': getattr(getattr(veterinario, 'user', None), 'name', None),
+                    'specialty_list': getattr(veterinario, 'specialty_list', None),
+                    'is_specialist': bool(getattr(veterinario, 'specialty_list', None)),
                 }
             ]
         include_colleagues = bool(clinic_ids)
@@ -7860,6 +7884,9 @@ def appointments():
                         'name': colleague.user.name
                         if getattr(colleague, 'user', None)
                         else None,
+                        'full_name': getattr(getattr(colleague, 'user', None), 'name', None),
+                        'specialty_list': getattr(colleague, 'specialty_list', None),
+                        'is_specialist': bool(getattr(colleague, 'specialty_list', None)),
                     }
                 )
                 known_ids.add(colleague_id)
@@ -7935,7 +7962,15 @@ def appointments():
             (vet.id, _vet_label(vet)) for vet in combined_vets
         ]
         calendar_summary_vets = [
-            {'id': vet.id, 'name': _vet_label(vet)}
+            {
+                'id': vet.id,
+                'name': _vet_label(vet),
+                'label': _vet_label(vet),
+                'full_name': getattr(getattr(vet, 'user', None), 'name', None),
+                'specialty_list': getattr(vet, 'specialty_list', None),
+                'is_specialist': getattr(vet, 'id', None) in specialist_ids
+                and getattr(vet, 'id', None) not in clinic_vet_ids,
+            }
             for vet in combined_vets
         ]
         if request.method == 'GET':
@@ -8525,6 +8560,11 @@ def appointments():
                 {
                     'id': vet.id,
                     'name': _vet_label(vet),
+                    'label': _vet_label(vet),
+                    'full_name': getattr(getattr(vet, 'user', None), 'name', None),
+                    'specialty_list': getattr(vet, 'specialty_list', None),
+                    'is_specialist': getattr(vet, 'id', None) in specialist_ids
+                    and getattr(vet, 'id', None) not in clinic_vet_ids,
                 }
                 for vet in combined_vets
             ]

--- a/helpers.py
+++ b/helpers.py
@@ -429,6 +429,7 @@ def appointment_to_event(appointment):
     vet = getattr(appointment, 'veterinario', None)
     vet_user = getattr(vet, 'user', None)
 
+    vet_specialty_list = getattr(vet, 'specialty_list', None)
     extra_props = {
         'kind': getattr(appointment, 'kind', None),
         'clinicId': getattr(appointment, 'clinica_id', None),
@@ -439,6 +440,9 @@ def appointment_to_event(appointment):
         'tutorName': getattr(tutor, 'name', None),
         'animalName': getattr(animal, 'name', None),
         'vetName': getattr(vet_user, 'name', None),
+        'vetFullName': getattr(vet_user, 'name', None),
+        'vetSpecialtyList': vet_specialty_list,
+        'vetIsSpecialist': bool(vet_specialty_list),
         'notes': getattr(appointment, 'notes', None),
     }
 
@@ -477,10 +481,17 @@ def exam_to_event(exam):
         title = f"{title} - {exam.specialist.user.name}"
     end_time = exam.scheduled_at + get_appointment_duration('exame')
 
+    specialist = getattr(exam, 'specialist', None)
+    specialist_user = getattr(specialist, 'user', None)
+    specialist_specialties = getattr(specialist, 'specialty_list', None)
     extra_props = {
         'status': getattr(exam, 'status', None),
         'animalId': getattr(exam, 'animal_id', None),
         'specialistId': getattr(exam, 'specialist_id', None),
+        'vetName': getattr(specialist_user, 'name', None),
+        'vetFullName': getattr(specialist_user, 'name', None),
+        'vetSpecialtyList': specialist_specialties,
+        'vetIsSpecialist': bool(specialist),
     }
 
     return _build_calendar_event(
@@ -558,6 +569,8 @@ def consulta_to_event(consulta):
     }
     event_status = status_map.get(status_key, 'scheduled')
 
+    vet_full_name = getattr(vet_user, 'name', None)
+    vet_profile_specialties = getattr(vet_profile, 'specialty_list', None)
     extra_props = {
         'status': event_status,
         'consultaStatus': status_key,
@@ -568,7 +581,10 @@ def consulta_to_event(consulta):
         'animalName': getattr(animal, 'name', None),
         'consultaId': getattr(consulta, 'id', None),
         'createdBy': getattr(consulta, 'created_by', None),
-        'vetName': getattr(vet_user, 'name', None),
+        'vetName': vet_full_name,
+        'vetFullName': vet_full_name,
+        'vetSpecialtyList': vet_profile_specialties,
+        'vetIsSpecialist': bool(vet_profile_specialties),
         'veterinarioId': getattr(vet_profile, 'id', None),
         'clinicaNome': getattr(clinic, 'nome', None) if clinic else None,
         'kind': 'consulta',

--- a/static/appointments_calendar_summary.js
+++ b/static/appointments_calendar_summary.js
@@ -411,6 +411,53 @@ export function setupAppointmentsCalendarSummary(options = {}) {
       return new Set(ids.filter(Boolean));
     })();
 
+    const calendarSummaryVetMetadata = (() => {
+      const parsed = parseCalendarSummaryAttributeJSON('data-calendar-summary-vets');
+      const entries = Array.isArray(parsed) ? parsed : (parsed ? [parsed] : []);
+      const map = new Map();
+      entries.forEach((item) => {
+        if (!item || typeof item !== 'object') {
+          return;
+        }
+        const normalizedId = normalizeSummaryVetId(
+          item.id
+            ?? item.vetId
+            ?? item.veterinario_id
+            ?? item.veterinarioId
+            ?? null,
+        );
+        if (!normalizedId) {
+          return;
+        }
+        const rawSpecialty = item.specialty_list ?? item.specialtyList ?? null;
+        const specialtyList = typeof rawSpecialty === 'string' ? rawSpecialty.trim() : rawSpecialty;
+        const isSpecialist = (() => {
+          if (typeof item.is_specialist === 'boolean') {
+            return item.is_specialist;
+          }
+          if (typeof item.isSpecialist === 'boolean') {
+            return item.isSpecialist;
+          }
+          if (typeof item.specialist === 'boolean') {
+            return item.specialist;
+          }
+          return typeof specialtyList === 'string' && specialtyList.trim().length > 0;
+        })();
+        map.set(normalizedId, {
+          vetId: normalizedId,
+          label: item.label ?? item.name ?? item.vetName ?? null,
+          fullName: item.full_name
+            ?? item.fullName
+            ?? item.vetFullName
+            ?? item.name
+            ?? null,
+          specialtyList: typeof specialtyList === 'string' ? specialtyList : null,
+          isSpecialist,
+        });
+      });
+      return map;
+    })();
+
     const calendarSummaryAllowedClinicIds = (() => {
       const ids = extractSummaryIds('data-calendar-summary-clinic-ids', (entry) => {
         if (entry && typeof entry === 'object') {
@@ -435,6 +482,103 @@ export function setupAppointmentsCalendarSummary(options = {}) {
         return true;
       }
       return calendarSummaryAllowedVetIds.has(normalized);
+    }
+
+    function getStoredCalendarSummaryVetMetadata(vetId) {
+      const normalized = normalizeSummaryVetId(vetId);
+      if (!normalized || !(calendarSummaryVetMetadata instanceof Map)) {
+        return null;
+      }
+      return calendarSummaryVetMetadata.get(normalized) || null;
+    }
+
+    function normalizeSummarySpecialtyList(value) {
+      if (Array.isArray(value)) {
+        return value
+          .map((item) => (typeof item === 'string' ? item.trim() : item))
+          .filter((item) => typeof item === 'string' && item.length)
+          .join(', ');
+      }
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed || null;
+      }
+      return null;
+    }
+
+    function updateCalendarSummaryVetMetadata(vetId, metadata) {
+      const normalized = normalizeSummaryVetId(vetId);
+      if (!normalized || !(calendarSummaryVetMetadata instanceof Map)) {
+        return;
+      }
+      const current = calendarSummaryVetMetadata.get(normalized) || {};
+      const next = { ...current };
+      if (metadata && typeof metadata === 'object') {
+        if (metadata.label) {
+          next.label = metadata.label;
+        }
+        if (metadata.fullName) {
+          next.fullName = metadata.fullName;
+        }
+        if (metadata.specialtyList !== undefined) {
+          next.specialtyList = normalizeSummarySpecialtyList(metadata.specialtyList);
+        }
+        if (typeof metadata.isSpecialist === 'boolean') {
+          next.isSpecialist = metadata.isSpecialist;
+        }
+      }
+      next.vetId = normalized;
+      calendarSummaryVetMetadata.set(normalized, next);
+    }
+
+    function extractEventVetMetadata(event, fallbackId) {
+      if (!event) {
+        return null;
+      }
+      const extended = event.extendedProps || {};
+      const normalizedId = normalizeSummaryVetId(
+        extended.veterinarioId
+          ?? extended.vetId
+          ?? extended.veterinarianId
+          ?? extended.specialistId
+          ?? fallbackId
+          ?? null,
+      );
+      const specialtyList = normalizeSummarySpecialtyList(
+        extended.vetSpecialtyList
+          ?? extended.vetSpecialties
+          ?? extended.specialty_list
+          ?? extended.specialtyList,
+      );
+      const isSpecialist = (() => {
+        if (typeof extended.vetIsSpecialist === 'boolean') {
+          return extended.vetIsSpecialist;
+        }
+        if (typeof extended.isSpecialist === 'boolean') {
+          return extended.isSpecialist;
+        }
+        if (typeof extended.specialist === 'boolean') {
+          return extended.specialist;
+        }
+        if (specialtyList) {
+          return true;
+        }
+        if (extended.specialistId) {
+          return true;
+        }
+        return null;
+      })();
+      return {
+        vetId: normalizedId,
+        label: extended.vetLabel ?? extended.vetName ?? null,
+        fullName: extended.vetFullName
+          ?? extended.veterinarioFullName
+          ?? extended.veterinarianName
+          ?? extended.vetName
+          ?? null,
+        specialtyList,
+        isSpecialist,
+      };
     }
 
     function isCalendarSummaryClinicAllowed(clinicId) {
@@ -617,16 +761,57 @@ export function setupAppointmentsCalendarSummary(options = {}) {
           return;
         }
         const name = deriveSummaryVetName(event, vetId);
+        const storedMetadata = getStoredCalendarSummaryVetMetadata(vetId) || {};
+        const eventMetadata = extractEventVetMetadata(event, vetId) || {};
+        const resolvedLabel = eventMetadata.label
+          || storedMetadata.label
+          || name;
+        const resolvedFullName = eventMetadata.fullName
+          || storedMetadata.fullName
+          || resolvedLabel
+          || name;
+        const resolvedSpecialtyList = normalizeSummarySpecialtyList(
+          eventMetadata.specialtyList ?? storedMetadata.specialtyList,
+        );
+        const resolvedIsSpecialist = (() => {
+          if (typeof eventMetadata.isSpecialist === 'boolean') {
+            return eventMetadata.isSpecialist;
+          }
+          if (typeof storedMetadata.isSpecialist === 'boolean') {
+            return storedMetadata.isSpecialist;
+          }
+          return !!resolvedSpecialtyList;
+        })();
+        updateCalendarSummaryVetMetadata(vetId, {
+          label: resolvedLabel,
+          fullName: resolvedFullName,
+          specialtyList: resolvedSpecialtyList,
+          isSpecialist: resolvedIsSpecialist,
+        });
         const eventDate = startOfDay(parseSummaryDate(event.start || event.startStr || event.date || null));
         const dateKey = formatSummaryDateKey(eventDate);
         const summaryEntry = summaryMap.get(vetId) || {
           vetId,
-          vetName: name,
+          vetName: resolvedLabel || name,
+          vetFullName: resolvedFullName || resolvedLabel || name,
+          specialtyList: resolvedSpecialtyList,
+          isSpecialist: resolvedIsSpecialist,
           total: 0,
           today: 0,
           thisWeek: 0,
           days: new Map(),
         };
+        summaryEntry.vetName = resolvedLabel || summaryEntry.vetName || name;
+        summaryEntry.vetFullName = resolvedFullName
+          || summaryEntry.vetFullName
+          || summaryEntry.vetName
+          || name;
+        if (resolvedSpecialtyList !== undefined) {
+          summaryEntry.specialtyList = resolvedSpecialtyList;
+        }
+        if (typeof resolvedIsSpecialist === 'boolean') {
+          summaryEntry.isSpecialist = resolvedIsSpecialist;
+        }
         summaryEntry.total += 1;
         if (dateKey === todayKey) {
           summaryEntry.today += 1;
@@ -649,6 +834,11 @@ export function setupAppointmentsCalendarSummary(options = {}) {
         return {
           vetId: entry.vetId,
           vetName: entry.vetName,
+          vetFullName: entry.vetFullName || entry.vetName,
+          specialtyList: normalizeSummarySpecialtyList(entry.specialtyList),
+          isSpecialist: typeof entry.isSpecialist === 'boolean'
+            ? entry.isSpecialist
+            : !!normalizeSummarySpecialtyList(entry.specialtyList),
           total: entry.total,
           today: entry.today,
           thisWeek: entry.thisWeek,
@@ -672,10 +862,22 @@ export function setupAppointmentsCalendarSummary(options = {}) {
         totalThisWeek += normalizeSummaryNumber(entry.thisWeek);
       });
 
-      const filters = rows.map((entry) => ({
-        vetId: entry.vetId,
-        vetName: entry.vetName,
-      }));
+      const filters = rows.map((entry) => {
+        const specialtyList = normalizeSummarySpecialtyList(entry.specialtyList);
+        const specialties = specialtyList
+          ? specialtyList.split(',').map((item) => item.trim()).filter(Boolean)
+          : [];
+        const primarySpecialty = specialties.length ? specialties[0] : '';
+        return {
+          vetId: entry.vetId,
+          vetName: entry.vetName,
+          vetFullName: entry.vetFullName || entry.vetName,
+          specialtyList,
+          specialties,
+          primarySpecialty,
+          isSpecialist: !!entry.isSpecialist,
+        };
+      });
 
       return {
         rows,
@@ -805,8 +1007,16 @@ export function setupAppointmentsCalendarSummary(options = {}) {
         if (normalizedId) {
           filterButton.dataset.vetId = normalizedId;
         }
-        const vetLabel = entry.vetName || `Profissional ${entry.vetId}`;
-        filterButton.setAttribute('aria-label', `Filtrar agenda por ${vetLabel}`);
+        const vetLabel = entry.vetName || entry.vetFullName || `Profissional ${entry.vetId}`;
+        const specialtyList = normalizeSummarySpecialtyList(entry.specialtyList);
+        const isSpecialist = !!entry.isSpecialist;
+        const ariaSegments = [`Filtrar agenda por ${vetLabel}`];
+        if (isSpecialist) {
+          ariaSegments.push(
+            specialtyList ? `especialista em ${specialtyList}` : 'especialista',
+          );
+        }
+        filterButton.setAttribute('aria-label', ariaSegments.join(', '));
         filterButton.setAttribute('title', vetLabel);
         filterButton.setAttribute('aria-pressed', 'false');
         filterButton.disabled = false;
@@ -814,14 +1024,38 @@ export function setupAppointmentsCalendarSummary(options = {}) {
         const icon = document.createElement('span');
         icon.classList.add('calendar-summary-filter-icon');
         icon.setAttribute('aria-hidden', 'true');
-        const initials = getSummaryVetInitials(vetLabel, entry.vetId);
+        const initials = getSummaryVetInitials(entry.vetFullName || vetLabel, entry.vetId);
         icon.textContent = initials || '•';
         filterButton.appendChild(icon);
 
-        const srLabel = document.createElement('span');
-        srLabel.classList.add('visually-hidden');
-        srLabel.textContent = vetLabel;
-        filterButton.appendChild(srLabel);
+        const content = document.createElement('span');
+        content.classList.add('calendar-summary-filter-content');
+        const nameElement = document.createElement('span');
+        nameElement.classList.add('calendar-summary-filter-name');
+        nameElement.textContent = vetLabel;
+        content.appendChild(nameElement);
+
+        if (isSpecialist) {
+          const badge = document.createElement('span');
+          badge.classList.add('calendar-summary-filter-badge', 'badge', 'rounded-pill');
+          badge.setAttribute('aria-hidden', 'true');
+          const badgeLabel = entry.primarySpecialty || 'Especialista';
+          badge.textContent = badgeLabel;
+          if (specialtyList && badgeLabel && badgeLabel !== specialtyList) {
+            badge.title = specialtyList;
+          }
+          content.appendChild(badge);
+
+          const srNote = document.createElement('span');
+          srNote.classList.add('visually-hidden');
+          srNote.textContent = specialtyList
+            ? `Especialista em ${specialtyList}`
+            : 'Especialista';
+          content.appendChild(srNote);
+        }
+
+        filterButton.classList.add('has-label');
+        filterButton.appendChild(content);
 
         calendarSummaryFilters.appendChild(filterButton);
       });

--- a/static/styles.css
+++ b/static/styles.css
@@ -335,16 +335,31 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  min-height: 2.25rem;
+  padding: 0.25rem;
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(241, 245, 249, 0.85);
   color: var(--calendar-vet-color, #1d4ed8);
-  font-weight: 700;
+  font-weight: 600;
   font-size: 0.85rem;
   letter-spacing: 0.01em;
   transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+  gap: 0.4rem;
+  line-height: 1.1;
+}
+
+.calendar-summary-filter:not(.has-label) {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+}
+
+.calendar-summary-filter.has-label {
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding-inline-start: 0.35rem;
+  padding-inline-end: 0.75rem;
 }
 
 .calendar-summary-filter .calendar-summary-filter-icon {
@@ -358,6 +373,44 @@
   color: var(--calendar-vet-color, #2563eb);
   text-transform: uppercase;
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  flex-shrink: 0;
+}
+
+.calendar-summary-filter.has-label .calendar-summary-filter-icon {
+  margin-top: 0.05rem;
+}
+
+.calendar-summary-filter-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  min-width: 0;
+  max-width: 14rem;
+}
+
+.calendar-summary-filter-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #0f172a;
+  line-height: 1.1;
+  word-break: break-word;
+  white-space: normal;
+}
+
+.calendar-summary-filter-badge {
+  background-color: rgba(37, 99, 235, 0.12);
+  color: var(--calendar-vet-color, #1d4ed8);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.1rem 0.45rem;
+  line-height: 1.1;
+  max-width: 100%;
+  text-transform: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .calendar-summary-filter:hover:not(:disabled),

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -29,7 +29,14 @@
   </div>
 
   {% set calendar_pets_endpoint = url_for('api_clinic_pets', view_as='veterinario', veterinario_id=veterinario.id) %}
-  {% set calendar_summary_vets = [{'id': veterinario.id}] %}
+  {% set calendar_summary_vets = [{
+    'id': veterinario.id,
+    'name': veterinario.user.name,
+    'label': veterinario.user.name,
+    'full_name': veterinario.user.name,
+    'specialty_list': veterinario.specialty_list,
+    'is_specialist': veterinario.specialty_list|length > 0
+  }] %}
   {% set calendar_summary_clinic_ids = [veterinario.clinica_id] if veterinario.clinica_id else [] %}
   {% set schedule_toggle_clinic_id = veterinario.clinica_id %}
   {% set schedule_toggle_calendar_redirect_url = url_for('appointments', view_as='veterinario', veterinario_id=veterinario.id) %}

--- a/templates/veterinarios/vet_detail.html
+++ b/templates/veterinarios/vet_detail.html
@@ -168,7 +168,14 @@
             </div>
           </div>
           <div class="col-12 col-xl-4 col-xxl-3" data-calendar-summary-column>
-            {% set calendar_summary_vets = calendar_summary_vets if calendar_summary_vets else [{'id': veterinario.id, 'name': veterinario.user.name}] %}
+            {% set calendar_summary_vets = calendar_summary_vets if calendar_summary_vets else [{
+              'id': veterinario.id,
+              'name': veterinario.user.name,
+              'label': veterinario.user.name,
+              'full_name': veterinario.user.name,
+              'specialty_list': veterinario.specialty_list,
+              'is_specialist': veterinario.specialty_list|length > 0
+            }] %}
             {% set calendar_summary_clinic_ids = calendar_summary_clinic_ids if calendar_summary_clinic_ids else ([veterinario.clinica_id] if veterinario.clinica_id else []) %}
             {% set calendar_summary_storage_key = 'vetCalendarSummaryCollapsed-' ~ veterinario.id %}
             {% include 'partials/calendar_summary_panel.html' %}


### PR DESCRIPTION
## Summary
- add full name and specialty metadata to calendar summary vet payloads and events
- extend calendar summary computations to surface specialist information in filters
- restyle vet filter chips to support text labels and specialist badges

## Testing
- not run (explanation: manual updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e4ee53ae40832e8ed089ee55596363