### PR TITLE
Fix tutor redirect to honor URL prefixes

### DIFF
--- a/templates/animais/tutores.html
+++ b/templates/animais/tutores.html
@@ -84,6 +84,21 @@
 <script>
   const inputTutor = document.getElementById('busca-tutor');
   const listaTutor = document.getElementById('lista-tutores');
+  const tutorRedirectTemplate = {{ (url_for('ficha_tutor', tutor_id=0).rsplit('/', 1)[0])|tojson }};
+  const tutorSearchUrl = {{ url_for('buscar_tutores')|tojson }};
+
+  function buildTutorRedirectUrl(template, tutorId) {
+    if (!template) {
+      return '';
+    }
+
+    if (template.includes('{id}')) {
+      return template.replace('{id}', tutorId);
+    }
+
+    const normalized = template.endsWith('/') ? template : `${template}/`;
+    return `${normalized}${tutorId}`;
+  }
 
   inputTutor.addEventListener('input', async () => {
     const q = inputTutor.value.trim();
@@ -93,7 +108,7 @@
       return;
     }
 
-    const res = await fetch(`/buscar_tutores?q=${encodeURIComponent(q)}`);
+    const res = await fetch(`${tutorSearchUrl}?q=${encodeURIComponent(q)}`);
     const data = await res.json();
 
     listaTutor.innerHTML = '';
@@ -136,7 +151,12 @@
           li.appendChild(addressEl);
         }
 
-        li.onclick = () => window.location = `/ficha_tutor/${t.id}`;
+        li.onclick = () => {
+          const redirectUrl = buildTutorRedirectUrl(tutorRedirectTemplate, t.id);
+          if (redirectUrl) {
+            window.location = redirectUrl;
+          }
+        };
         listaTutor.appendChild(li);
       });
       listaTutor.classList.remove('d-none');


### PR DESCRIPTION
## Summary
- compute the tutor redirect base URL in the tutors template using url_for so it respects blueprints or SCRIPT_NAME
- add a helper that builds the redirect target and update fetch to use url_for for tutor search requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4febc0ce0832e897ca64b3f1ae4da