### PR TITLE
Add collapsible agenda sidebar toggle to vet schedule

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -51,6 +51,7 @@
   {% set calendar_hide_experimental_tab = True %}
   {% set calendar_show_summary_toggle = False %}
   {% set vet_calendar_collapse_id = 'vet-calendar-collapse-' ~ veterinario.id %}
+  {% set agenda_sidebar_collapse_id = 'vet-agenda-sidebar-' ~ veterinario.id %}
 
   <!-- Gerenciar horários e agendamento -->
   {% set schedule_collapse_group_id = 'vet-schedule-collapse-group-' ~ veterinario.id %}
@@ -60,6 +61,16 @@
     <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
       <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
       <div class="d-flex flex-wrap align-items-center gap-2 justify-content-end">
+        <button
+          class="btn btn-light btn-sm"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#{{ agenda_sidebar_collapse_id }}"
+          aria-expanded="true"
+          aria-controls="{{ agenda_sidebar_collapse_id }}"
+        >
+          <i class="bi bi-journal-text me-1"></i> Agenda
+        </button>
         <button
           class="btn btn-light btn-sm collapsed"
           type="button"
@@ -302,7 +313,7 @@
     </div>
       </div>
     </div>
-    <div class="col-12 col-xxl-4">
+    <div class="col-12 col-xxl-4 collapse show" id="{{ agenda_sidebar_collapse_id }}">
       <div class="d-flex flex-column gap-4">
         <!-- Filtros com design melhorado -->
         <div class="card shadow-sm border-0 h-100">


### PR DESCRIPTION
## Summary
- add an agenda button next to the calendar toggle in the vet schedule header
- place the agenda sidebar content inside a Bootstrap collapse so it can be opened or hidden

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e50fdf34c0832eb29e709deae5eeb7