### PR TITLE
Ensure pet and tutor forms stretch to collapse container

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -274,11 +274,11 @@
       </div>
     </div>
     <div class="collapse" id="vetNewTutorForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
-      <div class="card-body bg-light p-4">
-        <div class="row justify-content-center">
-          <div class="col-lg-10 col-xl-8 col-xxl-7">
-            <div class="card shadow-lg border-0 rounded-4 overflow-hidden">
-              <div class="card-body p-4 p-lg-5">
+      <div class="card-body bg-light p-4 h-100">
+        <div class="row justify-content-center align-items-stretch h-100">
+          <div class="col-lg-10 col-xl-8 col-xxl-7 h-100">
+            <div class="card shadow-lg border-0 rounded-4 overflow-hidden h-100">
+              <div class="card-body p-4 p-lg-5 d-flex flex-column h-100">
                 <div class="text-center text-md-start mb-4">
                   <h3 id="vetNewTutorHeading" class="fw-semibold mb-2">👥 Cadastrar novo tutor</h3>
                   <p class="text-muted mb-0">Informe os dados essenciais do tutor e retome o agendamento sem sair desta tela.</p>
@@ -293,11 +293,11 @@
       </div>
     </div>
     <div class="collapse" id="vetNewPetForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
-      <div class="card-body bg-light p-4">
-        <div class="row justify-content-center">
-          <div class="col-lg-10 col-xl-8 col-xxl-7">
-            <div class="card shadow-lg border-0 rounded-4 overflow-hidden">
-              <div class="card-body p-4 p-lg-5">
+      <div class="card-body bg-light p-4 h-100">
+        <div class="row justify-content-center align-items-stretch h-100">
+          <div class="col-lg-10 col-xl-8 col-xxl-7 h-100">
+            <div class="card shadow-lg border-0 rounded-4 overflow-hidden h-100">
+              <div class="card-body p-4 p-lg-5 d-flex flex-column h-100">
                 <div class="text-center text-md-start mb-4">
                   <h3 class="fw-semibold mb-2">🐾 Cadastrar novo pet</h3>
                   <p class="text-muted mb-0">Preencha as informações do animal para vinculá-lo rapidamente ao tutor.</p>


### PR DESCRIPTION
## Summary
- make the new tutor and new pet forms stretch to fill their parent containers
- apply 100% height and flex utilities so cards occupy the available space within the collapse panels

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5174d92c8832ebf2db1a7b0353159