### PR TITLE
Style quick tutor and pet forms in vet schedule

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -261,15 +261,41 @@
       </div>
     </div>
     <div class="collapse" id="vetNewTutorForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
-      <div class="card-body p-4">
-        {% include 'partials/calendar_quick_tutor_form.html' %}
+      <div class="card-body bg-light p-4">
+        <div class="row justify-content-center">
+          <div class="col-lg-10 col-xl-8 col-xxl-7">
+            <div class="card shadow-lg border-0 rounded-4 overflow-hidden">
+              <div class="card-body p-4 p-lg-5">
+                <div class="text-center text-md-start mb-4">
+                  <h3 id="vetNewTutorHeading" class="fw-semibold mb-2">👥 Cadastrar novo tutor</h3>
+                  <p class="text-muted mb-0">Informe os dados essenciais do tutor e retome o agendamento sem sair desta tela.</p>
+                </div>
+                {% with show_intro=False, heading_id='vetNewTutorHeading' %}
+                  {% include 'partials/calendar_quick_tutor_form.html' %}
+                {% endwith %}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div class="collapse" id="vetNewPetForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
-      <div class="card-body p-4">
-        {% with species_list=species_list, breed_list=breed_list %}
-          {% include 'partials/animal_register_form.html' %}
-        {% endwith %}
+      <div class="card-body bg-light p-4">
+        <div class="row justify-content-center">
+          <div class="col-lg-10 col-xl-8 col-xxl-7">
+            <div class="card shadow-lg border-0 rounded-4 overflow-hidden">
+              <div class="card-body p-4 p-lg-5">
+                <div class="text-center text-md-start mb-4">
+                  <h3 class="fw-semibold mb-2">🐾 Cadastrar novo pet</h3>
+                  <p class="text-muted mb-0">Preencha as informações do animal para vinculá-lo rapidamente ao tutor.</p>
+                </div>
+                {% with species_list=species_list, breed_list=breed_list %}
+                  {% include 'partials/animal_register_form.html' %}
+                {% endwith %}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/templates/partials/calendar_quick_tutor_form.html
+++ b/templates/partials/calendar_quick_tutor_form.html
@@ -1,5 +1,10 @@
 {% set form_id = form_id|default('calendar-quick-tutor-form') %}
-{% set heading_id = heading_id|default(form_id ~ '-heading') %}
+{% set show_intro = show_intro|default(True) %}
+{% if show_intro %}
+  {% set header_id = heading_id|default(form_id ~ '-heading') %}
+{% else %}
+  {% set header_id = heading_id if heading_id is defined else None %}
+{% endif %}
 
 <form
   id="{{ form_id }}"
@@ -7,16 +12,18 @@
   action="{{ url_for('tutores') }}"
   class="js-tutor-form"
   data-sync="true"
-  aria-labelledby="{{ heading_id }}"
+  {% if header_id %}aria-labelledby="{{ header_id }}"{% endif %}
 >
+  {% if show_intro %}
   <div class="d-flex flex-column flex-md-row align-items-md-center gap-2 mb-3">
-    <h5 id="{{ heading_id }}" class="mb-0">
+    <h5 id="{{ header_id }}" class="mb-0">
       <i class="bi bi-person-plus me-2"></i> Cadastro rápido de tutor
     </h5>
     <span class="text-muted small">
       Preencha os dados essenciais para registrar um tutor sem sair da agenda.
     </span>
   </div>
+  {% endif %}
   <div class="row g-3">
     <div class="col-md-6">
       <label for="{{ form_id }}-name" class="form-label">Nome <span class="text-danger">*</span></label>


### PR DESCRIPTION
## Summary
- restyle the quick tutor form in the vet schedule collapse to mirror the dedicated tutores page card layout
- restyle the quick pet form to match the novo animal experience with centered card and description
- allow the shared quick tutor form partial to hide its inline header while preserving accessible labelling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4fc400b70832e932c752eb7564da1