### PR TITLE
Refactor vet schedule layout to integrate agenda pane

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -56,76 +56,554 @@
   <!-- Gerenciar horários e agendamento -->
   {% set schedule_collapse_group_id = 'vet-schedule-collapse-group-' ~ veterinario.id %}
   <div class="row g-4 align-items-start">
-    <div class="col-12 col-xxl-8 d-flex flex-column gap-4">
+    <div class="col-12 d-flex flex-column gap-4">
       <div class="card border-0 shadow-lg rounded-4" id="{{ schedule_collapse_group_id }}">
-    <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
-      <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
-      <div class="d-flex flex-wrap align-items-center gap-2 justify-content-end">
-        <button
-          class="btn btn-light btn-sm"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#{{ agenda_sidebar_collapse_id }}"
-          aria-expanded="true"
-          aria-controls="{{ agenda_sidebar_collapse_id }}"
+        <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
+          <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
+          <div class="d-flex flex-wrap align-items-center gap-2 justify-content-end">
+            <button
+              class="btn btn-light btn-sm"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#{{ agenda_sidebar_collapse_id }}"
+              aria-expanded="true"
+              aria-controls="{{ agenda_sidebar_collapse_id }}"
+            >
+              <i class="bi bi-journal-text me-1"></i> Agenda
+            </button>
+            <button
+              class="btn btn-light btn-sm collapsed"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#{{ vet_calendar_collapse_id }}"
+              aria-expanded="false"
+              aria-controls="{{ vet_calendar_collapse_id }}"
+              data-calendar-tab-target="#{{ calendar_experimental_tab_id }}"
+            >
+              <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
+            </button>
+            <button id="openScheduleModal" class="btn btn-light btn-sm" type="button">
+              <i class="bi bi-pencil"></i> Editar Horário
+            </button>
+            <button
+              class="btn btn-success btn-sm collapsed"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#newAppointmentForm"
+              aria-expanded="false"
+            >
+              <i class="bi bi-plus-circle"></i> Nova Consulta
+            </button>
+            <button
+              class="btn btn-light btn-sm collapsed"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#vetNewTutorForm"
+              aria-expanded="false"
+              aria-controls="vetNewTutorForm"
+            >
+              <i class="bi bi-person-plus"></i> Novo Tutor
+            </button>
+            <button
+              class="btn btn-primary btn-sm collapsed"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#vetNewPetForm"
+              aria-expanded="false"
+              aria-controls="vetNewPetForm"
+            >
+              <i class="bi bi-plus-circle"></i> Novo Pet
+            </button>
+          </div>
+        </div>
+        <div
+          class="collapse show"
+          id="{{ agenda_sidebar_collapse_id }}"
+          data-bs-parent="#{{ schedule_collapse_group_id }}"
         >
-          <i class="bi bi-journal-text me-1"></i> Agenda
-        </button>
-        <button
-          class="btn btn-light btn-sm collapsed"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#{{ vet_calendar_collapse_id }}"
-          aria-expanded="false"
-          aria-controls="{{ vet_calendar_collapse_id }}"
-          data-calendar-tab-target="#{{ calendar_experimental_tab_id }}"
+          <div class="card-body border-top p-4">
+            <div class="d-flex flex-column gap-4">
+              <!-- Filtros com design melhorado -->
+              <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-primary bg-gradient text-white border-0 py-3 position-relative overflow-hidden">
+                  <div class="d-flex align-items-center">
+                    <div class="bg-white text-primary rounded-circle d-flex align-items-center justify-content-center me-3" style="width: 42px; height: 42px;">
+                      <i class="fas fa-filter"></i>
+                    </div>
+                    <div>
+                      <h5 class="mb-1 text-white">Filtrar Agenda</h5>
+                      <small class="text-white-50">Selecione um período ou utilize os atalhos rápidos abaixo</small>
+                    </div>
+                  </div>
+                </div>
+                <div class="card-body">
+                  <form method="get" id="agenda-filter-form" class="row g-3 align-items-end">
+                    {% for arg_key, arg_val in request.args.items() if arg_key not in ['start', 'end'] %}
+                    <input type="hidden" name="{{ arg_key }}" value="{{ arg_val }}">
+                    {% endfor %}
+                    <div class="col-12 col-lg-6">
+                      <label class="form-label fw-bold text-muted">Data Inicial</label>
+                      <div class="input-group input-group-lg">
+                        <span class="input-group-text bg-light text-secondary"><i class="fas fa-calendar-day"></i></span>
+                        <input type="date" name="start" value="{{ start_dt.date() }}" class="form-control" aria-label="Data inicial">
+                      </div>
+                    </div>
+                    <div class="col-12 col-lg-6">
+                      <label class="form-label fw-bold text-muted">Data Final</label>
+                      <div class="input-group input-group-lg">
+                        <span class="input-group-text bg-light text-secondary"><i class="fas fa-calendar-check"></i></span>
+                        <input type="date" name="end" value="{{ (end_dt - timedelta(days=1)).date() }}" class="form-control" aria-label="Data final">
+                      </div>
+                    </div>
+                    <div class="col-12 d-flex flex-column flex-sm-row gap-2">
+                      <button class="btn btn-primary flex-fill">
+                        <i class="fas fa-search me-1"></i>Aplicar Filtro
+                      </button>
+                      <button type="button" class="btn btn-outline-secondary flex-fill" data-action="clear-dates">
+                        <i class="fas fa-undo me-1"></i>Limpar
+                      </button>
+                    </div>
+                    <div class="col-12">
+                      <div class="d-flex flex-wrap gap-2">
+                        <span class="text-muted me-2 align-self-center small fw-semibold text-uppercase">Atalhos rápidos:</span>
+                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="today">
+                          <i class="fas fa-sun me-1"></i>Hoje
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="tomorrow">
+                          <i class="fas fa-sunrise me-1"></i>Amanhã
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="week">
+                          <i class="fas fa-calendar-week me-1"></i>Semana Atual
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="next7">
+                          <i class="fas fa-calendar-plus me-1"></i>Próximos 7 dias
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="month">
+                          <i class="fas fa-calendar-alt me-1"></i>Mês Atual
+                        </button>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+
+              <!-- Agendamentos pendentes -->
+              <div class="card border-warning">
+                <div class="card-header bg-warning text-dark">
+                  <h5 class="mb-0"><i class="fas fa-clock me-2"></i>Agendamentos Pendentes</h5>
+                </div>
+                <div class="card-body p-0">
+                  <div class="list-group list-group-flush">
+                    {% if pending_consults_for_me or pending_consults_waiting_others or exams_pending_to_accept or exams_waiting_other_vets %}
+                      {% if pending_consults_for_me %}
+                      <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+                        <i class="fas fa-stethoscope me-2"></i>Consultas aguardando sua resposta
+                      </div>
+                      {% for item in pending_consults_for_me %}
+                        {% set appt = item.appt %}
+                        {% set can_respond = appt.time_left.total_seconds() > 0 %}
+                        {% set display_tutor = appt.tutor if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner %}
+                        {% set status_label = 'A fazer' if appt.status == 'scheduled'
+                          else 'Realizada' if appt.status == 'completed'
+                          else 'Cancelada' if appt.status == 'canceled'
+                          else 'Aceita' if appt.status == 'accepted'
+                          else 'Pendente' if appt.status == 'pending'
+                          else 'Aguardando Confirmação' if appt.status == 'awaiting_confirmation'
+                          else appt.status|replace('_', ' ')|title %}
+                        {% set type_label = {
+                          'consulta': 'Consulta',
+                          'retorno': 'Retorno',
+                          'banho_tosa': 'Banho e Tosa',
+                          'vacina': 'Vacina'
+                        }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title %}
+                        <div class="list-group-item list-group-item-action appointment-item"
+                            data-appointment-id="{{ appt.id }}"
+                            data-id="{{ appt.id }}"
+                            data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+                            data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
+                            data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
+                            data-vet="{{ appt.veterinario.user.name }}"
+                            data-vet-id="{{ appt.veterinario_id }}"
+                            data-tutor="{{ display_tutor.name if display_tutor else '' }}"
+                            data-tutor-id="{{ display_tutor.id if display_tutor else '' }}"
+                            data-animal="{{ appt.animal.name }}"
+                            data-animal-id="{{ appt.animal_id }}"
+                            data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
+                            data-tutor-url="{{ url_for('ficha_tutor', tutor_id=display_tutor.id) if display_tutor else '' }}"
+                            data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
+                            data-notes="{{ appt.notes or '' }}"
+                            data-created-by="{{ appt.creator.name if appt.creator else '' }}"
+                            data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
+                            data-status="{{ appt.status }}"
+                            data-status-label="{{ status_label }}"
+                            data-type="{{ item.kind }}"
+                            data-type-label="{{ type_label }}">
+                          <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center">
+                              <div class="me-3">
+                                <i class="fas fa-clock {% if can_respond %}text-warning{% else %}text-secondary{% endif %} fa-2x"></i>
+                              </div>
+                              <div>
+                                <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                                <small class="text-muted">
+                                  {{ display_tutor.name if display_tutor else '' }}
+                                  {% if item.kind == 'banho_tosa' %}
+                                    <span class="badge bg-primary ms-1">Banho e Tosa</span>
+                                  {% elif item.kind == 'vacina' %}
+                                    <span class="badge bg-success ms-1">Vacina</span>
+                                  {% elif item.kind == 'retorno' %}
+                                    <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                                  {% endif %}
+                                </small>
+                                <div class="mt-1">
+                                  {% if can_respond %}
+                                    <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Tempo restante: {{ appt.time_left|format_timedelta }}</small>
+                                  {% else %}
+                                    <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
+                                  {% endif %}
+                                </div>
+                              </div>
+                            </div>
+                            {% if can_respond %}
+                            <div class="d-flex gap-2">
+                              <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
+                                <input type="hidden" name="status" value="accepted">
+                                <button type="submit" class="btn btn-success btn-sm"><i class="fas fa-check me-1"></i>Aceitar</button>
+                              </form>
+                              <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
+                                <input type="hidden" name="status" value="canceled">
+                                <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-times me-1"></i>Recusar</button>
+                              </form>
+                            </div>
+                            {% endif %}
+                          </div>
+                        </div>
+                      {% endfor %}
+                      {% endif %}
+
+                      {% if pending_consults_waiting_others %}
+                      <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+                        <i class="fas fa-user-clock me-2"></i>Consultas aguardando outros profissionais
+                      </div>
+                      {% for item in pending_consults_waiting_others %}
+                        {% set appt = item.appt %}
+                        {% set can_respond = appt.time_left.total_seconds() > 0 %}
+                        {% set status_label = 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title %}
+                        {% set type_label = {
+                          'consulta': 'Consulta',
+                          'retorno': 'Retorno',
+                          'banho_tosa': 'Banho e Tosa',
+                          'vacina': 'Vacina'
+                        }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title %}
+                        <div class="list-group-item list-group-item-action appointment-item"
+                            data-appointment-id="{{ appt.id }}"
+                            data-id="{{ appt.id }}"
+                            data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+                            data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
+                            data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
+                            data-vet="{{ appt.veterinario.user.name }}"
+                            data-vet-id="{{ appt.veterinario_id }}"
+                            data-tutor="{{ appt.tutor.name if appt.tutor else (appt.animal.owner.name if appt.animal and appt.animal.owner else '') }}"
+                            data-tutor-id="{{ appt.tutor_id if appt.tutor_id else (appt.animal.owner.id if appt.animal and appt.animal.owner else '') }}"
+                            data-animal="{{ appt.animal.name if appt.animal else '' }}"
+                            data-animal-id="{{ appt.animal_id if appt.animal_id else '' }}"
+                            data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) if appt.animal_id else '' }}"
+                            data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) if appt.tutor_id else (url_for('ficha_tutor', tutor_id=appt.animal.owner.id) if appt.animal and appt.animal.owner else '') }}"
+                            data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
+                            data-notes="{{ (appt.notes or '')|e }}"
+                            data-created-by="{{ appt.creator.name if appt.creator else '' }}"
+                            data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
+                            data-status="{{ appt.status }}"
+                            data-status-label="{{ status_label }}"
+                            data-type="{{ item.kind }}"
+                            data-type-label="{{ type_label }}">
+                          <div class="d-flex align-items-center">
+                            <div class="me-3">
+                              <i class="fas fa-user-clock {% if can_respond %}text-warning{% else %}text-secondary{% endif %} fa-2x"></i>
+                            </div>
+                            <div>
+                              <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                              <small class="text-muted">
+                                {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
+                                {% if item.kind == 'banho_tosa' %}
+                                  <span class="badge bg-primary ms-1">Banho e Tosa</span>
+                                {% elif item.kind == 'vacina' %}
+                                  <span class="badge bg-success ms-1">Vacina</span>
+                                {% elif item.kind == 'retorno' %}
+                                  <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                                {% endif %}
+                                <span class="badge bg-light text-dark border ms-1"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
+                              </small>
+                              <div class="mt-1">
+                                {% if can_respond %}
+                                  <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Aguardando confirmação do profissional</small>
+                                {% else %}
+                                  <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
+                                {% endif %}
+                                <small class="text-muted d-block fst-italic mt-1">Clique para detalhes</small>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="text-end">
+                            {% if can_respond %}
+                              <span class="badge bg-warning text-dark"><i class="fas fa-user-clock me-1"></i>Aguardando confirmação</span>
+                            {% else %}
+                              <span class="badge bg-secondary"><i class="fas fa-hourglass-end me-1"></i>Prazo expirado</span>
+                            {% endif %}
+                          </div>
+                        </div>
+                      {% endfor %}
+                      {% endif %}
+
+                      {% if exams_pending_to_accept %}
+                      <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+                        <i class="fas fa-vial me-2"></i>Exames aguardando sua aceitação
+                      </div>
+                      {% for exam in exams_pending_to_accept %}
+                        {% set can_respond = exam.time_left.total_seconds() > 0 %}
+                        <div class="list-group-item list-group-item-action appointment-item"
+                            data-appointment-id="{{ exam.id }}"
+                            data-type="exame"
+                            data-status="{{ exam.status }}"
+                            data-status-label="{{ exam.status_display }}">
+                          <div class="d-flex justify-content-between align-items-start">
+                            <div class="d-flex align-items-center">
+                              <div class="me-3">
+                                <i class="fas fa-vial fa-2x text-info"></i>
+                              </div>
+                              <div>
+                                <h6 class="mb-0">{{ exam.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ exam.animal.name if exam.animal else '—' }}</h6>
+                                <small class="text-muted">Tutor: {{ exam.animal.owner.name if exam.animal and exam.animal.owner else '—' }}</small>
+                                <div class="mt-1">
+                                  {% if can_respond %}
+                                    <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Tempo restante: {{ exam.time_left|format_timedelta }}</small>
+                                  {% else %}
+                                    <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
+                                  {% endif %}
+                                </div>
+                              </div>
+                            </div>
+                            {% if can_respond %}
+                            <div class="d-flex gap-2">
+                              <form method="POST" action="{{ url_for('accept_exam_request', exam_id=exam.id) }}">
+                                <button type="submit" class="btn btn-success btn-sm"><i class="fas fa-check me-1"></i>Aceitar</button>
+                              </form>
+                              <form method="POST" action="{{ url_for('decline_exam_request', exam_id=exam.id) }}">
+                                <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-times me-1"></i>Recusar</button>
+                              </form>
+                            </div>
+                            {% endif %}
+                          </div>
+                        </div>
+                      {% endfor %}
+                      {% endif %}
+
+                      {% if exams_waiting_other_vets %}
+                      <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+                        <i class="fas fa-user-md me-2"></i>Exames aguardando outros profissionais
+                      </div>
+                      {% for exam in exams_waiting_other_vets %}
+                        <div class="list-group-item list-group-item-action">
+                          <div class="d-flex align-items-center justify-content-between">
+                            <div>
+                              <h6 class="mb-0">{{ exam.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ exam.animal.name if exam.animal else '—' }}</h6>
+                              <small class="text-muted">Tutor: {{ exam.animal.owner.name if exam.animal and exam.animal.owner else '—' }}</small>
+                              <div class="mt-1">
+                                <small class="text-muted"><i class="fas fa-user-md me-1"></i>Especialista responsável: {{ exam.specialist.user.name if exam.specialist and exam.specialist.user else '—' }}</small>
+                              </div>
+                            </div>
+                            <span class="badge bg-secondary"><i class="fas fa-hourglass-half me-1"></i>Aguardando</span>
+                          </div>
+                        </div>
+                      {% endfor %}
+                      {% endif %}
+                    {% else %}
+                      <div class="list-group-item text-center py-4">
+                        <i class="fas fa-inbox fa-2x text-muted mb-2"></i>
+                        <p class="text-muted mb-0">Não há agendamentos pendentes.</p>
+                      </div>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+
+              <!-- Próximos agendamentos -->
+              <div class="card border-primary">
+                <div class="card-header bg-primary text-white">
+                  <h5 class="mb-0"><i class="fas fa-calendar-check me-2"></i>Próximos Agendamentos</h5>
+                </div>
+                <div class="card-body p-0">
+                  <div class="list-group list-group-flush">
+                    {% if appointments_upcoming_for_me or appointments_upcoming_requested %}
+                      {% if appointments_upcoming_for_me %}
+                      <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+                        <i class="fas fa-stethoscope me-2"></i>Seus próximos atendimentos
+                      </div>
+                      {% for item in appointments_upcoming_for_me %}
+                        {% set appt = item.appt %}
+                        {% if item.kind == 'exame' %}
+                        <div class="list-group-item list-group-item-action appointment-item" data-type="exame" data-appointment-id="{{ appt.id }}">
+                          <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center">
+                              <div class="me-3">
+                                <i class="fas fa-flask fa-2x text-info"></i>
+                              </div>
+                              <div>
+                                <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                                <small class="text-muted">{{ appt.animal.owner.name }} <span class="badge bg-info ms-1">Exame</span></small>
+                              </div>
+                            </div>
+                            <div class="btn-group">
+                              <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                              <a href="{{ url_for('ficha_tutor', tutor_id=appt.animal.owner.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                            </div>
+                          </div>
+                        </div>
+                        {% else %}
+                        <div class="list-group-item list-group-item-action appointment-item"
+                            data-appointment-id="{{ appt.id }}"
+                            data-id="{{ appt.id }}"
+                            data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+                            data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
+                            data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
+                            data-vet="{{ appt.veterinario.user.name }}"
+                            data-vet-id="{{ appt.veterinario_id }}"
+                            data-tutor="{{ appt.tutor.name }}"
+                            data-tutor-id="{{ appt.tutor_id }}"
+                            data-animal="{{ appt.animal.name }}"
+                            data-animal-id="{{ appt.animal_id }}"
+                            data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
+                            data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
+                            data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
+                            data-notes="{{ appt.notes or '' }}"
+                            data-created-by="{{ appt.creator.name if appt.creator else '' }}"
+                            data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
+                            data-status="{{ appt.status }}"
+                            data-status-label="{{ 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title }}"
+                            data-type="{{ item.kind }}"
+                            data-type-label="{{ {
+                              'consulta': 'Consulta',
+                              'retorno': 'Retorno',
+                              'banho_tosa': 'Banho e Tosa',
+                              'vacina': 'Vacina'
+                            }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title }}">
+                          <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center">
+                              <div class="me-3">
+                                <i class="fas fa-stethoscope fa-2x text-success"></i>
+                              </div>
+                              <div>
+                                <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                                <small class="text-muted">{{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
+                                  {% if item.kind == 'retorno' %}
+                                    <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                                  {% elif item.kind == 'banho_tosa' %}
+                                    <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
+                                  {% elif item.kind == 'vacina' %}
+                                    <span class="badge bg-success text-white ms-1">Vacina</span>
+                                  {% endif %}
+                                </small>
+                              </div>
+                            </div>
+                            <div class="btn-group">
+                              <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                              <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                              <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
+                            </div>
+                          </div>
+                        </div>
+                        {% endif %}
+                      {% endfor %}
+                      {% endif %}
+
+                      {% if appointments_upcoming_requested %}
+                      <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
+                        <i class="fas fa-handshake me-2"></i>Acompanhando outros profissionais
+                      </div>
+                      {% for item in appointments_upcoming_requested %}
+                        {% set appt = item.appt %}
+                        {% set status_label = 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title %}
+                        {% set type_label = {
+                          'consulta': 'Consulta',
+                          'retorno': 'Retorno',
+                          'banho_tosa': 'Banho e Tosa',
+                          'vacina': 'Vacina'
+                        }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title %}
+                        <div class="list-group-item list-group-item-action appointment-item"
+                            data-appointment-id="{{ appt.id }}"
+                            data-id="{{ appt.id }}"
+                            data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
+                            data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
+                            data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
+                            data-vet="{{ appt.veterinario.user.name }}"
+                            data-vet-id="{{ appt.veterinario_id }}"
+                            data-tutor="{{ appt.tutor.name }}"
+                            data-tutor-id="{{ appt.tutor_id }}"
+                            data-animal="{{ appt.animal.name }}"
+                            data-animal-id="{{ appt.animal_id }}"
+                            data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
+                            data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
+                            data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
+                            data-notes="{{ appt.notes or '' }}"
+                            data-created-by="{{ appt.creator.name if appt.creator else '' }}"
+                            data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
+                            data-status="{{ appt.status }}"
+                            data-status-label="{{ status_label }}"
+                            data-type="{{ item.kind }}"
+                            data-type-label="{{ type_label }}">
+                          <div class="d-flex justify-content-between align-items-start">
+                            <div class="d-flex alignments-center">
+                              <div class="me-3">
+                                <i class="fas fa-handshake fa-2x text-info"></i>
+                              </div>
+                              <div>
+                                <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
+                                <small class="text-muted">
+                                  {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
+                                  {% if item.kind == 'retorno' %}
+                                    <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                                  {% elif item.kind == 'banho_tosa' %}
+                                    <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
+                                  {% elif item.kind == 'vacina' %}
+                                    <span class="badge bg-success text-white ms-1">Vacina</span>
+                                  {% endif %}
+                                  <span class="badge bg-light text-dark border ms-1"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
+                                </small>
+                              </div>
+                            </div>
+                            <div class="d-flex flex-column align-items-end gap-2">
+                              <div class="btn-group">
+                                <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                                <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                              </div>
+                              <span class="badge bg-success"><i class="fas fa-check me-1"></i>{{ status_label }}</span>
+                            </div>
+                          </div>
+                        </div>
+                      {% endfor %}
+                      {% endif %}
+                    {% else %}
+                      <div class="list-group-item text-center py-4">
+                        <i class="fas fa-calendar-times fa-2x text-muted mb-2"></i>
+                        <p class="text-muted mb-0">Nenhum agendamento encontrado.</p>
+                      </div>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="collapse"
+          id="{{ vet_calendar_collapse_id }}"
+          data-calendar-collapse
+          data-bs-parent="#{{ schedule_collapse_group_id }}"
         >
-          <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
-        </button>
-        <button id="openScheduleModal" class="btn btn-light btn-sm" type="button">
-          <i class="bi bi-pencil"></i> Editar Horário
-        </button>
-        <button
-          class="btn btn-success btn-sm collapsed"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#newAppointmentForm"
-          aria-expanded="false"
-        >
-          <i class="bi bi-plus-circle"></i> Nova Consulta
-        </button>
-        <button
-          class="btn btn-light btn-sm collapsed"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#vetNewTutorForm"
-          aria-expanded="false"
-          aria-controls="vetNewTutorForm"
-        >
-          <i class="bi bi-person-plus"></i> Novo Tutor
-        </button>
-        <button
-          class="btn btn-primary btn-sm collapsed"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#vetNewPetForm"
-          aria-expanded="false"
-          aria-controls="vetNewPetForm"
-        >
-          <i class="bi bi-plus-circle"></i> Novo Pet
-        </button>
-      </div>
-    </div>
-    <div
-      class="collapse"
-      id="{{ vet_calendar_collapse_id }}"
-      data-calendar-collapse
-      data-bs-parent="#{{ schedule_collapse_group_id }}"
-    >
-      <div class="card-body border-top p-4">
-        {% include 'partials/calendar_layout.html' %}
-      </div>
-    </div>
+          <div class="card-body border-top p-4">
+            {% include 'partials/calendar_layout.html' %}
+          </div>
+        </div>
     <div class="collapse" id="newAppointmentForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
       <div class="card-body p-4">
         <form method="POST" class="needs-validation" novalidate>
@@ -313,480 +791,6 @@
     </div>
       </div>
     </div>
-    <div class="col-12 col-xxl-4 collapse show" id="{{ agenda_sidebar_collapse_id }}">
-      <div class="d-flex flex-column gap-4">
-        <!-- Filtros com design melhorado -->
-        <div class="card shadow-sm border-0 h-100">
-          <div class="card-header bg-primary bg-gradient text-white border-0 py-3 position-relative overflow-hidden">
-            <div class="d-flex align-items-center">
-              <div class="bg-white text-primary rounded-circle d-flex align-items-center justify-content-center me-3" style="width: 42px; height: 42px;">
-                <i class="fas fa-filter"></i>
-              </div>
-              <div>
-                <h5 class="mb-1 text-white">Filtrar Agenda</h5>
-                <small class="text-white-50">Selecione um período ou utilize os atalhos rápidos abaixo</small>
-              </div>
-            </div>
-          </div>
-          <div class="card-body">
-            <form method="get" id="agenda-filter-form" class="row g-3 align-items-end">
-              {% for arg_key, arg_val in request.args.items() if arg_key not in ['start', 'end'] %}
-              <input type="hidden" name="{{ arg_key }}" value="{{ arg_val }}">
-              {% endfor %}
-              <div class="col-12 col-lg-6">
-                <label class="form-label fw-bold text-muted">Data Inicial</label>
-                <div class="input-group input-group-lg">
-                  <span class="input-group-text bg-light text-secondary"><i class="fas fa-calendar-day"></i></span>
-                  <input type="date" name="start" value="{{ start_dt.date() }}" class="form-control" aria-label="Data inicial">
-                </div>
-              </div>
-              <div class="col-12 col-lg-6">
-                <label class="form-label fw-bold text-muted">Data Final</label>
-                <div class="input-group input-group-lg">
-                  <span class="input-group-text bg-light text-secondary"><i class="fas fa-calendar-check"></i></span>
-                  <input type="date" name="end" value="{{ (end_dt - timedelta(days=1)).date() }}" class="form-control" aria-label="Data final">
-                </div>
-              </div>
-              <div class="col-12 d-flex flex-column flex-sm-row gap-2">
-                <button class="btn btn-primary flex-fill">
-                  <i class="fas fa-search me-1"></i>Aplicar Filtro
-                </button>
-                <button type="button" class="btn btn-outline-secondary flex-fill" data-action="clear-dates">
-                  <i class="fas fa-undo me-1"></i>Limpar
-                </button>
-              </div>
-              <div class="col-12">
-                <div class="d-flex flex-wrap gap-2">
-                  <span class="text-muted me-2 align-self-center small fw-semibold text-uppercase">Atalhos rápidos:</span>
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-range="today">
-                    <i class="fas fa-sun me-1"></i>Hoje
-                  </button>
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-range="tomorrow">
-                    <i class="fas fa-sunrise me-1"></i>Amanhã
-                  </button>
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-range="week">
-                    <i class="fas fa-calendar-week me-1"></i>Semana Atual
-                  </button>
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-range="next7">
-                    <i class="fas fa-calendar-plus me-1"></i>Próximos 7 dias
-                  </button>
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-range="month">
-                    <i class="fas fa-calendar-alt me-1"></i>Mês Atual
-                  </button>
-                </div>
-              </div>
-            </form>
-          </div>
-        </div>
-
-        <!-- Agendamentos pendentes -->
-        <div class="card border-warning">
-          <div class="card-header bg-warning text-dark">
-            <h5 class="mb-0"><i class="fas fa-clock me-2"></i>Agendamentos Pendentes</h5>
-          </div>
-          <div class="card-body p-0">
-            <div class="list-group list-group-flush">
-              {% if pending_consults_for_me or pending_consults_waiting_others or exams_pending_to_accept or exams_waiting_other_vets %}
-                {% if pending_consults_for_me %}
-                <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
-                  <i class="fas fa-stethoscope me-2"></i>Consultas aguardando sua resposta
-                </div>
-                {% for item in pending_consults_for_me %}
-                  {% set appt = item.appt %}
-                  {% set can_respond = appt.time_left.total_seconds() > 0 %}
-                  {% set display_tutor = appt.tutor if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner %}
-                  {% set status_label = 'A fazer' if appt.status == 'scheduled'
-                    else 'Realizada' if appt.status == 'completed'
-                    else 'Cancelada' if appt.status == 'canceled'
-                    else 'Aceita' if appt.status == 'accepted'
-                    else 'Pendente' if appt.status == 'pending'
-                    else 'Aguardando Confirmação' if appt.status == 'awaiting_confirmation'
-                    else appt.status|replace('_', ' ')|title %}
-                  {% set type_label = {
-                    'consulta': 'Consulta',
-                    'retorno': 'Retorno',
-                    'banho_tosa': 'Banho e Tosa',
-                    'vacina': 'Vacina'
-                  }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title %}
-                  <div class="list-group-item list-group-item-action appointment-item"
-                      data-appointment-id="{{ appt.id }}"
-                      data-id="{{ appt.id }}"
-                      data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
-                      data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
-                      data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
-                      data-vet="{{ appt.veterinario.user.name }}"
-                      data-vet-id="{{ appt.veterinario_id }}"
-                      data-tutor="{{ display_tutor.name if display_tutor else '' }}"
-                      data-tutor-id="{{ display_tutor.id if display_tutor else '' }}"
-                      data-animal="{{ appt.animal.name }}"
-                      data-animal-id="{{ appt.animal_id }}"
-                      data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
-                      data-tutor-url="{{ url_for('ficha_tutor', tutor_id=display_tutor.id) if display_tutor else '' }}"
-                      data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
-                      data-notes="{{ appt.notes or '' }}"
-                      data-created-by="{{ appt.creator.name if appt.creator else '' }}"
-                      data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
-                      data-status="{{ appt.status }}"
-                      data-status-label="{{ status_label }}"
-                      data-type="{{ item.kind }}"
-                      data-type-label="{{ type_label }}">
-                    <div class="d-flex justify-content-between align-items-center">
-                      <div class="d-flex align-items-center">
-                        <div class="me-3">
-                          <i class="fas fa-clock {% if can_respond %}text-warning{% else %}text-secondary{% endif %} fa-2x"></i>
-                        </div>
-                        <div>
-                          <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                          <small class="text-muted">
-                            {{ display_tutor.name if display_tutor else '' }}
-                            {% if item.kind == 'banho_tosa' %}
-                              <span class="badge bg-primary ms-1">Banho e Tosa</span>
-                            {% elif item.kind == 'vacina' %}
-                              <span class="badge bg-success ms-1">Vacina</span>
-                            {% elif item.kind == 'retorno' %}
-                              <span class="badge bg-warning text-dark ms-1">Retorno</span>
-                            {% endif %}
-                          </small>
-                          <div class="mt-1">
-                            {% if can_respond %}
-                              <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Tempo restante: {{ appt.time_left|format_timedelta }}</small>
-                            {% else %}
-                              <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
-                            {% endif %}
-                          </div>
-                        </div>
-                      </div>
-                      {% if can_respond %}
-                      <div class="d-flex gap-2">
-                        <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
-                          <input type="hidden" name="status" value="accepted">
-                          <button type="submit" class="btn btn-success btn-sm"><i class="fas fa-check me-1"></i>Aceitar</button>
-                        </form>
-                        <form method="POST" action="{{ url_for('update_appointment_status', appointment_id=appt.id) }}">
-                          <input type="hidden" name="status" value="canceled">
-                          <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-times me-1"></i>Recusar</button>
-                        </form>
-                      </div>
-                      {% endif %}
-                    </div>
-                  </div>
-                {% endfor %}
-                {% endif %}
-
-                {% if pending_consults_waiting_others %}
-                <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
-                  <i class="fas fa-user-clock me-2"></i>Consultas aguardando outros profissionais
-                </div>
-                {% for item in pending_consults_waiting_others %}
-                  {% set appt = item.appt %}
-                  {% set can_respond = appt.time_left.total_seconds() > 0 %}
-                  {% set status_label = 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title %}
-                  {% set type_label = {
-                    'consulta': 'Consulta',
-                    'retorno': 'Retorno',
-                    'banho_tosa': 'Banho e Tosa',
-                    'vacina': 'Vacina'
-                  }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title %}
-                  <div class="list-group-item list-group-item-action appointment-item"
-                      data-appointment-id="{{ appt.id }}"
-                      data-id="{{ appt.id }}"
-                      data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
-                      data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
-                      data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
-                      data-vet="{{ appt.veterinario.user.name }}"
-                      data-vet-id="{{ appt.veterinario_id }}"
-                      data-tutor="{{ appt.tutor.name if appt.tutor else (appt.animal.owner.name if appt.animal and appt.animal.owner else '') }}"
-                      data-tutor-id="{{ appt.tutor_id if appt.tutor_id else (appt.animal.owner.id if appt.animal and appt.animal.owner else '') }}"
-                      data-animal="{{ appt.animal.name if appt.animal else '' }}"
-                      data-animal-id="{{ appt.animal_id if appt.animal_id else '' }}"
-                      data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) if appt.animal_id else '' }}"
-                      data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) if appt.tutor_id else (url_for('ficha_tutor', tutor_id=appt.animal.owner.id) if appt.animal and appt.animal.owner else '') }}"
-                      data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
-                      data-notes="{{ (appt.notes or '')|e }}"
-                      data-created-by="{{ appt.creator.name if appt.creator else '' }}"
-                      data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
-                      data-status="{{ appt.status }}"
-                      data-status-label="{{ status_label }}"
-                      data-type="{{ item.kind }}"
-                      data-type-label="{{ type_label }}"
-                      data-created-by-id="{{ appt.created_by if appt.created_by else '' }}">
-                    <div class="d-flex align-items-center">
-                      <div class="me-3">
-                        <i class="fas fa-user-clock {% if can_respond %}text-warning{% else %}text-secondary{% endif %} fa-2x"></i>
-                      </div>
-                      <div>
-                        <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                        <small class="text-muted">
-                          {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
-                          {% if item.kind == 'banho_tosa' %}
-                            <span class="badge bg-primary ms-1">Banho e Tosa</span>
-                          {% elif item.kind == 'vacina' %}
-                            <span class="badge bg-success ms-1">Vacina</span>
-                          {% elif item.kind == 'retorno' %}
-                            <span class="badge bg-warning text-dark ms-1">Retorno</span>
-                          {% endif %}
-                          <span class="badge bg-light text-dark border ms-1"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
-                        </small>
-                        <div class="mt-1">
-                          {% if can_respond %}
-                            <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Aguardando confirmação do profissional</small>
-                          {% else %}
-                            <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
-                          {% endif %}
-                          <small class="text-muted d-block fst-italic mt-1">Clique para detalhes</small>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="text-end">
-                      {% if can_respond %}
-                        <span class="badge bg-warning text-dark"><i class="fas fa-user-clock me-1"></i>Aguardando confirmação</span>
-                      {% else %}
-                        <span class="badge bg-secondary"><i class="fas fa-hourglass-end me-1"></i>Prazo expirado</span>
-                      {% endif %}
-                    </div>
-                  </div>
-                {% endfor %}
-                {% endif %}
-
-                {% if exams_pending_to_accept %}
-                <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
-                  <i class="fas fa-vial me-2"></i>Exames aguardando sua aceitação
-                </div>
-                {% for exam in exams_pending_to_accept %}
-                  {% set can_respond = exam.time_left.total_seconds() > 0 %}
-                  <div class="list-group-item list-group-item-action appointment-item"
-                      data-appointment-id="{{ exam.id }}"
-                      data-type="exame"
-                      data-status="{{ exam.status }}"
-                      data-status-label="{{ exam.status_display }}">
-                    <div class="d-flex justify-content-between align-items-start">
-                      <div class="d-flex align-items-center">
-                        <div class="me-3">
-                          <i class="fas fa-vial fa-2x text-info"></i>
-                        </div>
-                        <div>
-                          <h6 class="mb-0">{{ exam.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ exam.animal.name if exam.animal else '—' }}</h6>
-                          <small class="text-muted">Tutor: {{ exam.animal.owner.name if exam.animal and exam.animal.owner else '—' }}</small>
-                          <div class="mt-1">
-                            {% if can_respond %}
-                              <small class="text-muted"><i class="fas fa-hourglass-half me-1"></i>Tempo restante: {{ exam.time_left|format_timedelta }}</small>
-                            {% else %}
-                              <small class="text-muted"><i class="fas fa-exclamation-circle me-1"></i>Prazo expirado</small>
-                            {% endif %}
-                          </div>
-                        </div>
-                      </div>
-                      {% if can_respond %}
-                      <div class="d-flex gap-2">
-                        <form method="POST" action="{{ url_for('accept_exam_request', exam_id=exam.id) }}">
-                          <button type="submit" class="btn btn-success btn-sm"><i class="fas fa-check me-1"></i>Aceitar</button>
-                        </form>
-                        <form method="POST" action="{{ url_for('decline_exam_request', exam_id=exam.id) }}">
-                          <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-times me-1"></i>Recusar</button>
-                        </form>
-                      </div>
-                      {% endif %}
-                    </div>
-                  </div>
-                {% endfor %}
-                {% endif %}
-
-                {% if exams_waiting_other_vets %}
-                <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
-                  <i class="fas fa-user-md me-2"></i>Exames aguardando outros profissionais
-                </div>
-                {% for exam in exams_waiting_other_vets %}
-                  <div class="list-group-item list-group-item-action">
-                    <div class="d-flex align-items-center justify-content-between">
-                      <div>
-                        <h6 class="mb-0">{{ exam.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ exam.animal.name if exam.animal else '—' }}</h6>
-                        <small class="text-muted">Tutor: {{ exam.animal.owner.name if exam.animal and exam.animal.owner else '—' }}</small>
-                        <div class="mt-1">
-                          <small class="text-muted"><i class="fas fa-user-md me-1"></i>Especialista responsável: {{ exam.specialist.user.name if exam.specialist and exam.specialist.user else '—' }}</small>
-                        </div>
-                      </div>
-                      <span class="badge bg-secondary"><i class="fas fa-hourglass-half me-1"></i>Aguardando</span>
-                    </div>
-                  </div>
-                {% endfor %}
-                {% endif %}
-              {% else %}
-                <div class="list-group-item text-center py-4">
-                  <i class="fas fa-inbox fa-2x text-muted mb-2"></i>
-                  <p class="text-muted mb-0">Não há agendamentos pendentes.</p>
-                </div>
-              {% endif %}
-            </div>
-          </div>
-        </div>
-
-        <!-- Próximos agendamentos -->
-        <div class="card border-primary">
-          <div class="card-header bg-primary text-white">
-            <h5 class="mb-0"><i class="fas fa-calendar-check me-2"></i>Próximos Agendamentos</h5>
-          </div>
-          <div class="card-body p-0">
-            <div class="list-group list-group-flush">
-              {% if appointments_upcoming_for_me or appointments_upcoming_requested %}
-                {% if appointments_upcoming_for_me %}
-                <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
-                  <i class="fas fa-stethoscope me-2"></i>Seus próximos atendimentos
-                </div>
-                {% for item in appointments_upcoming_for_me %}
-                  {% set appt = item.appt %}
-                  {% if item.kind == 'exame' %}
-                  <div class="list-group-item list-group-item-action appointment-item" data-type="exame" data-appointment-id="{{ appt.id }}">
-                    <div class="d-flex justify-content-between align-items-center">
-                      <div class="d-flex align-items-center">
-                        <div class="me-3">
-                          <i class="fas fa-flask fa-2x text-info"></i>
-                        </div>
-                        <div>
-                          <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                          <small class="text-muted">{{ appt.animal.owner.name }} <span class="badge bg-info ms-1">Exame</span></small>
-                        </div>
-                      </div>
-                      <div class="btn-group">
-                        <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                        <a href="{{ url_for('ficha_tutor', tutor_id=appt.animal.owner.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
-                      </div>
-                    </div>
-                  </div>
-                  {% else %}
-                  <div class="list-group-item list-group-item-action appointment-item"
-                      data-appointment-id="{{ appt.id }}"
-                      data-id="{{ appt.id }}"
-                      data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
-                      data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
-                      data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
-                      data-vet="{{ appt.veterinario.user.name }}"
-                      data-vet-id="{{ appt.veterinario_id }}"
-                      data-tutor="{{ appt.tutor.name }}"
-                      data-tutor-id="{{ appt.tutor_id }}"
-                      data-animal="{{ appt.animal.name }}"
-                      data-animal-id="{{ appt.animal_id }}"
-                      data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
-                      data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
-                      data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
-                      data-notes="{{ appt.notes or '' }}"
-                      data-created-by="{{ appt.creator.name if appt.creator else '' }}"
-                      data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
-                      data-status="{{ appt.status }}"
-                      data-status-label="{{ 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title }}"
-                      data-type="{{ item.kind }}"
-                      data-type-label="{{ {
-                        'consulta': 'Consulta',
-                        'retorno': 'Retorno',
-                        'banho_tosa': 'Banho e Tosa',
-                        'vacina': 'Vacina'
-                      }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title }}">
-                    <div class="d-flex justify-content-between align-items-center">
-                      <div class="d-flex align-items-center">
-                        <div class="me-3">
-                          <i class="fas fa-stethoscope fa-2x text-success"></i>
-                        </div>
-                        <div>
-                          <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                          <small class="text-muted">{{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
-                            {% if item.kind == 'retorno' %}
-                              <span class="badge bg-warning text-dark ms-1">Retorno</span>
-                            {% elif item.kind == 'banho_tosa' %}
-                              <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
-                            {% elif item.kind == 'vacina' %}
-                              <span class="badge bg-success text-white ms-1">Vacina</span>
-                            {% endif %}
-                          </small>
-                        </div>
-                      </div>
-                      <div class="btn-group">
-                        <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                        <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
-                        <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
-                      </div>
-                    </div>
-                  </div>
-                  {% endif %}
-                {% endfor %}
-                {% endif %}
-
-                {% if appointments_upcoming_requested %}
-                <div class="list-group-item bg-light text-muted fw-semibold text-uppercase small">
-                  <i class="fas fa-handshake me-2"></i>Acompanhando outros profissionais
-                </div>
-                {% for item in appointments_upcoming_requested %}
-                  {% set appt = item.appt %}
-                  {% set status_label = 'A fazer' if appt.status == 'scheduled' else 'Realizada' if appt.status == 'completed' else 'Cancelada' if appt.status == 'canceled' else 'Aceita' if appt.status == 'accepted' else appt.status|replace('_', ' ')|title %}
-                  {% set type_label = {
-                    'consulta': 'Consulta',
-                    'retorno': 'Retorno',
-                    'banho_tosa': 'Banho e Tosa',
-                    'vacina': 'Vacina'
-                  }[item.kind] if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else item.kind|replace('_', ' ')|title %}
-                  <div class="list-group-item list-group-item-action appointment-item"
-                      data-appointment-id="{{ appt.id }}"
-                      data-id="{{ appt.id }}"
-                      data-date="{{ appt.scheduled_at|format_datetime_brazil('%Y-%m-%d') }}"
-                      data-date-label="{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y') }}"
-                      data-time="{{ appt.scheduled_at|format_datetime_brazil('%H:%M') }}"
-                      data-vet="{{ appt.veterinario.user.name }}"
-                      data-vet-id="{{ appt.veterinario_id }}"
-                      data-tutor="{{ appt.tutor.name }}"
-                      data-tutor-id="{{ appt.tutor_id }}"
-                      data-animal="{{ appt.animal.name }}"
-                      data-animal-id="{{ appt.animal_id }}"
-                      data-animal-url="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}"
-                      data-tutor-url="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}"
-                      data-consulta-url="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}"
-                      data-notes="{{ appt.notes or '' }}"
-                      data-created-by="{{ appt.creator.name if appt.creator else '' }}"
-                      data-created-at="{{ appt.created_at|format_datetime_brazil('%d/%m/%Y %H:%M') if appt.created_at else '' }}"
-                      data-status="{{ appt.status }}"
-                      data-status-label="{{ status_label }}"
-                      data-type="{{ item.kind }}"
-                      data-type-label="{{ type_label }}">
-                    <div class="d-flex justify-content-between align-items-start">
-                      <div class="d-flex alignments-center">
-                        <div class="me-3">
-                          <i class="fas fa-handshake fa-2x text-info"></i>
-                        </div>
-                        <div>
-                          <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                          <small class="text-muted">
-                            {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
-                            {% if item.kind == 'retorno' %}
-                              <span class="badge bg-warning text-dark ms-1">Retorno</span>
-                            {% elif item.kind == 'banho_tosa' %}
-                              <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
-                            {% elif item.kind == 'vacina' %}
-                              <span class="badge bg-success text-white ms-1">Vacina</span>
-                            {% endif %}
-                            <span class="badge bg-light text-dark border ms-1"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
-                          </small>
-                        </div>
-                      </div>
-                      <div class="d-flex flex-column align-items-end gap-2">
-                        <div class="btn-group">
-                          <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                          <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
-                        </div>
-                        <span class="badge bg-success"><i class="fas fa-check me-1"></i>{{ status_label }}</span>
-                      </div>
-                    </div>
-                  </div>
-                {% endfor %}
-                {% endif %}
-              {% else %}
-                <div class="list-group-item text-center py-4">
-                  <i class="fas fa-calendar-times fa-2x text-muted mb-2"></i>
-                  <p class="text-muted mb-0">Nenhum agendamento encontrado.</p>
-                </div>
-              {% endif %}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
 
   <!-- Consultas finalizadas, retornos e exames -->
   <div class="card mb-4 border-secondary">


### PR DESCRIPTION
## Summary
- integrate the agenda view as a collapse panel inside the main schedule card so it shares the same Bootstrap parent as the other panes
- remove the extra sidebar column and update the schedule header controls to target the relocated agenda collapse

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e513d86d08832ea7c5ce17c890ad11