### PR TITLE
Improve calendar sidebar with tutor registration form

### DIFF
--- a/templates/partials/calendar_quick_tutor_form.html
+++ b/templates/partials/calendar_quick_tutor_form.html
@@ -1,5 +1,7 @@
 {% set form_id = form_id|default('calendar-quick-tutor-form') %}
 {% set show_intro = show_intro|default(True) %}
+{% set include_address = include_address|default(False) %}
+{% set address_prefix = address_prefix|default(form_id ~ '-address') %}
 {% if show_intro %}
   {% set header_id = heading_id|default(form_id ~ '-heading') %}
 {% else %}
@@ -89,6 +91,138 @@
       ></textarea>
     </div>
   </div>
+  {% if include_address %}
+  <hr class="my-4">
+  <div class="mb-3">
+    <h6 class="fw-semibold mb-1">
+      <i class="bi bi-geo-alt me-2"></i> Endereço
+    </h6>
+    <p class="text-muted small mb-0">Informe o endereço completo do tutor como no cadastro tradicional.</p>
+  </div>
+  <div class="row g-3">
+    <div class="col-sm-6 col-lg-4">
+      <label for="{{ address_prefix }}-cep" class="form-label">CEP <span class="text-danger">*</span></label>
+      <div class="input-group">
+        <input
+          type="text"
+          class="form-control"
+          id="{{ address_prefix }}-cep"
+          name="cep"
+          placeholder="00000-000"
+          inputmode="numeric"
+          pattern="\d{5}-?\d{3}"
+          data-address-field="cep"
+          required
+        >
+        <button
+          type="button"
+          class="btn btn-outline-secondary"
+          data-address-lookup="{{ address_prefix }}"
+          aria-label="Buscar CEP automaticamente"
+        >
+          <i class="bi bi-search"></i>
+        </button>
+      </div>
+      <div class="form-text">Digite apenas números. A busca ViaCEP preenche os demais campos.</div>
+    </div>
+    <div class="col-sm-6 col-lg-8">
+      <label for="{{ address_prefix }}-rua" class="form-label">Logradouro <span class="text-danger">*</span></label>
+      <input
+        type="text"
+        class="form-control"
+        id="{{ address_prefix }}-rua"
+        name="rua"
+        placeholder="Rua, avenida..."
+        data-address-field="rua"
+        required
+      >
+    </div>
+    <div class="col-sm-6 col-lg-4">
+      <label for="{{ address_prefix }}-numero" class="form-label">Número</label>
+      <input
+        type="text"
+        class="form-control"
+        id="{{ address_prefix }}-numero"
+        name="numero"
+        placeholder="Nº"
+        data-address-field="numero"
+      >
+    </div>
+    <div class="col-sm-6 col-lg-4">
+      <label for="{{ address_prefix }}-complemento" class="form-label">Complemento</label>
+      <input
+        type="text"
+        class="form-control"
+        id="{{ address_prefix }}-complemento"
+        name="complemento"
+        placeholder="Apto, bloco, etc."
+        data-address-field="complemento"
+      >
+    </div>
+    <div class="col-sm-6 col-lg-4">
+      <label for="{{ address_prefix }}-bairro" class="form-label">Bairro</label>
+      <input
+        type="text"
+        class="form-control"
+        id="{{ address_prefix }}-bairro"
+        name="bairro"
+        placeholder="Bairro"
+        data-address-field="bairro"
+      >
+    </div>
+    <div class="col-sm-6 col-lg-6">
+      <label for="{{ address_prefix }}-cidade" class="form-label">Cidade <span class="text-danger">*</span></label>
+      <input
+        type="text"
+        class="form-control"
+        id="{{ address_prefix }}-cidade"
+        name="cidade"
+        placeholder="Cidade"
+        data-address-field="cidade"
+        required
+      >
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <label for="{{ address_prefix }}-estado" class="form-label">UF <span class="text-danger">*</span></label>
+      <select
+        id="{{ address_prefix }}-estado"
+        class="form-select"
+        name="estado"
+        data-address-field="estado"
+        required
+      >
+        <option value="">Selecione</option>
+        <option value="AC">AC - Acre</option>
+        <option value="AL">AL - Alagoas</option>
+        <option value="AP">AP - Amapá</option>
+        <option value="AM">AM - Amazonas</option>
+        <option value="BA">BA - Bahia</option>
+        <option value="CE">CE - Ceará</option>
+        <option value="DF">DF - Distrito Federal</option>
+        <option value="ES">ES - Espírito Santo</option>
+        <option value="GO">GO - Goiás</option>
+        <option value="MA">MA - Maranhão</option>
+        <option value="MT">MT - Mato Grosso</option>
+        <option value="MS">MS - Mato Grosso do Sul</option>
+        <option value="MG">MG - Minas Gerais</option>
+        <option value="PA">PA - Pará</option>
+        <option value="PB">PB - Paraíba</option>
+        <option value="PR">PR - Paraná</option>
+        <option value="PE">PE - Pernambuco</option>
+        <option value="PI">PI - Piauí</option>
+        <option value="RJ">RJ - Rio de Janeiro</option>
+        <option value="RN">RN - Rio Grande do Norte</option>
+        <option value="RS">RS - Rio Grande do Sul</option>
+        <option value="RO">RO - Rondônia</option>
+        <option value="RR">RR - Roraima</option>
+        <option value="SC">SC - Santa Catarina</option>
+        <option value="SP">SP - São Paulo</option>
+        <option value="SE">SE - Sergipe</option>
+        <option value="TO">TO - Tocantins</option>
+      </select>
+    </div>
+  </div>
+  {% endif %}
   <div class="d-flex flex-column flex-sm-row gap-2 justify-content-end mt-4">
     <a class="btn btn-outline-secondary" href="{{ url_for('tutores') }}" target="_blank" rel="noopener">
       <i class="bi bi-box-arrow-up-right me-1"></i> Abrir página completa
@@ -114,5 +248,102 @@
       submitBtn.disabled = true;
     }
   });
+  {% if include_address %}
+  const cepInput = form.querySelector('[data-address-field="cep"]');
+  const lookupBtn = form.querySelector('[data-address-lookup="{{ address_prefix }}"]');
+  const addressFields = Array.from(form.querySelectorAll('[data-address-field]')).reduce(function(map, field) {
+    const key = field.dataset.addressField;
+    if (key) {
+      map[key] = field;
+    }
+    return map;
+  }, {});
+
+  function sanitizeCep(value) {
+    return (value || '').replace(/\D/g, '').slice(0, 8);
+  }
+
+  function fillAddressFields(data) {
+    if (!data) {
+      return;
+    }
+    if (addressFields.rua && data.logradouro) {
+      addressFields.rua.value = data.logradouro;
+    }
+    if (addressFields.complemento && data.complemento) {
+      addressFields.complemento.value = data.complemento;
+    }
+    if (addressFields.bairro && data.bairro) {
+      addressFields.bairro.value = data.bairro;
+    }
+    if (addressFields.cidade && data.localidade) {
+      addressFields.cidade.value = data.localidade;
+    }
+    if (addressFields.estado && data.uf) {
+      addressFields.estado.value = data.uf;
+    }
+    if (addressFields.numero) {
+      addressFields.numero.focus();
+    }
+  }
+
+  function lookupCep() {
+    if (!cepInput) {
+      return;
+    }
+    const raw = sanitizeCep(cepInput.value);
+    if (raw.length !== 8) {
+      return;
+    }
+    const previousValue = cepInput.value;
+    cepInput.value = raw.replace(/(\d{5})(\d{3})/, '$1-$2');
+    fetch(`https://viacep.com.br/ws/${raw}/json/`)
+      .then(function(response) {
+        if (!response.ok) {
+          throw new Error('Não foi possível buscar o CEP informado.');
+        }
+        return response.json();
+      })
+      .then(function(data) {
+        if (data && data.erro) {
+          throw new Error('CEP não encontrado.');
+        }
+        fillAddressFields(data);
+      })
+      .catch(function(error) {
+        console.error('Erro ao buscar CEP:', error);
+        cepInput.value = previousValue;
+      });
+  }
+
+  if (cepInput) {
+    cepInput.addEventListener('input', function(event) {
+      const value = sanitizeCep(event.target.value);
+      if (value.length <= 5) {
+        event.target.value = value;
+      } else {
+        event.target.value = value.replace(/(\d{5})(\d{0,3})/, '$1-$2');
+      }
+    });
+    cepInput.addEventListener('blur', lookupCep);
+  }
+
+  if (lookupBtn) {
+    lookupBtn.addEventListener('click', function(event) {
+      event.preventDefault();
+      lookupCep();
+    });
+  }
+
+  form.addEventListener('submit', function() {
+    if (!cepInput) {
+      return;
+    }
+    const raw = sanitizeCep(cepInput.value);
+    if (raw.length === 8) {
+      cepInput.value = raw;
+    }
+  });
+  {% endif %}
 })();
 </script>

--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -135,66 +135,96 @@
     </div>
 
     <div class="col-12">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-body">
-          <div class="d-flex justify-content-between align-items-start mb-3 flex-wrap gap-2">
-            <div>
-              <h3 class="h6 mb-1">Pacientes (Pets)</h3>
-              <span class="text-muted small" data-pet-subtitle>Dados reais da clínica</span>
-            </div>
-            {% if new_pet_url %}
-            <a class="btn btn-primary btn-sm" href="{{ new_pet_url }}">
-              <i class="bi bi-plus-circle me-1"></i> Novo pet
-            </a>
-            {% endif %}
-          </div>
-          <div class="tutor-calendar__pet-filters" data-pet-filters>
-            <div class="tutor-calendar__pet-filter-control tutor-calendar__pet-filter-control--search">
-              <div class="input-group input-group-sm">
-                <span class="input-group-text">
-                  <i class="bi bi-search"></i>
-                </span>
-                <input
-                  type="search"
-                  class="form-control"
-                  data-pet-filter-search
-                  placeholder="Buscar por nome, tutor ou detalhes"
-                  aria-label="Buscar pets"
-                />
+      <div class="row g-4 align-items-stretch">
+        <div class="col-12 col-xl-6">
+          <div class="card shadow-sm border-0 h-100">
+            <div class="card-body d-flex flex-column">
+              <div class="d-flex justify-content-between align-items-start mb-3 flex-wrap gap-2">
+                <div>
+                  <h3 class="h6 mb-1">Pacientes (Pets)</h3>
+                  <span class="text-muted small" data-pet-subtitle>Dados reais da clínica</span>
+                </div>
+                {% if new_pet_url %}
+                <a class="btn btn-primary btn-sm" href="{{ new_pet_url }}">
+                  <i class="bi bi-plus-circle me-1"></i> Novo pet
+                </a>
+                {% endif %}
+              </div>
+              <p class="text-muted small mb-3">
+                Filtre pacientes recentes e acesse rapidamente a ficha ou cadastre um novo pet quando necessário.
+              </p>
+              <div class="tutor-calendar__pet-filters" data-pet-filters>
+                <div class="tutor-calendar__pet-filter-control tutor-calendar__pet-filter-control--search">
+                  <div class="input-group input-group-sm">
+                    <span class="input-group-text">
+                      <i class="bi bi-search"></i>
+                    </span>
+                    <input
+                      type="search"
+                      class="form-control"
+                      data-pet-filter-search
+                      placeholder="Buscar por nome, tutor ou detalhes"
+                      aria-label="Buscar pets"
+                    />
+                  </div>
+                </div>
+                <div class="tutor-calendar__pet-filter-control">
+                  <select class="form-select form-select-sm" data-pet-filter-species aria-label="Filtrar por espécie">
+                    <option value="">Todas as espécies</option>
+                  </select>
+                </div>
+                <div class="tutor-calendar__pet-filter-control">
+                  <select class="form-select form-select-sm" data-pet-filter-breed aria-label="Filtrar por raça" disabled>
+                    <option value="">Todas as raças</option>
+                  </select>
+                </div>
+                <div class="tutor-calendar__pet-filter-actions">
+                  <button type="button" class="btn btn-outline-secondary btn-sm w-100" data-pet-filter-clear disabled>
+                    <i class="bi bi-x-circle me-1"></i> Limpar filtros
+                  </button>
+                </div>
+              </div>
+              <div class="tutor-calendar__pet-list flex-grow-1" data-pet-list aria-live="polite">
+                <div class="text-muted small">Carregando pets...</div>
+              </div>
+              <div class="d-flex flex-column flex-sm-row gap-2 mt-3">
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary btn-sm w-100 flex-sm-fill d-none"
+                  data-toggle-pets
+                  aria-expanded="false"
+                  aria-hidden="true"
+                >
+                  <i class="bi bi-plus-circle me-1"></i> Ver mais pets
+                </button>
+                <button type="button" class="btn btn-outline-primary btn-sm w-100 flex-sm-fill" data-refresh-pets>
+                  <i class="bi bi-arrow-clockwise me-1"></i> Atualizar lista
+                </button>
               </div>
             </div>
-            <div class="tutor-calendar__pet-filter-control">
-              <select class="form-select form-select-sm" data-pet-filter-species aria-label="Filtrar por espécie">
-                <option value="">Todas as espécies</option>
-              </select>
-            </div>
-            <div class="tutor-calendar__pet-filter-control">
-              <select class="form-select form-select-sm" data-pet-filter-breed aria-label="Filtrar por raça" disabled>
-                <option value="">Todas as raças</option>
-              </select>
-            </div>
-            <div class="tutor-calendar__pet-filter-actions">
-              <button type="button" class="btn btn-outline-secondary btn-sm w-100" data-pet-filter-clear disabled>
-                <i class="bi bi-x-circle me-1"></i> Limpar filtros
-              </button>
-            </div>
           </div>
-          <div class="tutor-calendar__pet-list" data-pet-list aria-live="polite">
-            <div class="text-muted small">Carregando pets...</div>
-          </div>
-          <div class="d-flex flex-column flex-sm-row gap-2 mt-3">
-            <button
-              type="button"
-              class="btn btn-outline-secondary btn-sm w-100 flex-sm-fill d-none"
-              data-toggle-pets
-              aria-expanded="false"
-              aria-hidden="true"
-            >
-              <i class="bi bi-plus-circle me-1"></i> Ver mais pets
-            </button>
-            <button type="button" class="btn btn-outline-primary btn-sm w-100 flex-sm-fill" data-refresh-pets>
-              <i class="bi bi-arrow-clockwise me-1"></i> Atualizar lista
-            </button>
+        </div>
+        <div class="col-12 col-xl-6">
+          <div class="card shadow-sm border-0 h-100">
+            <div class="card-body d-flex flex-column">
+              <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
+                <div>
+                  <h3 class="h6 mb-1">Tutores</h3>
+                  <span class="text-muted small">Cadastre um novo responsável com endereço completo sem sair da agenda.</span>
+                </div>
+                <a class="btn btn-outline-primary btn-sm" href="{{ url_for('tutores') }}" target="_blank" rel="noopener">
+                  <i class="bi bi-box-arrow-up-right me-1"></i> Ver todos
+                </a>
+              </div>
+              {% with
+                form_id=component_id ~ '-quick-tutor-form',
+                show_intro=False,
+                include_address=True,
+                address_prefix=component_id ~ '-quick-tutor-address'
+              %}
+                {% include 'partials/calendar_quick_tutor_form.html' %}
+              {% endwith %}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- restructure the calendar sidebar to group the pet list with guidance and a dedicated column
- embed a quick tutor registration card that supports full address entry and ViaCEP lookup
- extend the shared quick tutor form partial with optional address fields and auto-fill helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5023968e8832e9b2f61f90fab6ffe