### PR TITLE
Expand tutor search coverage across tutor metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -2539,34 +2539,118 @@ def imprimir_consulta(consulta_id):
 
 @app.route('/buscar_tutores', methods=['GET'])
 def buscar_tutores():
-    query = request.args.get('q', '').strip()
+    raw_query = request.args.get('q', '')
+    query = raw_query.strip()
 
     if not query:
         return jsonify([])
 
-    query = f"%{query}%"
+    like_query = f"%{query}%"
+    numeric_query = re.sub(r'\D', '', query)
+    numeric_like = f"%{numeric_query}%" if numeric_query else None
 
-    # Filtra por campos individualmente e junta os resultados (sem usar or_)
-    nome_matches = User.query.filter(User.name.ilike(query)).all()
-    email_matches = User.query.filter(User.email.ilike(query)).all()
-    cpf_matches = User.query.filter(User.cpf.ilike(query)).all()
-    rg_matches = User.query.filter(User.rg.ilike(query)).all()
-    phone_matches = User.query.filter(User.phone.ilike(query)).all()
+    def sanitize_expression(expr, characters):
+        sanitized = expr
+        for char in characters:
+            sanitized = func.replace(sanitized, char, '')
+        return sanitized
 
-    # Junta os resultados e remove duplicados (por ID)
-    todos = {user.id: user for user in (
-        nome_matches + email_matches + cpf_matches + rg_matches + phone_matches
-    )}.values()
+    # Junta resultados de múltiplos campos evitando duplicados
+    encontrados = {}
 
-    resultados = [
-        {
-            'id': tutor.id,
-            'name': tutor.name,
-            'email': tutor.email,
-            'specialties': ', '.join(s.nome for s in tutor.veterinario.specialties) if getattr(tutor, 'veterinario', None) else ''
-        }
-        for tutor in todos
+    def adicionar_usuarios(usuarios):
+        for usuario in usuarios:
+            encontrados[usuario.id] = usuario
+
+    campos_texto = [
+        User.name,
+        User.email,
+        User.worker,
+        User.address,
+        User.cpf,
+        User.rg,
+        User.phone,
     ]
+
+    for campo in campos_texto:
+        adicionar_usuarios(User.query.filter(campo.ilike(like_query)).all())
+
+    # Busca por dados numéricos removendo formatação
+    if numeric_like:
+        campos_numericos = [
+            sanitize_expression(User.cpf, ['.', '-', '/', ' ']),
+            sanitize_expression(User.rg, ['.', '-', '/', ' ']),
+            sanitize_expression(User.phone, ['(', ')', '-', ' ']),
+        ]
+
+        for campo in campos_numericos:
+            adicionar_usuarios(User.query.filter(campo.ilike(numeric_like)).all())
+
+    # Campos de endereço vinculados ao tutor
+    campos_endereco = [
+        Endereco.cep,
+        Endereco.rua,
+        Endereco.numero,
+        Endereco.complemento,
+        Endereco.bairro,
+        Endereco.cidade,
+        Endereco.estado,
+    ]
+
+    for campo in campos_endereco:
+        adicionar_usuarios(
+            User.query.join(User.endereco, isouter=True)
+            .filter(campo.ilike(like_query))
+            .all()
+        )
+
+    if numeric_like:
+        adicionar_usuarios(
+            User.query.join(User.endereco, isouter=True)
+            .filter(sanitize_expression(Endereco.cep, ['-', ' ']).ilike(numeric_like))
+            .all()
+        )
+
+    resultados = []
+
+    for tutor in encontrados.values():
+        address_summary = (
+            tutor.address
+            or (tutor.endereco.full if getattr(tutor, 'endereco', None) else '')
+        )
+        detalhes = [
+            valor
+            for valor in [
+                tutor.email,
+                tutor.phone,
+                f"CPF: {tutor.cpf}" if tutor.cpf else '',
+                f"RG: {tutor.rg}" if tutor.rg else '',
+                tutor.worker,
+            ]
+            if valor
+        ]
+
+        resultados.append(
+            {
+                'id': tutor.id,
+                'name': tutor.name,
+                'email': tutor.email,
+                'cpf': tutor.cpf,
+                'rg': tutor.rg,
+                'phone': tutor.phone,
+                'worker': tutor.worker,
+                'address_summary': address_summary,
+                'details': ' • '.join(detalhes),
+                'specialties': ', '.join(
+                    s.nome for s in tutor.veterinario.specialties
+                )
+                if getattr(tutor, 'veterinario', None)
+                else '',
+            }
+        )
+
+    # Ordena por nome para facilitar a leitura
+    resultados.sort(key=lambda item: item['name'] or '')
 
     return jsonify(resultados)
 

--- a/static/js/tutor_search.js
+++ b/static/js/tutor_search.js
@@ -105,7 +105,36 @@
         tutors.forEach((tutor) => {
           const li = document.createElement('li');
           li.className = 'list-group-item list-group-item-action';
-          li.textContent = `${tutor.name} (${tutor.email})`;
+
+          const nameLine = document.createElement('div');
+          nameLine.className = 'fw-semibold';
+          nameLine.textContent = tutor.name || 'Tutor sem nome';
+          li.appendChild(nameLine);
+
+          const detailsLine = tutor.details || [
+            tutor.email,
+            tutor.phone,
+            tutor.cpf ? `CPF: ${tutor.cpf}` : null,
+            tutor.rg ? `RG: ${tutor.rg}` : null,
+            tutor.worker,
+          ]
+            .filter(Boolean)
+            .join(' • ');
+
+          if (detailsLine) {
+            const detailsEl = document.createElement('div');
+            detailsEl.className = 'small text-muted';
+            detailsEl.textContent = detailsLine;
+            li.appendChild(detailsEl);
+          }
+
+          if (tutor.address_summary) {
+            const addressEl = document.createElement('div');
+            addressEl.className = 'small text-muted';
+            addressEl.textContent = tutor.address_summary;
+            li.appendChild(addressEl);
+          }
+
           li.addEventListener('click', () => handleTutorSelected(tutor));
           resultsContainer.appendChild(li);
         });

--- a/templates/animais/tutores.html
+++ b/templates/animais/tutores.html
@@ -8,7 +8,7 @@
   <div class="card mb-4">
     <div class="card-body">
       <h5 class="card-title mb-3">🔍 Buscar Tutor</h5>
-      <input id="busca-tutor" class="form-control" placeholder="Digite nome, e‑mail, CPF ou telefone">
+      <input id="busca-tutor" class="form-control" placeholder="Digite nome, e-mail, CPF, RG, telefone ou endereço">
       <ul id="lista-tutores" class="list-group mt-2 d-none"></ul>
     </div>
   </div>
@@ -101,11 +101,41 @@
       data.forEach(t => {
         const li = document.createElement('li');
         li.className = 'list-group-item list-group-item-action';
-        let texto = `${t.name} (${t.email})`;
-        if (t.specialties) {
-          texto += ` – ${t.specialties}`;
+
+        const nameLine = document.createElement('div');
+        nameLine.className = 'fw-semibold';
+        nameLine.textContent = t.name || 'Tutor sem nome';
+        li.appendChild(nameLine);
+
+        const details = t.details || [
+          t.email,
+          t.phone,
+          t.cpf ? `CPF: ${t.cpf}` : null,
+          t.rg ? `RG: ${t.rg}` : null,
+          t.worker,
+        ].filter(Boolean).join(' • ');
+
+        if (details) {
+          const detailsEl = document.createElement('div');
+          detailsEl.className = 'small text-muted';
+          detailsEl.textContent = details;
+          li.appendChild(detailsEl);
         }
-        li.textContent = texto;
+
+        if (t.specialties) {
+          const specialtiesEl = document.createElement('div');
+          specialtiesEl.className = 'small text-muted';
+          specialtiesEl.textContent = `Especialidades: ${t.specialties}`;
+          li.appendChild(specialtiesEl);
+        }
+
+        if (t.address_summary) {
+          const addressEl = document.createElement('div');
+          addressEl.className = 'small text-muted';
+          addressEl.textContent = t.address_summary;
+          li.appendChild(addressEl);
+        }
+
         li.onclick = () => window.location = `/ficha_tutor/${t.id}`;
         listaTutor.appendChild(li);
       });

--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -6,7 +6,7 @@
     <!-- 🔎 Tutor -->
     <div class="mb-3 position-relative">
       <label for="autocomplete-tutor" class="form-label">👤 Tutor</label>
-      <input type="text" id="autocomplete-tutor" class="form-control" placeholder="Digite nome ou e-mail do tutor">
+      <input type="text" id="autocomplete-tutor" class="form-control" placeholder="Digite nome, e-mail, CPF, RG, telefone ou endereço do tutor">
       <input type="hidden" name="tutor_id" id="tutor_id">
       <ul class="list-group position-absolute w-100 mt-1 d-none" id="tutor-results" style="z-index: 1000;"></ul>
       <div id="tutor-selection-feedback" class="text-danger small d-none mt-2">

--- a/templates/partials/tutor_form.html
+++ b/templates/partials/tutor_form.html
@@ -7,8 +7,8 @@
     <i class="bi bi-search me-1"></i> Buscar Tutor Existente
   </label>
   <div class="input-group">
-    <input type="text" id="autocomplete-tutor" class="form-control" 
-           placeholder="Digite nome, e-mail, CPF ou telefone"
+    <input type="text" id="autocomplete-tutor" class="form-control"
+           placeholder="Digite nome, e-mail, CPF, RG, telefone ou endereço"
            aria-label="Buscar tutor existente"
            aria-describedby="tutor-search-help">
     <button class="btn btn-outline-secondary" type="button" id="clear-search">


### PR DESCRIPTION
## Summary
- expand the `/buscar_tutores` endpoint to match tutors by every stored contact and address field, normalizing formatted identifiers and returning richer metadata
- update autocomplete UIs to surface the additional tutor details and guide the user with revised placeholders

## Testing
- pytest *(fails: existing TypeError "Object of type Undefined is not JSON serializable" plus unrelated vaccine UI assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68e4fa1537c0832eb3b99555e3ebb855