### PR TITLE
Improve tutor and animal management panels

### DIFF
--- a/templates/animais/novo_animal.html
+++ b/templates/animais/novo_animal.html
@@ -1,14 +1,24 @@
 {% extends "layout.html" %}
 
 {% block main %}
-  <div class="container d-flex justify-content-center mt-5">
-    <div class="card shadow-lg p-4 rounded-4" style="width: 100%; max-width: 700px;">
-      <h3 class="text-center mb-4">🐾 Animal 🐾 </h3>
-      {% include 'partials/animal_register_form.html' %}
+  <div class="container-fluid py-4">
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-5">
+        <div class="card shadow-sm border-0 rounded-4 h-100">
+          <div class="card-body p-4">
+            <div class="mb-4">
+              <h3 class="fw-semibold mb-1">Cadastro de Animais</h3>
+              <p class="text-muted small mb-0">Associe rapidamente um novo pet a um tutor e visualize os registros existentes ao lado.</p>
+            </div>
+            {% include 'partials/animal_register_form.html' %}
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-7">
+        <div id="animais-adicionados">
+          {% include 'partials/animais_adicionados.html' with compact=True %}
+        </div>
+      </div>
     </div>
   </div>
-  <div id="animais-adicionados">
-  {% include 'partials/animais_adicionados.html' %}
-  </div>
-
 {% endblock %}

--- a/templates/animais/tutores.html
+++ b/templates/animais/tutores.html
@@ -1,79 +1,79 @@
 {% extends 'layout.html' %}
 {% block main %}
-<div class="container py-4">
-
-  <h2 class="mb-4">👥 Tutores</h2>
-
-  <!-- 🔍 Busca de tutor -->
-  <div class="card mb-4">
-    <div class="card-body">
-      <h5 class="card-title mb-3">🔍 Buscar Tutor</h5>
-      <input id="busca-tutor" class="form-control" placeholder="Digite nome, e-mail, CPF, RG, telefone ou endereço">
-      <ul id="lista-tutores" class="list-group mt-2 d-none"></ul>
-    </div>
-  </div>
-
-  <hr>
-
-  <!-- ➕ Cadastro de novo tutor -->
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title mb-3">➕ Cadastrar Novo Tutor</h5>
-
-      <form id="novo-tutor-form" method="POST" action="{{ url_for('tutores') }}" class="js-tutor-form" data-sync="true">
-        <div class="row">
-          <div class="mb-3 col-md-6">
-            <label class="form-label">Nome</label>
-            <input name="name" class="form-control" required>
-          </div>
-          <div class="mb-3 col-md-6">
-            <label class="form-label">E‑mail</label>
-            <input name="email" type="email" class="form-control" required>
-          </div>
-          <div class="mb-3 col-md-6">
-            <label class="form-label">Telefone</label>
-            <input name="phone" class="form-control">
+<div class="container-fluid py-4">
+  <div class="row g-4 align-items-start">
+    <div class="col-12 col-xl-4">
+      <div class="card shadow-sm border-0 rounded-4 h-100">
+        <div class="card-body p-4">
+          <div class="mb-4">
+            <h3 class="fw-semibold mb-1">Gestão de Tutores</h3>
+            <p class="text-muted small mb-0">Busque um tutor existente ou cadastre um novo sem sair desta tela.</p>
           </div>
 
+          <!-- 🔍 Busca de tutor -->
+          <div class="p-3 rounded-4 border bg-light-subtle mb-4">
+            <div class="d-flex align-items-center gap-2 mb-2">
+              <span class="badge bg-primary-subtle text-primary-emphasis rounded-pill">🔍</span>
+              <h6 class="mb-0">Buscar Tutor</h6>
+            </div>
+            <input id="busca-tutor" class="form-control" placeholder="Digite nome, e-mail, CPF, RG, telefone ou endereço">
+            <ul id="lista-tutores" class="list-group shadow-sm mt-2 d-none"></ul>
+            <p class="text-muted small mb-0 mt-2">Selecione para abrir a ficha do tutor.</p>
+          </div>
 
-          <div class="mb-3 col-md-6">
-            <label class="form-label">CPF</label>
-            <input name="cpf" class="form-control">
-          </div>
-          <div class="mb-3 col-md-6">
-            <label class="form-label">RG</label>
-            <input name="rg" class="form-control">
+          <!-- ➕ Cadastro de novo tutor -->
+          <div class="d-flex align-items-center gap-2 mb-3">
+            <span class="badge bg-success-subtle text-success-emphasis rounded-pill">➕</span>
+            <h5 class="fw-semibold mb-0">Cadastrar Novo Tutor</h5>
           </div>
 
-          <!-- Data e idade -->
-          <div class="mb-3 col-md-6">
-            <label class="form-label">Data de Nascimento</label>
-            <input id="date_of_birth" name="date_of_birth" type="text" class="form-control">
-          </div>
-          <div class="mb-3 col-md-6">
-            <label class="form-label">Idade</label>
-            <input id="age" type="number" class="form-control" min="0">
-          </div>
+          <form id="novo-tutor-form" method="POST" action="{{ url_for('tutores') }}" class="js-tutor-form" data-sync="true">
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label class="form-label">Nome</label>
+                <input name="name" class="form-control" required>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">E-mail</label>
+                <input name="email" type="email" class="form-control" required>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Telefone</label>
+                <input name="phone" class="form-control">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">CPF</label>
+                <input name="cpf" class="form-control">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">RG</label>
+                <input name="rg" class="form-control">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Data de Nascimento</label>
+                <input id="date_of_birth" name="date_of_birth" type="text" class="form-control">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Idade</label>
+                <input id="age" type="number" class="form-control" min="0">
+              </div>
+              <div class="col-12">
+                {% include "partials/endereco_form.html" %}
+              </div>
+            </div>
+            <button class="btn btn-success w-100 mt-4" data-original="💾 Salvar e abrir ficha">💾 Salvar e abrir ficha</button>
+          </form>
         </div>
+      </div>
+    </div>
 
-                  
-          <!-- Novo endereço com CEP -->
-          <div class="col-12">
-            {% include "partials/endereco_form.html" %}
-          </div>
-
-        <button class="btn btn-primary btn-lg" data-original="💾 Salvar e abrir ficha">💾 Salvar e abrir ficha</button>
-      </form>
+    <div class="col-12 col-xl-8">
+      <div id="tutores-adicionados">
+        {% include 'partials/tutores_adicionados.html' with compact=True %}
+      </div>
     </div>
   </div>
-
 </div>
-
-<div id="tutores-adicionados">
-{% include 'partials/tutores_adicionados.html' %}
-</div>
-
-
 
 <!-- ✨ Flatpickr CSS & JS -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">

--- a/templates/partials/animais_adicionados.html
+++ b/templates/partials/animais_adicionados.html
@@ -1,8 +1,13 @@
 <!-- partials/animais_adicionados.html -->
-<div class="container d-flex justify-content-center my-5">
-  <div style="width: 100%; max-width: 700px;">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h4 class="mb-0">🐾 Animais</h4>
+{% set compact = compact|default(False) %}
+{% set card_block %}
+<div class="card shadow-sm border-0 rounded-4 h-100 d-flex flex-column">
+  <div class="card-header bg-white border-0 pb-0">
+    <div class="d-flex justify-content-between align-items-start flex-wrap gap-2">
+      <div>
+        <h4 class="mb-1">🐾 Animais</h4>
+        <p class="text-muted small mb-0">Visualize, filtre e organize rapidamente os pets cadastrados.</p>
+      </div>
       {% if scope is defined %}
       <div class="btn-group btn-group-sm">
         <a href="{{ url_for('novo_animal', scope='all') }}" class="btn btn-outline-primary {% if scope != 'mine' %}active{% endif %}">Todos</a>
@@ -10,12 +15,15 @@
       </div>
       {% endif %}
     </div>
-
-    <div class="row mb-3">
-      <div class="col-md-8">
+  </div>
+  <div class="card-body p-4 flex-grow-1 d-flex flex-column">
+    <div class="row g-3 align-items-end mb-4">
+      <div class="col-12 col-lg-7">
+        <label for="animal-filter" class="form-label small text-muted mb-1">Buscar</label>
         <input type="text" id="animal-filter" class="form-control" placeholder="Buscar por nome, espécie...">
       </div>
-      <div class="col-md-4">
+      <div class="col-12 col-lg-5">
+        <label for="animal-sort" class="form-label small text-muted mb-1">Ordenar por</label>
         <select id="animal-sort" class="form-select">
           <option value="date_desc">Data (recentes)</option>
           <option value="date_asc">Data (antigos)</option>
@@ -27,43 +35,46 @@
       </div>
     </div>
 
-    <div id="animal-cards" class="row g-3">
+    <div id="animal-cards" class="row g-3 flex-grow-1">
       {% if animais_adicionados %}
         {% for animal in animais_adicionados %}
         <div class="col-md-6 d-flex" data-name="{{ animal.name|lower }}" data-date="{{ animal.date_added.isoformat() if animal.date_added else '' }}" data-age="{{ animal.age_years or 0 }}">
-          <div class="card shadow-sm rounded-4 h-100 flex-fill">
+          <div class="card shadow-sm rounded-4 h-100 flex-fill border-0">
             {% if animal.image %}
-              <img src="{{ animal.image }}" class="card-img card-img-top rounded-top-4" height="180" loading="lazy" alt="Foto de {{ animal.name }}">
+            <img src="{{ animal.image }}" class="card-img card-img-top rounded-top-4" height="180" loading="lazy" alt="Foto de {{ animal.name }}">
             {% else %}
-              <div class="d-flex align-items-center justify-content-center bg-light rounded-top-4" style="height: 180px;">
-                <span class="text-muted" style="font-size: 2rem;">🐾</span>
-              </div>
+            <div class="d-flex align-items-center justify-content-center bg-light rounded-top-4" style="height: 180px;">
+              <span class="text-muted" style="font-size: 2rem;">🐾</span>
+            </div>
             {% endif %}
             <div class="card-body d-flex flex-column justify-content-between">
-              <div>
-                <h5 class="card-title">{{ animal.name }}</h5>
+              <div class="mb-3">
+                <h5 class="card-title mb-1">{{ animal.name }}</h5>
                 <p class="mb-1"><strong>Espécie:</strong> {{ animal.species }}</p>
-                <p class="mb-1"><strong>Adicionado em:</strong> {{ animal.date_added|format_datetime_brazil('%d/%m/%Y') }}</p>
+                <p class="mb-0"><strong>Adicionado em:</strong> {{ animal.date_added|format_datetime_brazil('%d/%m/%Y') }}</p>
               </div>
-              <div class="d-flex flex-wrap gap-2 mt-3">
-                <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary w-100">🩺 Consulta</a>
-                <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark w-100">📋 Ficha</a>
+              <div class="d-flex flex-wrap gap-2">
+                <a href="{{ url_for('consulta_direct', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary flex-fill">🩺 Consulta</a>
+                <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-dark flex-fill">📋 Ficha</a>
               </div>
             </div>
           </div>
         </div>
         {% endfor %}
       {% else %}
-        <div class="text-center text-muted mt-4">
+      <div class="col-12">
+        <div class="text-center text-muted py-5 border rounded-4" style="border-style: dashed;">
           Nenhum animal cadastrado para esta clínica ainda.
         </div>
+      </div>
       {% endif %}
     </div>
-
-    {% if pagination and pagination.pages > 1 %}
-    <div class="d-flex justify-content-center mt-4">
+  </div>
+  {% if pagination and pagination.pages > 1 %}
+  <div class="card-footer bg-white border-0 pt-0">
+    <div class="d-flex justify-content-center">
       <nav aria-label="Navegação de páginas">
-        <ul class="pagination">
+        <ul class="pagination mb-0">
           {% if pagination.has_prev %}
             <li class="page-item">
               <a class="page-link" href="{{ url_for('novo_animal', page=pagination.prev_num, scope=scope) }}">Anterior</a>
@@ -92,9 +103,22 @@
         </ul>
       </nav>
     </div>
-    {% endif %}
+  </div>
+  {% endif %}
+</div>
+{% endset %}
+
+{% if compact %}
+  {{ card_block }}
+{% else %}
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-10 col-xl-9">
+      {{ card_block }}
+    </div>
   </div>
 </div>
+{% endif %}
 
 <script>
 (function() {

--- a/templates/partials/tutores_adicionados.html
+++ b/templates/partials/tutores_adicionados.html
@@ -1,7 +1,12 @@
-<div class="container d-flex justify-content-center my-5">
-  <div style="width: 100%; max-width: 700px;">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h4 class="mb-0">👥 Tutores</h4>
+{% set compact = compact|default(False) %}
+{% set card_block %}
+<div class="card shadow-sm border-0 rounded-4 h-100 d-flex flex-column">
+  <div class="card-header bg-white border-0 pb-0">
+    <div class="d-flex justify-content-between align-items-start flex-wrap gap-2">
+      <div>
+        <h4 class="mb-1">👥 Tutores</h4>
+        <p class="text-muted small mb-0">Filtre, ordene e acesse os tutores da clínica com rapidez.</p>
+      </div>
       {% if scope is defined %}
       <div class="btn-group btn-group-sm">
         <a href="{{ url_for('tutores', scope='all') }}" class="btn btn-outline-primary {% if scope != 'mine' %}active{% endif %}">Todos</a>
@@ -9,11 +14,15 @@
       </div>
       {% endif %}
     </div>
-    <div class="row mb-3">
-      <div class="col-md-8">
+  </div>
+  <div class="card-body p-4 flex-grow-1 d-flex flex-column">
+    <div class="row g-3 align-items-end mb-4">
+      <div class="col-12 col-lg-7">
+        <label for="tutor-filter" class="form-label small text-muted mb-1">Buscar</label>
         <input type="text" id="tutor-filter" class="form-control" placeholder="Buscar por nome, CPF, telefone...">
       </div>
-      <div class="col-md-4">
+      <div class="col-12 col-lg-5">
+        <label for="tutor-sort" class="form-label small text-muted mb-1">Ordenar por</label>
         <select id="tutor-sort" class="form-select">
           <option value="name_asc">Nome (A-Z)</option>
           <option value="name_desc">Nome (Z-A)</option>
@@ -24,33 +33,29 @@
         </select>
       </div>
     </div>
-    <div id="tutor-cards" class="row g-3">
+    <div id="tutor-cards" class="row g-3 flex-grow-1">
       {% if tutores_adicionados %}
         {% for tutor in tutores_adicionados %}
         <div class="col-md-6 d-flex" data-name="{{ tutor.name|lower }}" data-date="{{ tutor.created_at.isoformat() if tutor.created_at else '' }}" data-cpf="{{ tutor.cpf or '' }}" data-phone="{{ tutor.phone or '' }}" {% if tutor.date_of_birth %}data-dob="{{ tutor.date_of_birth.isoformat() }}"{% endif %}>
-<div class="card shadow-sm rounded-4 h-100 flex-fill position-relative">
-  {% if tutor.worker|lower == 'veterinario' %}
-    <span class="badge bg-success position-absolute top-0 end-0 m-2">Veterinário</span>
-  {% endif %}
+          <div class="card shadow-sm rounded-4 h-100 flex-fill position-relative border-0">
+            {% if tutor.worker|lower == 'veterinario' %}
+            <span class="badge bg-success position-absolute top-0 end-0 m-2">Veterinário</span>
+            {% endif %}
             <div class="card-body d-flex flex-column justify-content-between">
-              <div>
-                <h5 class="card-title">{{ tutor.name }}</h5>
+              <div class="mb-3">
+                <h5 class="card-title mb-1">{{ tutor.name }}</h5>
                 <p class="mb-1"><strong>Email:</strong> {{ tutor.email }}</p>
                 {% if tutor.cpf %}
-                  <p class="mb-1"><strong>CPF:</strong> {{ tutor.cpf }}</p>
+                <p class="mb-1"><strong>CPF:</strong> {{ tutor.cpf }}</p>
                 {% endif %}
                 {% if tutor.worker|lower == 'veterinario' and tutor.veterinario.specialties %}
-                  <p class="mb-1"><strong>Especialidades:</strong> {{ tutor.veterinario.specialty_list }}</p>
+                <p class="mb-0"><strong>Especialidades:</strong> {{ tutor.veterinario.specialty_list }}</p>
                 {% endif %}
               </div>
-              <div class="d-flex flex-wrap gap-2 mt-3">
-                <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-dark w-100">
-                  📋 Ver Ficha
-                </a>
+              <div class="d-flex flex-wrap gap-2">
+                <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-dark flex-fill">📋 Ver Ficha</a>
                 {% if tutor.worker|lower == 'veterinario' %}
-                <a href="{{ url_for('edit_vet_specialties', veterinario_id=tutor.veterinario.id) }}" class="btn btn-sm btn-outline-primary w-100">
-                  🩺 Especialidades
-                </a>
+                <a href="{{ url_for('edit_vet_specialties', veterinario_id=tutor.veterinario.id) }}" class="btn btn-sm btn-outline-primary flex-fill">🩺 Especialidades</a>
                 {% endif %}
               </div>
             </div>
@@ -58,17 +63,19 @@
         </div>
         {% endfor %}
       {% else %}
-        <div class="text-center text-muted mt-4">
+      <div class="col-12">
+        <div class="text-center text-muted py-5 border rounded-4" style="border-style: dashed;">
           Nenhum tutor associado à clínica ainda.
         </div>
+      </div>
       {% endif %}
     </div>
-
-    <!-- Paginação -->
-    {% if pagination and pagination.pages > 1 %}
-    <div class="d-flex justify-content-center mt-4">
+  </div>
+  {% if pagination and pagination.pages > 1 %}
+  <div class="card-footer bg-white border-0 pt-0">
+    <div class="d-flex justify-content-center">
       <nav>
-        <ul class="pagination">
+        <ul class="pagination mb-0">
           {% if pagination.has_prev %}
           <li class="page-item">
             <a class="page-link" href="{{ url_for('tutores', page=pagination.prev_num, scope=scope) }}">Anterior</a>
@@ -99,9 +106,22 @@
         </ul>
       </nav>
     </div>
-    {% endif %}
+  </div>
+  {% endif %}
+</div>
+{% endset %}
+
+{% if compact %}
+  {{ card_block }}
+{% else %}
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-10 col-xl-9">
+      {{ card_block }}
+    </div>
   </div>
 </div>
+{% endif %}
 
 <script>
 (function() {


### PR DESCRIPTION
## Summary
- redesign the tutor management page to combine the search panel and registration form beside the filtered tutor list
- reorganize the animal registration view so the form and filtered pet gallery share the screen responsively
- refresh the shared tutor and animal listing partials with compact card layouts, sortable filters, and flexible containers

## Testing
- `pytest tests/test_clinic_collaboration.py` *(fails: remote PostgreSQL database is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ff7846cc832ea0ca2445f7b069c9