### PR TITLE
Wrap date/age partial in column container

### DIFF
--- a/templates/partials/animal_register_form.html
+++ b/templates/partials/animal_register_form.html
@@ -58,7 +58,9 @@
       {% set prefixo = 'animal_reg' %}
       {% set nome_data = 'date_of_birth' %}
       {% set nome_idade = 'age' %}
-      {% include 'components/campo_data_idade.html' %}
+      <div class="col-12">
+        {% include 'components/campo_data_idade.html' %}
+      </div>
       <div class="col-md-6">
         <label class="form-label">Microchip</label>
         <input type="text" name="microchip_number" class="form-control">


### PR DESCRIPTION
## Summary
- wrap the date/age partial in a column wrapper so the parent row only contains column elements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e51a128aa0832e8468f568d64337fe