### PR TITLE
Fix novo_animal template include compatibility

### DIFF
--- a/templates/animais/novo_animal.html
+++ b/templates/animais/novo_animal.html
@@ -18,7 +18,9 @@
         <div class="d-flex flex-column gap-4">
           {% include 'partials/pet_quick_list.html' %}
           <div id="animais-adicionados">
-            {% include 'partials/animais_adicionados.html' with compact=True %}
+            {% set compact = True %}
+            {% include 'partials/animais_adicionados.html' %}
+            {% set compact = None %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure the novo_animal template sets the `compact` flag before rendering the animals list partial
- avoid Jinja include syntax that is unsupported in the current environment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e51c6e74a4832e9c117f1b267b9ae9