### PR TITLE
Normalize calendar summary metadata

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -11,6 +11,8 @@ from dateutil.relativedelta import relativedelta
 from sqlalchemy import case
 from zoneinfo import ZoneInfo
 
+from .calendar_summary import serialize_vet_for_summary
+
 
 BR_TZ = ZoneInfo("America/Sao_Paulo")
 
@@ -446,6 +448,22 @@ def appointment_to_event(appointment):
         'notes': getattr(appointment, 'notes', None),
     }
 
+    summary_entry = serialize_vet_for_summary(
+        vet,
+        clinic_ids=[getattr(appointment, 'clinica_id', None)],
+    )
+    if summary_entry:
+        extra_props.setdefault('vetName', summary_entry.get('label'))
+        if summary_entry.get('full_name'):
+            extra_props['vetFullName'] = summary_entry['full_name']
+        if summary_entry.get('specialty_text') is not None:
+            extra_props['vetSpecialtyList'] = summary_entry['specialty_text']
+            extra_props['vetSummarySpecialtyText'] = summary_entry['specialty_text']
+        extra_props['vetLabel'] = summary_entry.get('label')
+        extra_props['vetInitials'] = summary_entry.get('initials')
+        extra_props['vetSummaryIsSpecialist'] = summary_entry.get('is_specialist')
+        extra_props['vetIsSpecialist'] = summary_entry.get('is_specialist')
+
     consulta = getattr(appointment, 'consulta', None)
     if consulta:
         extra_props.update(
@@ -493,6 +511,22 @@ def exam_to_event(exam):
         'vetSpecialtyList': specialist_specialties,
         'vetIsSpecialist': bool(specialist),
     }
+
+    summary_entry = serialize_vet_for_summary(
+        specialist,
+        clinic_ids=[getattr(exam, 'clinica_id', None)],
+    )
+    if summary_entry:
+        extra_props.setdefault('vetName', summary_entry.get('label'))
+        if summary_entry.get('full_name'):
+            extra_props['vetFullName'] = summary_entry['full_name']
+        if summary_entry.get('specialty_text') is not None:
+            extra_props['vetSpecialtyList'] = summary_entry['specialty_text']
+            extra_props['vetSummarySpecialtyText'] = summary_entry['specialty_text']
+        extra_props['vetLabel'] = summary_entry.get('label')
+        extra_props['vetInitials'] = summary_entry.get('initials')
+        extra_props['vetSummaryIsSpecialist'] = summary_entry.get('is_specialist')
+        extra_props['vetIsSpecialist'] = summary_entry.get('is_specialist')
 
     return _build_calendar_event(
         event_id=f"exam-{exam.id}",
@@ -589,6 +623,22 @@ def consulta_to_event(consulta):
         'clinicaNome': getattr(clinic, 'nome', None) if clinic else None,
         'kind': 'consulta',
     }
+
+    summary_entry = serialize_vet_for_summary(
+        vet_profile,
+        clinic_ids=[getattr(consulta, 'clinica_id', None)],
+    )
+    if summary_entry:
+        extra_props.setdefault('vetName', summary_entry.get('label'))
+        if summary_entry.get('full_name'):
+            extra_props['vetFullName'] = summary_entry['full_name']
+        if summary_entry.get('specialty_text') is not None:
+            extra_props['vetSpecialtyList'] = summary_entry['specialty_text']
+            extra_props['vetSummarySpecialtyText'] = summary_entry['specialty_text']
+        extra_props['vetLabel'] = summary_entry.get('label')
+        extra_props['vetInitials'] = summary_entry.get('initials')
+        extra_props['vetSummaryIsSpecialist'] = summary_entry.get('is_specialist')
+        extra_props['vetIsSpecialist'] = summary_entry.get('is_specialist')
 
     if tutor is None and animal and getattr(animal, 'owner', None):
         extra_props['tutorName'] = getattr(animal.owner, 'name', None)

--- a/helpers/calendar_summary.py
+++ b/helpers/calendar_summary.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional, Set
+import re
+import unicodedata
+
+__all__ = ["serialize_vet_for_summary"]
+
+
+def _clean_string(value: Optional[object]) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    stripped = value.strip()
+    return stripped or None
+
+
+def _normalize_id_set(values: Optional[Iterable[object]]) -> Set[int]:
+    result: Set[int] = set()
+    if not values:
+        return result
+    for candidate in values:
+        if candidate is None:
+            continue
+        try:
+            normalized = int(candidate)
+        except (TypeError, ValueError):
+            continue
+        result.add(normalized)
+    return result
+
+
+def _collect_vet_clinic_ids(vet: object) -> Set[int]:
+    clinic_ids: Set[int] = set()
+    primary_clinic_id = getattr(vet, "clinica_id", None)
+    if primary_clinic_id is not None:
+        try:
+            clinic_ids.add(int(primary_clinic_id))
+        except (TypeError, ValueError):
+            pass
+    associated_clinics = getattr(vet, "clinicas", None) or []
+    for clinic in associated_clinics:
+        clinic_id = getattr(clinic, "id", None)
+        if clinic_id is None:
+            continue
+        try:
+            clinic_ids.add(int(clinic_id))
+        except (TypeError, ValueError):
+            continue
+    return clinic_ids
+
+
+def _strip_accents(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch))
+
+
+def _compute_initials(name: Optional[str], fallback: Optional[object] = None) -> str:
+    candidate = _clean_string(name)
+    if candidate:
+        words = re.split(r"\s+", _strip_accents(candidate))
+        words = [word for word in words if word]
+        if len(words) == 1:
+            word = words[0]
+            if len(word) >= 2:
+                return (word[0] + word[1]).upper()
+            return word[:1].upper()
+        if words:
+            first = words[0][:1]
+            last = words[-1][:1]
+            initials = (first + last).strip()
+            if initials:
+                return initials.upper()
+    fallback_text = _clean_string(fallback)
+    if fallback_text:
+        fallback_text = _strip_accents(fallback_text)
+        if len(fallback_text) >= 2:
+            return fallback_text[-2:].upper()
+        return fallback_text[:1].upper()
+    return ""
+
+
+def serialize_vet_for_summary(
+    vet: object,
+    *,
+    label: Optional[str] = None,
+    clinic_ids: Optional[Iterable[object]] = None,
+) -> Optional[dict]:
+    """Return a normalized mapping with metadata for calendar summaries.
+
+    The result contains the keys ``id``, ``label``, ``full_name``, ``initials``,
+    ``is_specialist`` and ``specialty_text`` so that templates and client-side
+    code can operate on a predictable shape.
+    """
+
+    if vet is None:
+        return None
+
+    vet_id = getattr(vet, "id", None)
+    if vet_id is None:
+        return None
+    try:
+        normalized_id = int(vet_id)
+    except (TypeError, ValueError):
+        return None
+
+    vet_user = getattr(vet, "user", None)
+    full_name = _clean_string(getattr(vet_user, "name", None))
+    provided_label = _clean_string(label)
+    normalized_label = provided_label or full_name or f"Profissional #{normalized_id}"
+
+    specialty_text = _clean_string(getattr(vet, "specialty_list", None))
+    normalized_clinic_ids = _normalize_id_set(clinic_ids)
+    vet_clinic_ids = _collect_vet_clinic_ids(vet)
+
+    is_specialist = bool(specialty_text)
+    if not is_specialist and normalized_label and "especialista" in normalized_label.lower():
+        is_specialist = True
+    if not is_specialist and normalized_clinic_ids:
+        if vet_clinic_ids and not vet_clinic_ids.intersection(normalized_clinic_ids):
+            is_specialist = bool(specialty_text)
+
+    initials = _compute_initials(full_name or normalized_label, normalized_id)
+
+    return {
+        "id": normalized_id,
+        "label": normalized_label,
+        "full_name": full_name or normalized_label,
+        "initials": initials,
+        "is_specialist": bool(is_specialist),
+        "specialty_text": specialty_text,
+    }

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -29,15 +29,6 @@
   </div>
 
   {% set calendar_pets_endpoint = url_for('api_clinic_pets', view_as='veterinario', veterinario_id=veterinario.id) %}
-  {% set calendar_summary_vets = calendar_summary_vets if calendar_summary_vets else [{
-    'id': veterinario.id,
-    'name': veterinario.user.name,
-    'label': veterinario.user.name,
-    'full_name': veterinario.user.name,
-    'specialty_list': veterinario.specialty_list,
-    'is_specialist': veterinario.specialty_list|length > 0
-  }] %}
-  {% set calendar_summary_clinic_ids = calendar_summary_clinic_ids if calendar_summary_clinic_ids else ([veterinario.clinica_id] if veterinario.clinica_id else []) %}
   {% set schedule_toggle_clinic_id = veterinario.clinica_id %}
   {% set schedule_toggle_calendar_redirect_url = url_for('appointments', view_as='veterinario', veterinario_id=veterinario.id) %}
   {% set schedule_toggle_prefer_user_vet_source = True %}

--- a/templates/partials/calendar_summary_panel.html
+++ b/templates/partials/calendar_summary_panel.html
@@ -1,8 +1,8 @@
 {% set summary_title = summary_title|default('Resumo por profissional') %}
 {% set summary_description = summary_description|default('Totais diários e semanais por veterinário com base no calendário visível.') %}
-{% set summary_vets = calendar_summary_vets|default([], true) %}
-{% set summary_clinic_ids = calendar_summary_clinic_ids|default([], true) %}
-{% set summary_storage_key = calendar_summary_storage_key|default('', true) %}
+{% set summary_vets = calendar_summary_vets %}
+{% set summary_clinic_ids = calendar_summary_clinic_ids %}
+{% set summary_storage_key = calendar_summary_storage_key %}
 <div
   class="card calendar-summary-card border-0 shadow-sm h-100 is-loading"
   data-calendar-summary-panel

--- a/templates/veterinarios/vet_detail.html
+++ b/templates/veterinarios/vet_detail.html
@@ -168,15 +168,6 @@
             </div>
           </div>
           <div class="col-12 col-xl-4 col-xxl-3" data-calendar-summary-column>
-            {% set calendar_summary_vets = calendar_summary_vets if calendar_summary_vets else [{
-              'id': veterinario.id,
-              'name': veterinario.user.name,
-              'label': veterinario.user.name,
-              'full_name': veterinario.user.name,
-              'specialty_list': veterinario.specialty_list,
-              'is_specialist': veterinario.specialty_list|length > 0
-            }] %}
-            {% set calendar_summary_clinic_ids = calendar_summary_clinic_ids if calendar_summary_clinic_ids else ([veterinario.clinica_id] if veterinario.clinica_id else []) %}
             {% set calendar_summary_storage_key = 'vetCalendarSummaryCollapsed-' ~ veterinario.id %}
             {% include 'partials/calendar_summary_panel.html' %}
           </div>


### PR DESCRIPTION
## Summary
- add a serialize_vet_for_summary helper and rework calendar views to provide normalized vet metadata
- update calendar summary templates, scripts, and event payloads to rely on the normalized fields

## Testing
- pytest tests/test_calendar_access_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_68e4fd377568832e896bb5f8d7dfd8da