### PR TITLE
Fix schedule modal click binding

### DIFF
--- a/static/appointments_vet.js
+++ b/static/appointments_vet.js
@@ -534,15 +534,31 @@ export async function updateAppointmentTimes(options = {}) {
   return times;
 }
 
+const scheduleModalClickHandlers = new WeakMap();
+
 function bindScheduleModalButton(root) {
-  const scheduleButton = document.getElementById('openScheduleModal');
-  if (!scheduleButton || scheduleButton.dataset.vetScheduleBound === 'true') {
+  const resolvedRoot = getRootElement(root);
+  const buttons = Array.from(document.querySelectorAll('#openScheduleModal'));
+  if (buttons.length === 0) {
     return;
   }
-  scheduleButton.dataset.vetScheduleBound = 'true';
-  scheduleButton.addEventListener('click', (event) => {
-    event.preventDefault();
-    toggleScheduleForm(root);
+
+  buttons.forEach((button) => {
+    if (scheduleModalClickHandlers.has(button)) {
+      return;
+    }
+
+    const clickHandler = (event) => {
+      event.preventDefault();
+      const contextRoot =
+        button.closest(ROOT_SELECTOR) ||
+        resolvedRoot ||
+        getRootElement();
+      toggleScheduleForm(contextRoot);
+    };
+
+    scheduleModalClickHandlers.set(button, clickHandler);
+    button.addEventListener('click', clickHandler);
   });
 }
 


### PR DESCRIPTION
## Summary
- bind every "Editar Horário" trigger instead of skipping elements copied with `data-vet-schedule-bound="bound"`
- reuse a single click handler per button via a `WeakMap` and resolve the appropriate schedule root before toggling the form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5104872b8832e8ff63b7b7595fad0