### PR TITLE
Refine animal registration layout

### DIFF
--- a/templates/animais/novo_animal.html
+++ b/templates/animais/novo_animal.html
@@ -2,24 +2,26 @@
 
 {% block main %}
   <div class="container-fluid py-4">
-    <div class="row g-4 align-items-start">
-      <div class="col-12 col-xl-5">
-        <div class="card shadow-sm border-0 rounded-4 h-100">
-          <div class="card-body p-4">
-            <div class="mb-4">
-              <h3 class="fw-semibold mb-1">Cadastro de Animais</h3>
-              <p class="text-muted small mb-0">Associe rapidamente um novo pet a um tutor e visualize os registros existentes ao lado.</p>
+    <div class="card shadow-sm border-0 rounded-4">
+      <div class="card-body p-4 d-flex flex-column gap-4">
+        <div class="d-flex flex-column gap-1">
+          <h3 class="fw-semibold mb-0">Cadastro de Animais</h3>
+          <p class="text-muted small mb-0">Associe rapidamente um novo pet a um tutor e visualize os registros existentes ao lado.</p>
+        </div>
+        <div class="row row-cols-1 row-cols-xl-2 g-4 align-items-stretch">
+          <div class="col d-flex">
+            <div class="d-flex flex-column gap-4 w-100 h-100 p-4 bg-body-tertiary rounded-4 border border-light-subtle">
+              {% include 'partials/animal_register_form.html' %}
             </div>
-            {% include 'partials/animal_register_form.html' %}
+          </div>
+          <div class="col d-flex">
+            <div class="d-flex flex-column w-100 h-100 p-4 bg-body-tertiary rounded-4 border border-light-subtle">
+              {% include 'partials/pet_quick_list.html' with bare=True %}
+            </div>
           </div>
         </div>
-      </div>
-      <div class="col-12 col-xl-7">
-        <div class="d-flex flex-column gap-4">
-          {% include 'partials/pet_quick_list.html' %}
-          <div id="animais-adicionados">
-            {% include 'partials/animais_adicionados.html' with compact=True %}
-          </div>
+        <div id="animais-adicionados">
+          {% include 'partials/animais_adicionados.html' with compact=True %}
         </div>
       </div>
     </div>

--- a/templates/partials/pet_quick_list.html
+++ b/templates/partials/pet_quick_list.html
@@ -2,13 +2,21 @@
 {% set pets_endpoint = pets_endpoint|default(url_for('api_clinic_pets')) %}
 {% set new_pet_url = new_pet_url|default(url_for('novo_animal')) %}
 {% set profile_url_template = profile_url_template|default(url_for('ficha_animal', animal_id=0)) %}
+{% set bare = bare|default(False) %}
+{% if bare %}
+  {% set wrapper_classes = 'd-flex flex-column h-100 w-100' %}
+  {% set body_classes = 'd-flex flex-column gap-3 h-100' %}
+{% else %}
+  {% set wrapper_classes = 'card shadow-sm border-0 h-100 w-100' %}
+  {% set body_classes = 'card-body d-flex flex-column gap-3' %}
+{% endif %}
 <div
   id="{{ component_id }}"
-  class="card shadow-sm border-0 h-100"
+  class="{{ wrapper_classes }}"
   data-pets-url="{{ pets_endpoint }}"
   data-profile-template="{{ profile_url_template }}"
 >
-  <div class="card-body d-flex flex-column">
+  <div class="{{ body_classes }}">
     <div class="d-flex justify-content-between align-items-start mb-3 flex-wrap gap-2">
       <div>
         <h3 class="h6 mb-1">Pacientes (Pets)</h3>


### PR DESCRIPTION
## Summary
- wrap the new animal page content in a full-width card with a responsive two-column row for the form and quick list
- allow the pet quick list partial to render without its card wrapper so it can share the surrounding layout

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68e51a14810c832e9e96876fb2c4eb3e