### PR TITLE
Revamp quick tutor workflow in calendar

### DIFF
--- a/templates/partials/tutor_calendar.html
+++ b/templates/partials/tutor_calendar.html
@@ -135,31 +135,74 @@
     </div>
 
     <div class="col-12">
-      <div class="row g-4 align-items-stretch">
-        <div class="col-12">
-          <div class="card shadow-sm border-0 h-100">
-            <div class="card-body d-flex flex-column">
-              <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
-                <div>
-                  <h3 class="h6 mb-1">Tutores</h3>
-                  <span class="text-muted small">Cadastre um novo responsável com endereço completo sem sair da agenda.</span>
-                </div>
-                <a class="btn btn-outline-primary btn-sm" href="{{ url_for('tutores') }}" target="_blank" rel="noopener">
-                  <i class="bi bi-box-arrow-up-right me-1"></i> Ver todos
-                </a>
-              </div>
-              {% with
-                form_id=component_id ~ '-quick-tutor-form',
-                show_intro=False,
-                include_address=True,
-                address_prefix=component_id ~ '-quick-tutor-address'
-              %}
-                {% include 'partials/calendar_quick_tutor_form.html' %}
-              {% endwith %}
+      <section
+        class="tutor-calendar__quick-tutor"
+        aria-labelledby="{{ component_id }}-quick-tutor-heading"
+      >
+        <header class="tutor-calendar__quick-tutor-hero">
+          <div class="tutor-calendar__quick-tutor-icon" aria-hidden="true">
+            <i class="bi bi-person-hearts"></i>
+          </div>
+          <div class="tutor-calendar__quick-tutor-copy">
+            <p class="tutor-calendar__quick-tutor-eyebrow">Cadastro rápido de tutor</p>
+            <h3 id="{{ component_id }}-quick-tutor-heading" class="tutor-calendar__quick-tutor-title">
+              Registre um responsável sem sair da agenda
+            </h3>
+            <p class="tutor-calendar__quick-tutor-description">
+              Simplifique o atendimento preenchendo os dados essenciais do tutor e sincronizando o endereço completo em segundos.
+            </p>
+            <div class="tutor-calendar__quick-tutor-actions">
+              <a class="btn btn-light btn-sm text-primary" href="{{ url_for('tutores') }}" target="_blank" rel="noopener">
+                <i class="bi bi-box-arrow-up-right me-1"></i> Ver todos os tutores
+              </a>
             </div>
           </div>
+          <ul class="tutor-calendar__quick-tutor-highlights" aria-label="Diferenciais do cadastro rápido">
+            <li>
+              <i class="bi bi-magic"></i>
+              <span>Preenchimento guiado com validação em tempo real.</span>
+            </li>
+            <li>
+              <i class="bi bi-geo"></i>
+              <span>Busca automática de endereço via CEP integrado.</span>
+            </li>
+            <li>
+              <i class="bi bi-link-45deg"></i>
+              <span>Cadastro sincronizado com o perfil completo do tutor.</span>
+            </li>
+          </ul>
+        </header>
+        <div class="tutor-calendar__quick-tutor-body">
+          <div class="tutor-calendar__quick-tutor-form">
+            {% with
+              form_id=component_id ~ '-quick-tutor-form',
+              show_intro=False,
+              include_address=True,
+              address_prefix=component_id ~ '-quick-tutor-address'
+            %}
+              {% include 'partials/calendar_quick_tutor_form.html' %}
+            {% endwith %}
+          </div>
+          <aside class="tutor-calendar__quick-tutor-support" aria-label="Resumo do fluxo de cadastro">
+            <div class="tutor-calendar__quick-tutor-support-card">
+              <h4 class="tutor-calendar__quick-tutor-support-title">Fluxo em três passos</h4>
+              <ol class="tutor-calendar__quick-tutor-steps">
+                <li>Identifique o tutor com nome e contato.</li>
+                <li>Adicione documentos e dados adicionais relevantes.</li>
+                <li>Confirme o endereço completo com busca inteligente de CEP.</li>
+              </ol>
+            </div>
+            <div class="tutor-calendar__quick-tutor-support-card">
+              <h4 class="tutor-calendar__quick-tutor-support-title">Dicas de atendimento</h4>
+              <ul class="tutor-calendar__quick-tutor-tips">
+                <li><i class="bi bi-chat-dots"></i> Reforce as preferências de contato para comunicação eficiente.</li>
+                <li><i class="bi bi-people"></i> Vincule o tutor aos pets diretamente após o cadastro.</li>
+                <li><i class="bi bi-shield-check"></i> Garanta que CPF e data de nascimento estejam corretos para prontuários.</li>
+              </ul>
+            </div>
+          </aside>
         </div>
-      </div>
+      </section>
     </div>
   </div>
 </section>
@@ -218,6 +261,206 @@
 
 #{{ component_id }} .tutor-calendar__pet-filter-actions .btn {
   border-radius: 999px;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor {
+  border-radius: 1.75rem;
+  box-shadow: 0 28px 45px -30px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+  background: var(--bs-body-bg, #fff);
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-hero {
+  display: grid;
+  gap: 1.75rem;
+  align-items: center;
+  padding: clamp(1.5rem, 2vw + 1rem, 2.75rem);
+  background: linear-gradient(125deg, rgba(14, 165, 233, 0.9) 0%, rgba(79, 70, 229, 0.9) 100%);
+  color: #f8fafc;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-icon {
+  width: 72px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.18);
+  font-size: 2rem;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-eyebrow {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-title {
+  font-size: clamp(1.25rem, 2vw + 1rem, 1.75rem);
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-description {
+  margin-bottom: 1.25rem;
+  max-width: 46ch;
+  color: rgba(241, 245, 249, 0.9);
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-actions .btn {
+  border-radius: 999px;
+  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.7);
+  font-weight: 600;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-highlights {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-highlights li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(4px);
+  font-size: 0.875rem;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-highlights i {
+  font-size: 1rem;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-body {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+  padding: clamp(1.5rem, 2vw + 1rem, 2.75rem);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(248, 250, 252, 0.95) 100%);
+  grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr);
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-form {
+  background: var(--bs-body-bg, #fff);
+  border-radius: 1.25rem;
+  padding: clamp(1.25rem, 1.5vw + 1rem, 2rem);
+  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.05), 0 24px 40px -32px rgba(15, 23, 42, 0.35);
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-support {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-support-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-support-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-steps {
+  counter-reset: quick-tutor-step;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-steps li {
+  position: relative;
+  padding-left: 2.75rem;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-steps li::before {
+  counter-increment: quick-tutor-step;
+  content: counter(quick-tutor-step);
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.9), rgba(79, 70, 229, 0.9));
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 12px 24px -16px rgba(79, 70, 229, 0.6);
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-tips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-tips li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+#{{ component_id }} .tutor-calendar__quick-tutor-tips i {
+  color: #4f46e5;
+  font-size: 1rem;
+  margin-top: 0.2rem;
+}
+
+@media (max-width: 992px) {
+  #{{ component_id }} .tutor-calendar__quick-tutor-body {
+    grid-template-columns: 1fr;
+  }
+
+  #{{ component_id }} .tutor-calendar__quick-tutor-support {
+    order: -1;
+  }
+}
+
+@media (max-width: 768px) {
+  #{{ component_id }} .tutor-calendar__quick-tutor-hero {
+    text-align: center;
+    justify-items: center;
+  }
+
+  #{{ component_id }} .tutor-calendar__quick-tutor-highlights {
+    justify-content: center;
+  }
+
+  #{{ component_id }} .tutor-calendar__quick-tutor-actions .btn {
+    width: 100%;
+  }
+
+  #{{ component_id }} .tutor-calendar__quick-tutor-form {
+    padding: 1.25rem;
+  }
 }
 
 #{{ component_id }} .tutor-calendar__pet-filter-actions .btn:disabled {


### PR DESCRIPTION
## Summary
- replace the old tutor card in the calendar with a new quick-tutor experience featuring a hero banner, highlights, and helpful guidance
- refresh the inline tutor form container with a split layout and responsive styling for a more elegant UX/UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e519b52e10832e82a9adbbb37cf765