### PR TITLE
Improve tutor search resilience and UX

### DIFF
--- a/static/js/tutor_search.js
+++ b/static/js/tutor_search.js
@@ -1,0 +1,369 @@
+const DEFAULT_TIMEOUT_MS = 8000;
+
+export class TutorSearchError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = 'TutorSearchError';
+    this.code = code;
+    if (options.cause) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+function createTutorFetcher({ endpoint = '/buscar_tutores', timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  let activeController = null;
+
+  return async function fetchTutors(query) {
+    if (activeController) {
+      // Abort the previous request before starting a new one.
+      activeController.abort();
+    }
+
+    const controller = new AbortController();
+    activeController = controller;
+
+    let didTimeout = false;
+    const timeoutId = setTimeout(() => {
+      didTimeout = true;
+      controller.abort();
+    }, timeoutMs);
+
+    try {
+      const response = await fetch(`${endpoint}?q=${encodeURIComponent(query)}`, {
+        headers: {
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        signal: controller.signal,
+      });
+
+      if (response.status === 429) {
+        throw new TutorSearchError(
+          'rate_limit',
+          'Muitas buscas seguidas. Aguarde um instante e tente novamente.'
+        );
+      }
+
+      if (response.status >= 500) {
+        throw new TutorSearchError(
+          'server',
+          'Não foi possível buscar os tutores agora. Tente novamente em instantes.'
+        );
+      }
+
+      if (!response.ok) {
+        throw new TutorSearchError(
+          'http_error',
+          'Não foi possível buscar os tutores. Verifique os dados e tente novamente.'
+        );
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        if (didTimeout) {
+          throw new TutorSearchError(
+            'timeout',
+            'A busca demorou mais do que o esperado. Tente novamente.'
+          );
+        }
+        return { aborted: true };
+      }
+
+      if (error instanceof TutorSearchError) {
+        throw error;
+      }
+
+      throw new TutorSearchError('network', 'Não foi possível conectar ao servidor.', { cause: error });
+    } finally {
+      clearTimeout(timeoutId);
+      if (activeController === controller) {
+        activeController = null;
+      }
+    }
+  };
+}
+
+const defaultFormatTutor = (tutor) => {
+  if (!tutor) {
+    return '';
+  }
+  const email = tutor.email ? ` (${tutor.email})` : '';
+  return `${tutor.name || 'Tutor'}${email}`;
+};
+
+export function setupTutorSearch({
+  input,
+  resultsList,
+  statusElement,
+  endpoint = '/buscar_tutores',
+  minChars = 2,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  formatTutor = defaultFormatTutor,
+  onTutorSelected = () => {},
+  retryLabel = 'Tentar novamente',
+  emptyMessage = 'Nenhum tutor encontrado.',
+  loadingMessage = 'Buscando tutores...',
+  offlineMessage = 'Você está offline. Verifique sua conexão e tente novamente.',
+} = {}) {
+  if (!input || !resultsList) {
+    return {
+      hideResults: () => {},
+      refresh: () => {},
+      showResults: () => {},
+    };
+  }
+
+  const fetchTutors = createTutorFetcher({ endpoint, timeoutMs });
+
+  const state = {
+    currentQuery: '',
+    requestId: 0,
+    lastResults: [],
+  };
+
+  const updateStatus = (message) => {
+    if (statusElement) {
+      statusElement.textContent = message || '';
+    }
+  };
+
+  const setBusy = (busy) => {
+    if (busy) {
+      resultsList.setAttribute('aria-busy', 'true');
+    } else {
+      resultsList.removeAttribute('aria-busy');
+    }
+  };
+
+  const showList = () => {
+    resultsList.classList.remove('d-none');
+    resultsList.dataset.visible = 'true';
+    if (input) {
+      input.setAttribute('aria-expanded', 'true');
+    }
+  };
+
+  const hideList = () => {
+    resultsList.classList.add('d-none');
+    resultsList.dataset.visible = 'false';
+    if (input) {
+      input.setAttribute('aria-expanded', 'false');
+    }
+    setBusy(false);
+  };
+
+  const renderLoading = () => {
+    resultsList.innerHTML = '';
+    state.lastResults = [];
+    const li = document.createElement('li');
+    li.className = 'list-group-item d-flex align-items-center gap-2';
+    li.setAttribute('role', 'option');
+
+    const spinner = document.createElement('span');
+    spinner.className = 'spinner-border spinner-border-sm text-primary';
+    spinner.setAttribute('role', 'status');
+    spinner.setAttribute('aria-hidden', 'true');
+
+    const text = document.createElement('span');
+    text.textContent = loadingMessage;
+
+    li.appendChild(spinner);
+    li.appendChild(text);
+    resultsList.appendChild(li);
+
+    showList();
+    updateStatus(loadingMessage);
+    setBusy(true);
+  };
+
+  const renderEmpty = () => {
+    resultsList.innerHTML = '';
+    state.lastResults = [];
+    const li = document.createElement('li');
+    li.className = 'list-group-item text-muted';
+    li.setAttribute('role', 'option');
+    li.textContent = emptyMessage;
+    resultsList.appendChild(li);
+
+    showList();
+    updateStatus(emptyMessage);
+    setBusy(false);
+  };
+
+  const renderError = (error) => {
+    resultsList.innerHTML = '';
+    state.lastResults = [];
+
+    const messageByCode = {
+      offline: offlineMessage,
+      timeout: 'A busca demorou mais do que o esperado. Tente novamente.',
+      rate_limit: 'Muitas buscas seguidas. Aguarde alguns segundos antes de tentar novamente.',
+      server: 'Não foi possível buscar os tutores agora. Tente novamente em instantes.',
+      network: 'Não foi possível conectar ao servidor. Verifique sua conexão e tente novamente.',
+    };
+
+    const message = messageByCode[error.code] || error.message || 'Não foi possível buscar os tutores.';
+
+    const li = document.createElement('li');
+    li.className = 'list-group-item d-flex align-items-center gap-2';
+    li.setAttribute('role', 'option');
+
+    const text = document.createElement('span');
+    text.textContent = message;
+    li.appendChild(text);
+
+    const retryButton = document.createElement('button');
+    retryButton.type = 'button';
+    retryButton.className = 'btn btn-sm btn-outline-secondary ms-auto';
+    retryButton.textContent = retryLabel;
+    retryButton.dataset.retrySearch = 'true';
+    retryButton.setAttribute('aria-label', `${retryLabel}: ${message}`);
+    li.appendChild(retryButton);
+
+    resultsList.appendChild(li);
+
+    showList();
+    updateStatus(message);
+    setBusy(false);
+  };
+
+  const renderResults = (tutors) => {
+    resultsList.innerHTML = '';
+    state.lastResults = tutors.slice();
+
+    tutors.forEach((tutor, index) => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item list-group-item-action';
+      li.tabIndex = 0;
+      li.dataset.tutorIndex = String(index);
+      li.setAttribute('role', 'option');
+      li.textContent = formatTutor(tutor, index, tutors);
+      resultsList.appendChild(li);
+    });
+
+    showList();
+    const countMessage = tutors.length === 1
+      ? '1 tutor encontrado.'
+      : `${tutors.length} tutores encontrados.`;
+    updateStatus(countMessage);
+    setBusy(false);
+  };
+
+  const executeSearch = async (query, { skipMinLength = false } = {}) => {
+    state.currentQuery = query;
+    if (!skipMinLength && query.length < minChars) {
+      state.lastResults = [];
+      resultsList.innerHTML = '';
+      hideList();
+      updateStatus('');
+      setBusy(false);
+      return;
+    }
+
+    const requestId = ++state.requestId;
+    renderLoading();
+
+    try {
+      if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+        throw new TutorSearchError('offline', offlineMessage);
+      }
+
+      const response = await fetchTutors(query);
+      if (response && response.aborted) {
+        return;
+      }
+
+      if (requestId !== state.requestId) {
+        return;
+      }
+
+      if (!Array.isArray(response) || response.length === 0) {
+        renderEmpty();
+        return;
+      }
+
+      renderResults(response);
+    } catch (error) {
+      if (requestId !== state.requestId) {
+        return;
+      }
+
+      if (!(error instanceof TutorSearchError)) {
+        error = new TutorSearchError('unknown', error?.message || 'Não foi possível buscar tutores.');
+      }
+
+      renderError(error);
+    }
+  };
+
+  resultsList.setAttribute('role', resultsList.getAttribute('role') || 'listbox');
+  resultsList.setAttribute('aria-live', resultsList.getAttribute('aria-live') || 'polite');
+  resultsList.setAttribute('aria-atomic', resultsList.getAttribute('aria-atomic') || 'false');
+  hideList();
+
+  input.addEventListener('input', () => {
+    const value = input.value.trim();
+    state.currentQuery = value;
+    if (!value) {
+      state.lastResults = [];
+      resultsList.innerHTML = '';
+      hideList();
+      updateStatus('');
+      setBusy(false);
+      return;
+    }
+    executeSearch(value);
+  });
+
+  resultsList.addEventListener('click', (event) => {
+    const retryButton = event.target.closest('[data-retry-search]');
+    if (retryButton) {
+      event.preventDefault();
+      if (state.currentQuery) {
+        executeSearch(state.currentQuery, { skipMinLength: true });
+      }
+      return;
+    }
+
+    const item = event.target.closest('[data-tutor-index]');
+    if (!item) {
+      return;
+    }
+
+    const index = Number.parseInt(item.dataset.tutorIndex, 10);
+    const tutor = state.lastResults[index];
+    if (tutor) {
+      onTutorSelected(tutor, { query: state.currentQuery, index });
+    }
+  });
+
+  resultsList.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+
+    const item = event.target.closest('[data-tutor-index]');
+    if (!item) {
+      return;
+    }
+
+    event.preventDefault();
+    const index = Number.parseInt(item.dataset.tutorIndex, 10);
+    const tutor = state.lastResults[index];
+    if (tutor) {
+      onTutorSelected(tutor, { query: state.currentQuery, index });
+    }
+  });
+
+  return {
+    hideResults: hideList,
+    showResults: showList,
+    refresh: () => {
+      if (state.currentQuery) {
+        executeSearch(state.currentQuery, { skipMinLength: true });
+      }
+    },
+  };
+}

--- a/templates/animais/tutores.html
+++ b/templates/animais/tutores.html
@@ -8,8 +8,9 @@
   <div class="card mb-4">
     <div class="card-body">
       <h5 class="card-title mb-3">🔍 Buscar Tutor</h5>
-      <input id="busca-tutor" class="form-control" placeholder="Digite nome, e‑mail, CPF ou telefone">
-      <ul id="lista-tutores" class="list-group mt-2 d-none"></ul>
+      <input id="busca-tutor" class="form-control" placeholder="Digite nome, e‑mail, CPF ou telefone" aria-controls="lista-tutores">
+      <ul id="lista-tutores" class="list-group mt-2 d-none" role="listbox"></ul>
+      <span id="lista-tutores-status" class="visually-hidden" aria-live="polite" aria-atomic="true"></span>
     </div>
   </div>
 
@@ -81,45 +82,39 @@
 <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
 
 <!-- Script geral -->
-<script>
+<script type="module">
+  import { setupTutorSearch } from "{{ url_for('static', filename='js/tutor_search.js') }}";
+
   const inputTutor = document.getElementById('busca-tutor');
   const listaTutor = document.getElementById('lista-tutores');
+  const listaStatus = document.getElementById('lista-tutores-status');
 
-  inputTutor.addEventListener('input', async () => {
-    const q = inputTutor.value.trim();
-    if (q.length < 2) {
-      listaTutor.classList.add('d-none');
-      listaTutor.innerHTML = '';
-      return;
-    }
-
-    const res = await fetch(`/buscar_tutores?q=${encodeURIComponent(q)}`);
-    const data = await res.json();
-
-    listaTutor.innerHTML = '';
-    if (data.length) {
-      data.forEach(t => {
-        const li = document.createElement('li');
-        li.className = 'list-group-item list-group-item-action';
-        let texto = `${t.name} (${t.email})`;
-        if (t.specialties) {
-          texto += ` – ${t.specialties}`;
+  if (inputTutor && listaTutor) {
+    const search = setupTutorSearch({
+      input: inputTutor,
+      resultsList: listaTutor,
+      statusElement: listaStatus,
+      formatTutor: (tutor) => {
+        let texto = tutor.name || '';
+        if (tutor.email) {
+          texto += ` (${tutor.email})`;
         }
-        li.textContent = texto;
-        li.onclick = () => window.location = `/ficha_tutor/${t.id}`;
-        listaTutor.appendChild(li);
-      });
-      listaTutor.classList.remove('d-none');
-    } else {
-      listaTutor.classList.add('d-none');
-    }
-  });
+        if (tutor.specialties) {
+          texto += ` – ${tutor.specialties}`;
+        }
+        return texto;
+      },
+      onTutorSelected: (tutor) => {
+        window.location = `/ficha_tutor/${tutor.id}`;
+      },
+    });
 
-  document.addEventListener('click', e => {
-    if (!inputTutor.contains(e.target) && !listaTutor.contains(e.target)) {
-      listaTutor.classList.add('d-none');
-    }
-  });
+    document.addEventListener('click', (event) => {
+      if (!inputTutor.contains(event.target) && !listaTutor.contains(event.target)) {
+        search.hideResults();
+      }
+    });
+  }
 
   // Flatpickr + Sincronização idade
   const dobInput = document.getElementById("date_of_birth");

--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -6,9 +6,10 @@
     <!-- 🔎 Tutor -->
     <div class="mb-3 position-relative">
       <label for="autocomplete-tutor" class="form-label">👤 Tutor</label>
-      <input type="text" id="autocomplete-tutor" class="form-control" placeholder="Digite nome ou e-mail do tutor">
+      <input type="text" id="autocomplete-tutor" class="form-control" placeholder="Digite nome ou e-mail do tutor" aria-controls="tutor-results">
       <input type="hidden" name="tutor_id" id="tutor_id">
-      <ul class="list-group position-absolute w-100 mt-1 d-none" id="tutor-results" style="z-index: 1000;"></ul>
+      <ul class="list-group position-absolute w-100 mt-1 d-none" id="tutor-results" style="z-index: 1000;" role="listbox"></ul>
+      <span id="tutor-results-status" class="visually-hidden" aria-live="polite" aria-atomic="true"></span>
       <div class="text-end mt-2">
         <a href="{{ url_for('tutores') }}" class="btn btn-sm btn-outline-secondary">
           ➕ Cadastrar novo tutor
@@ -114,33 +115,43 @@
       return true;
     }
 
+  </script>
+
+  <script type="module">
+    import { setupTutorSearch } from "{{ url_for('static', filename='js/tutor_search.js') }}";
+
     const tutorInput = document.getElementById('autocomplete-tutor');
     const tutorResults = document.getElementById('tutor-results');
+    const tutorStatus = document.getElementById('tutor-results-status');
     const tutorIdField = document.getElementById('tutor_id');
 
-    tutorInput?.addEventListener('input', async () => {
-      const q = tutorInput.value.trim();
-      if (q.length < 2) {
-        tutorResults.classList.add('d-none');
-        tutorResults.innerHTML = '';
-        return;
-      }
-      const res = await fetch(`/buscar_tutores?q=${encodeURIComponent(q)}`);
-      const data = await res.json();
-      tutorResults.innerHTML = '';
-      data.forEach(t => {
-        const li = document.createElement('li');
-        li.className = 'list-group-item list-group-item-action';
-        li.textContent = `${t.name} (${t.email})`;
-        li.onclick = () => {
-          tutorInput.value = t.name;
-          tutorIdField.value = t.id;
-          tutorResults.classList.add('d-none');
-        };
-        tutorResults.appendChild(li);
+    if (tutorInput && tutorResults) {
+      const search = setupTutorSearch({
+        input: tutorInput,
+        resultsList: tutorResults,
+        statusElement: tutorStatus,
+        onTutorSelected: (tutor) => {
+          tutorInput.value = tutor.name;
+          if (tutorIdField) {
+            tutorIdField.value = tutor.id;
+          }
+          search.hideResults();
+        },
       });
-      tutorResults.classList.toggle('d-none', data.length === 0);
-    });
+
+      tutorInput.addEventListener('input', () => {
+        if (tutorIdField) {
+          tutorIdField.value = '';
+        }
+      });
+
+      document.addEventListener('click', (event) => {
+        if (event.target === tutorInput || tutorResults.contains(event.target)) {
+          return;
+        }
+        search.hideResults();
+      });
+    }
   </script>
 
   <style>


### PR DESCRIPTION
## Summary
- add a shared tutor search module that wraps fetch with AbortController, explicit HTTP error handling, timeout support, and offline detection
- show loading and error indicators with accessible status updates in tutor result lists and provide a retry action
- integrate the shared search helper into the animal registration and tutor listing screens

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4f4f127d8832ea40d1a624bb279f5