### PR TITLE
Improve mobile layout for schedule header

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -13,6 +13,22 @@
   width: 100%;
 }
 
+.card-header-responsive {
+  text-align: left;
+}
+
+.card-header-responsive .card-header-actions {
+  width: 100%;
+}
+
+.card-header-responsive .card-header-title {
+  font-size: 1.05rem;
+}
+
+.card-header-responsive .card-header-subtitle {
+  line-height: 1.4;
+}
+
 .btn-stack-item {
   width: 100%;
   min-height: 44px;
@@ -26,6 +42,15 @@
 
   .btn-stack-item {
     width: auto;
+  }
+
+  .card-header-responsive {
+    text-align: inherit;
+  }
+
+  .card-header-responsive .card-header-actions {
+    width: auto;
+    justify-content: flex-end;
   }
 }
 

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -14,6 +14,9 @@
       <h2 class="mb-0"><i class="fas fa-calendar-alt me-2 text-primary"></i>Agenda – {{ veterinario.user.name }}</h2>
       <p class="text-muted">Gerencie seus horários e consultas</p>
     </div>
+    <!-- Sugestões de melhorias mobile: considerar tornar tabelas relacionadas roláveis horizontalmente por padrão,
+         revisar espaçamentos verticais em formulários longos e reduzir tamanhos de tipografia em títulos secundários
+         para evitar quebras de linha excessivas em dispositivos abaixo de 360px. -->
     <div class="ms-auto d-flex flex-column gap-2">
       {% if current_user.role == 'admin' %}
       {% set preserve_params = ['start', 'end'] %}
@@ -55,11 +58,19 @@
   <!-- Gerenciar horários e agendamento -->
   {% set schedule_collapse_group_id = 'vet-schedule-collapse-group-' ~ veterinario.id %}
   <div class="card border-0 shadow-lg rounded-4 mb-5" id="{{ schedule_collapse_group_id }}">
-    <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
-      <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
-      <div class="d-flex flex-wrap align-items-center gap-2 justify-content-end">
+    <div class="card-header bg-primary text-white rounded-top-4 d-flex flex-column flex-lg-row gap-3 align-items-lg-center card-header-responsive">
+      <div class="d-flex flex-column gap-1 w-100">
+        <h5 class="mb-0 d-flex align-items-center gap-2 card-header-title">
+          <i class="bi bi-clock-history"></i>
+          <span>Gerenciar Horários</span>
+        </h5>
+        <p class="card-header-subtitle text-white-75 small mb-0 d-lg-none">
+          Acesse ações rápidas sem comprometer o espaço na tela pequena.
+        </p>
+      </div>
+      <div class="button-action-group card-header-actions d-flex flex-column flex-sm-row flex-lg-row gap-2 ms-lg-auto">
         <button
-          class="btn btn-light btn-sm collapsed"
+          class="btn btn-light btn-sm btn-stack-item collapsed"
           type="button"
           data-bs-toggle="collapse"
           data-bs-target="#{{ vet_calendar_collapse_id }}"
@@ -69,11 +80,11 @@
         >
           <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
         </button>
-        <button id="openScheduleModal" class="btn btn-light btn-sm" type="button">
+        <button id="openScheduleModal" class="btn btn-light btn-sm btn-stack-item" type="button">
           <i class="bi bi-pencil"></i> Editar Horário
         </button>
         <button
-          class="btn btn-success btn-sm collapsed"
+          class="btn btn-success btn-sm btn-stack-item collapsed"
           type="button"
           data-bs-toggle="collapse"
           data-bs-target="#newAppointmentForm"
@@ -82,7 +93,7 @@
           <i class="bi bi-plus-circle"></i> Nova Consulta
         </button>
         <button
-          class="btn btn-light btn-sm collapsed"
+          class="btn btn-light btn-sm btn-stack-item collapsed"
           type="button"
           data-bs-toggle="collapse"
           data-bs-target="#vetNewTutorForm"
@@ -92,7 +103,7 @@
           <i class="bi bi-person-plus"></i> Novo Tutor
         </button>
         <button
-          class="btn btn-primary btn-sm collapsed"
+          class="btn btn-primary btn-sm btn-stack-item collapsed"
           type="button"
           data-bs-toggle="collapse"
           data-bs-target="#vetNewPetForm"


### PR DESCRIPTION
## Summary
- restructure the vet schedule action header to stack controls neatly on small screens
- add responsive utility classes and helper styles for card header layouts
- document suggested mobile enhancements for related sections directly in the template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e50024b9c0832e904f96087f1e4deb