### PR TITLE
Improve calendar summary responsiveness

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -323,6 +323,21 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  align-items: stretch;
+}
+
+.calendar-summary-filters::-webkit-scrollbar {
+  height: 6px;
+}
+
+.calendar-summary-filters::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.55);
+  border-radius: 999px;
+}
+
+.calendar-summary-filters::-webkit-scrollbar-track {
+  background-color: rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
 }
 
 .calendar-summary-filters.is-disabled {
@@ -336,7 +351,7 @@
   align-items: center;
   justify-content: center;
   min-height: 2.25rem;
-  padding: 0.25rem;
+  padding: 0.35rem 0.85rem;
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(241, 245, 249, 0.85);
@@ -358,8 +373,8 @@
 .calendar-summary-filter.has-label {
   justify-content: flex-start;
   align-items: flex-start;
-  padding-inline-start: 0.35rem;
-  padding-inline-end: 0.75rem;
+  padding-inline-start: 0.65rem;
+  padding-inline-end: 0.85rem;
 }
 
 .calendar-summary-filter--all {
@@ -409,7 +424,7 @@
   align-items: flex-start;
   gap: 0.15rem;
   min-width: 0;
-  max-width: 14rem;
+  max-width: 100%;
 }
 
 .calendar-summary-filter-name {
@@ -553,13 +568,16 @@
 
 .calendar-summary-item {
   border-radius: 0.9rem;
-  padding: 0.9rem 1rem;
+  padding: 0.95rem 1rem;
   background: linear-gradient(135deg, var(--calendar-vet-soft, rgba(148, 163, 184, 0.12)), #ffffff);
   border: 1px solid rgba(148, 163, 184, 0.18);
   box-shadow: 0 16px 32px -26px rgba(15, 23, 42, 0.6);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
 .calendar-summary-item:hover {
@@ -595,6 +613,8 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .calendar-summary-item .calendar-summary-name {
@@ -603,6 +623,8 @@
   gap: 0.5rem;
   font-weight: 600;
   color: #0f172a;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .calendar-summary-item .calendar-summary-bullet {
@@ -617,11 +639,13 @@
   display: inline-flex;
   align-items: baseline;
   gap: 0.35rem;
-  padding: 0.2rem 0.65rem;
+  padding: 0.2rem 0.75rem;
   border-radius: 999px;
   background-color: rgba(255, 255, 255, 0.75);
   font-size: 0.8rem;
   color: #475569;
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .calendar-summary-item .calendar-summary-total .value {
@@ -632,12 +656,12 @@
 .calendar-summary-item .calendar-summary-metrics {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 0.75rem;
+  gap: 0.65rem 0.75rem;
   font-size: 0.86rem;
   color: #475569;
   list-style: none;
   padding: 0;
+  margin: 0;
 }
 
 .calendar-summary-item .calendar-summary-metrics .metric {
@@ -654,9 +678,9 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem 0.55rem;
-  margin-top: 0.85rem;
   list-style: none;
   padding: 0;
+  margin: 0;
 }
 
 .calendar-summary-item .calendar-summary-day {
@@ -674,6 +698,55 @@
 
 .calendar-summary-item .calendar-summary-day .label {
   font-weight: 500;
+}
+
+@media (min-width: 992px) {
+  .calendar-summary-filter-content {
+    max-width: 18rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  [data-calendar-main-column],
+  [data-calendar-summary-column] {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+
+  [data-calendar-main-column] {
+    order: 1;
+  }
+
+  [data-calendar-summary-column] {
+    order: 2;
+    margin-top: 1.75rem;
+  }
+
+  .calendar-summary-card .card-body {
+    padding-inline: 0.75rem;
+  }
+
+  .calendar-summary-filters {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    gap: 0.65rem;
+    padding-bottom: 0.35rem;
+    padding-inline: 0.25rem;
+  }
+
+  .calendar-summary-filter {
+    flex: 0 0 auto;
+  }
+
+  .calendar-summary-filter .calendar-summary-filter-content {
+    max-width: 80vw;
+  }
+
+  .calendar-summary-item .calendar-summary-total {
+    margin-left: 0;
+  }
 }
 
 @media (min-width: 1200px) {

--- a/templates/partials/calendar_summary_panel.html
+++ b/templates/partials/calendar_summary_panel.html
@@ -1,12 +1,89 @@
 {% set summary_title = summary_title|default('Resumo por profissional') %}
 {% set summary_description = summary_description|default('Totais diários e semanais por veterinário com base no calendário visível.') %}
 {% set summary_vets = calendar_summary_vets|default([], true) %}
+{% if summary_vets %}
+  {% if summary_vets is mapping %}
+    {% set summary_vet_list = [summary_vets] %}
+  {% elif summary_vets is iterable and summary_vets is not string %}
+    {% set summary_vet_list = summary_vets|list %}
+  {% else %}
+    {% set summary_vet_list = [summary_vets] %}
+  {% endif %}
+{% else %}
+  {% set summary_vet_list = [] %}
+{% endif %}
+{% set sanitized_vets = namespace(items=[]) %}
+{% for vet in summary_vet_list if vet %}
+  {% set vet_id = vet.id
+    or vet.vet_id
+    or vet.veterinario_id
+    or vet.veterinarioId
+    or vet.veterinarian_id
+    or vet.veterinarianId %}
+  {% set vet_full_name = vet.full_name
+    if vet.full_name is defined
+    else (vet.fullName if vet.fullName is defined else None) %}
+  {% set vet_label = vet.label
+    if vet.label is defined
+    else (vet.name if vet.name is defined else None) %}
+  {% if not vet_label and vet_full_name %}
+    {% set vet_label = vet_full_name %}
+  {% endif %}
+  {% if not vet_full_name and vet_label %}
+    {% set vet_full_name = vet_label %}
+  {% endif %}
+  {% set vet_display = vet_label if vet_label else 'Profissional ' ~ loop.index %}
+  {% set vet_title = vet_full_name if vet_full_name else vet_display %}
+  {% set raw_specialty = none %}
+  {% if vet.specialty_list is defined and vet.specialty_list %}
+    {% set raw_specialty = vet.specialty_list %}
+  {% elif vet.specialtyList is defined and vet.specialtyList %}
+    {% set raw_specialty = vet.specialtyList %}
+  {% endif %}
+  {% if raw_specialty is string %}
+    {% set specialty_text = raw_specialty|trim %}
+  {% elif raw_specialty is sequence %}
+    {% set specialty_text = raw_specialty|join(', ') %}
+  {% elif raw_specialty is not none %}
+    {% set specialty_text = raw_specialty|string %}
+  {% else %}
+    {% set specialty_text = '' %}
+  {% endif %}
+  {% if vet.is_specialist is defined %}
+    {% set is_specialist = vet.is_specialist %}
+  {% elif vet.isSpecialist is defined %}
+    {% set is_specialist = vet.isSpecialist %}
+  {% elif vet.specialist is defined %}
+    {% set is_specialist = vet.specialist %}
+  {% else %}
+    {% set is_specialist = specialty_text is string and specialty_text|length > 0 %}
+  {% endif %}
+  {% set primary_specialty = '' %}
+  {% if vet.primary_specialty is defined and vet.primary_specialty %}
+    {% set primary_specialty = vet.primary_specialty %}
+  {% elif vet.primarySpecialty is defined and vet.primarySpecialty %}
+    {% set primary_specialty = vet.primarySpecialty %}
+  {% endif %}
+  {% set sanitized_vets.items = sanitized_vets.items + [{
+    'id': vet_id,
+    'label': vet_display,
+    'name': vet_display,
+    'full_name': vet_title,
+    'vetName': vet_display,
+    'vetFullName': vet_title,
+    'specialty_list': specialty_text,
+    'is_specialist': is_specialist,
+    'primary_specialty': primary_specialty,
+    'primarySpecialty': primary_specialty
+  }] %}
+{% endfor %}
+{% set summary_vet_entries = sanitized_vets.items %}
 {% set summary_clinic_ids = calendar_summary_clinic_ids|default([], true) %}
 {% set summary_storage_key = calendar_summary_storage_key|default('', true) %}
 <div
   class="card calendar-summary-card border-0 shadow-sm h-100 is-loading"
   data-calendar-summary-panel
-  data-calendar-summary-vets='{{ summary_vets|tojson }}'
+  data-calendar-summary-vets='{{ summary_vet_entries|tojson }}'
   data-calendar-summary-clinic-ids='{{ summary_clinic_ids|tojson }}'
   {% if summary_storage_key %}
   data-calendar-summary-storage-key="{{ summary_storage_key }}"
@@ -37,12 +114,82 @@
       </div>
     </div>
     <div
-      class="calendar-summary-filters d-flex flex-wrap align-items-center gap-2 mt-3 d-none"
+      class="calendar-summary-filters d-flex flex-wrap align-items-center gap-2 mt-3{% if not summary_vet_entries %} d-none{% endif %}"
       data-calendar-summary-filters
       data-calendar-summary-all-label="Toda a clínica"
       data-calendar-summary-all-vet-id=""
       aria-label="Filtrar agenda por profissional"
-    ></div>
+    >
+      {% if summary_vet_entries %}
+        {% set all_label = 'Toda a clínica' %}
+        <button
+          type="button"
+          class="calendar-summary-filter calendar-summary-filter--all"
+          data-vet-id=""
+          aria-pressed="false"
+          aria-label="Mostrar agenda de {{ all_label.lower() }}"
+          title="{{ all_label }}"
+        >
+          <span class="calendar-summary-filter-label">{{ all_label }}</span>
+        </button>
+        {% for vet in summary_vet_entries %}
+          {% set vet_id = vet.id %}
+          {% set vet_display = vet.label if vet.label is defined and vet.label else (vet.name if vet.name is defined and vet.name else 'Profissional ' ~ loop.index) %}
+          {% set vet_title = vet.full_name if vet.full_name is defined and vet.full_name else vet_display %}
+          {% set specialty_text = (vet.specialty_list if vet.specialty_list is defined else '')|trim %}
+          {% set is_specialist = vet.is_specialist if vet.is_specialist is defined else False %}
+          {% set primary_specialty = '' %}
+          {% if vet.primary_specialty is defined and vet.primary_specialty %}
+            {% set primary_specialty = vet.primary_specialty %}
+          {% elif vet.primarySpecialty is defined and vet.primarySpecialty %}
+            {% set primary_specialty = vet.primarySpecialty %}
+          {% endif %}
+          {% set name_source = (vet_title or '')|trim %}
+          {% set name_parts = name_source.split() %}
+          {% set part_count = name_parts|length %}
+          {% if part_count >= 1 %}
+            {% set first_part = name_parts[0] %}
+            {% set last_part = name_parts[-1] if part_count > 1 else name_parts[0] %}
+            {% if part_count > 1 and first_part and last_part %}
+              {% set initials_text = (first_part[0] ~ last_part[0])|upper %}
+            {% else %}
+              {% set initials_text = first_part[:2]|upper %}
+            {% endif %}
+          {% else %}
+            {% set initials_text = '•' %}
+          {% endif %}
+          {% set aria_label = 'Filtrar agenda por ' ~ vet_display %}
+          {% if is_specialist %}
+            {% if specialty_text %}
+              {% set aria_label = aria_label ~ ', especialista em ' ~ specialty_text %}
+            {% else %}
+              {% set aria_label = aria_label ~ ', especialista' %}
+            {% endif %}
+          {% endif %}
+          <button
+            type="button"
+            class="calendar-summary-filter has-label"
+            data-vet-id="{{ vet_id if vet_id is not none else '' }}"
+            aria-pressed="false"
+            aria-label="{{ aria_label }}"
+            title="{{ vet_title }}"
+          >
+            <span class="calendar-summary-filter-icon" aria-hidden="true">{{ initials_text }}</span>
+            <span class="calendar-summary-filter-content">
+              <span class="calendar-summary-filter-name">{{ vet_display }}</span>
+              {% if is_specialist %}
+                <span class="calendar-summary-filter-badge badge rounded-pill" aria-hidden="true"{% if specialty_text %} title="{{ specialty_text }}"{% endif %}>
+                  {{ primary_specialty if primary_specialty else 'Especialista' }}
+                </span>
+                <span class="visually-hidden">
+                  {% if specialty_text %}Especialista em {{ specialty_text }}{% else %}Especialista{% endif %}
+                </span>
+              {% endif %}
+            </span>
+          </button>
+        {% endfor %}
+      {% endif %}
+    </div>
     <div class="calendar-summary-overview row g-3 mt-1" data-calendar-summary-overview hidden>
       <div class="col-12 col-sm-6">
         <div class="calendar-summary-overview-card is-today">


### PR DESCRIPTION
## Summary
- add responsive styling so the calendar summary column stacks cleanly on narrow viewports while keeping filter chips scrollable and wrapping text gracefully
- render pre-populated calendar summary filters with tooltips and padding that match the dynamic UI, while sanitizing metadata for downstream scripts

## Testing
- pytest tests/test_appointment_notifications.py::test_pending_page_allows_accept
- pytest tests/test_vet_schedule_order.py::test_schedule_days_order
- pytest tests/test_vacinas.py::test_alterar_vacina_cria_proxima_dose *(fails: expected appointment list to contain "V10" after vaccine update; failure also present before this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f65e8840832ea3a3027c15196d47