### PR TITLE
Fix vet schedule modal button binding guard

### DIFF
--- a/static/appointments_vet.js
+++ b/static/appointments_vet.js
@@ -536,10 +536,10 @@ export async function updateAppointmentTimes(options = {}) {
 
 function bindScheduleModalButton(root) {
   const scheduleButton = document.getElementById('openScheduleModal');
-  if (!scheduleButton || scheduleButton.dataset.vetScheduleBound === 'true') {
+  if (!scheduleButton || scheduleButton.dataset.vetScheduleBound === 'bound') {
     return;
   }
-  scheduleButton.dataset.vetScheduleBound = 'true';
+  scheduleButton.dataset.vetScheduleBound = 'bound';
   scheduleButton.addEventListener('click', (event) => {
     event.preventDefault();
     toggleScheduleForm(root);


### PR DESCRIPTION
## Summary
- allow the "Editar Horário" button to be rebound even when the template already sets `data-vet-schedule-bound`
- keep the guard against duplicate listeners by marking bound buttons with the value `bound`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5104872b8832e8ff63b7b7595fad0