### PR TITLE
Fix tutor autocomplete validation handling

### DIFF
--- a/static/js/tutor_search.js
+++ b/static/js/tutor_search.js
@@ -1,0 +1,125 @@
+(function(window) {
+  function setupTutorSearch(options = {}) {
+    const {
+      inputId = 'autocomplete-tutor',
+      resultsId = 'tutor-results',
+      hiddenFieldId = 'tutor_id',
+      searchUrl = '/buscar_tutores',
+      minChars = 2,
+      validationMessageId = null,
+    } = options;
+
+    const tutorInput = document.getElementById(inputId);
+    const resultsContainer = document.getElementById(resultsId);
+    const tutorIdField = document.getElementById(hiddenFieldId);
+
+    if (!tutorInput || !resultsContainer || !tutorIdField) {
+      return null;
+    }
+
+    const validationMessage = validationMessageId
+      ? document.getElementById(validationMessageId)
+      : null;
+
+    const normalize = (value) => (value || '').trim().toLowerCase();
+
+    let selectedTutorName = '';
+
+    const hideValidationMessage = () => {
+      if (validationMessage) {
+        validationMessage.classList.add('d-none');
+      }
+    };
+
+    const showValidationMessage = () => {
+      if (validationMessage) {
+        validationMessage.classList.remove('d-none');
+      }
+    };
+
+    const clearTutorSelection = () => {
+      tutorIdField.value = '';
+      selectedTutorName = '';
+    };
+
+    const closeResults = () => {
+      resultsContainer.classList.add('d-none');
+    };
+
+    const enforceSelectionConsistency = () => {
+      if (tutorIdField.value && normalize(tutorInput.value) !== selectedTutorName) {
+        clearTutorSelection();
+      }
+    };
+
+    const openResults = () => {
+      enforceSelectionConsistency();
+      if (resultsContainer.children.length > 0) {
+        resultsContainer.classList.remove('d-none');
+      }
+    };
+
+    const handleTutorSelected = (tutor) => {
+      selectedTutorName = normalize(tutor.name);
+      tutorInput.value = tutor.name;
+      tutorIdField.value = tutor.id;
+      hideValidationMessage();
+      closeResults();
+    };
+
+    tutorInput.addEventListener('input', async () => {
+      enforceSelectionConsistency();
+      hideValidationMessage();
+
+      const query = tutorInput.value.trim();
+      if (query.length < minChars) {
+        closeResults();
+        resultsContainer.innerHTML = '';
+        return;
+      }
+
+      try {
+        const response = await fetch(`${searchUrl}?q=${encodeURIComponent(query)}`);
+        if (!response.ok) {
+          throw new Error('Erro ao buscar tutores');
+        }
+
+        const tutors = await response.json();
+        resultsContainer.innerHTML = '';
+
+        tutors.forEach((tutor) => {
+          const li = document.createElement('li');
+          li.className = 'list-group-item list-group-item-action';
+          li.textContent = `${tutor.name} (${tutor.email})`;
+          li.addEventListener('click', () => handleTutorSelected(tutor));
+          resultsContainer.appendChild(li);
+        });
+
+        resultsContainer.classList.toggle('d-none', tutors.length === 0);
+      } catch (error) {
+        console.error(error);
+        resultsContainer.innerHTML = '';
+        closeResults();
+      }
+    });
+
+    tutorInput.addEventListener('focus', openResults);
+    tutorInput.addEventListener('click', openResults);
+
+    document.addEventListener('click', (event) => {
+      if (!resultsContainer.contains(event.target) && event.target !== tutorInput) {
+        closeResults();
+      }
+    });
+
+    return {
+      clearTutorSelection,
+      hideValidationMessage,
+      showValidationMessage,
+      hasSelection: () => Boolean(tutorIdField.value),
+      getTypedValue: () => tutorInput.value.trim(),
+    };
+  }
+
+  window.setupTutorSearch = setupTutorSearch;
+})(window);

--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -9,6 +9,9 @@
       <input type="text" id="autocomplete-tutor" class="form-control" placeholder="Digite nome ou e-mail do tutor">
       <input type="hidden" name="tutor_id" id="tutor_id">
       <ul class="list-group position-absolute w-100 mt-1 d-none" id="tutor-results" style="z-index: 1000;"></ul>
+      <div id="tutor-selection-feedback" class="text-danger small d-none mt-2">
+        Selecione um tutor da lista para continuar.
+      </div>
       <div class="text-end mt-2">
         <a href="{{ url_for('tutores') }}" class="btn btn-sm btn-outline-secondary">
           ➕ Cadastrar novo tutor
@@ -90,13 +93,39 @@
     <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/inputmask@5.0.8/dist/inputmask.min.js"></script>
 
+    <script src="{{ url_for('static', filename='js/tutor_search.js') }}"></script>
     <script>
+    let tutorSearchController;
+
+    const initTutorSearch = () => {
+      tutorSearchController = window.setupTutorSearch?.({
+        inputId: 'autocomplete-tutor',
+        resultsId: 'tutor-results',
+        hiddenFieldId: 'tutor_id',
+        searchUrl: '/buscar_tutores',
+        minChars: 2,
+        validationMessageId: 'tutor-selection-feedback',
+      });
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initTutorSearch);
+    } else {
+      initTutorSearch();
+    }
+
     function validarTutor() {
       {% if not tutor %}
-      if (!document.getElementById('tutor_id').value) {
-        alert('Por favor, selecione um tutor antes de salvar o animal.');
+      if (!tutorSearchController?.hasSelection?.()) {
+        const typedValue = tutorSearchController?.getTypedValue?.() || '';
+        if (typedValue) {
+          tutorSearchController?.showValidationMessage?.();
+        } else {
+          tutorSearchController?.hideValidationMessage?.();
+        }
         return false;
       }
+      tutorSearchController?.hideValidationMessage?.();
       {% endif %}
       return true;
     }
@@ -113,34 +142,6 @@
       }
       return true;
     }
-
-    const tutorInput = document.getElementById('autocomplete-tutor');
-    const tutorResults = document.getElementById('tutor-results');
-    const tutorIdField = document.getElementById('tutor_id');
-
-    tutorInput?.addEventListener('input', async () => {
-      const q = tutorInput.value.trim();
-      if (q.length < 2) {
-        tutorResults.classList.add('d-none');
-        tutorResults.innerHTML = '';
-        return;
-      }
-      const res = await fetch(`/buscar_tutores?q=${encodeURIComponent(q)}`);
-      const data = await res.json();
-      tutorResults.innerHTML = '';
-      data.forEach(t => {
-        const li = document.createElement('li');
-        li.className = 'list-group-item list-group-item-action';
-        li.textContent = `${t.name} (${t.email})`;
-        li.onclick = () => {
-          tutorInput.value = t.name;
-          tutorIdField.value = t.id;
-          tutorResults.classList.add('d-none');
-        };
-        tutorResults.appendChild(li);
-      });
-      tutorResults.classList.toggle('d-none', data.length === 0);
-    });
   </script>
 
   <style>


### PR DESCRIPTION
## Summary
- add a reusable tutor search helper that resets the hidden tutor id when the typed text no longer matches
- integrate the helper with the animal registration form and show an inline validation warning when no tutor is selected

## Testing
- not run (frontend-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e4f4e704a4832eaa10d0dabcf63961