### PR TITLE
Enable inline schedule editing in vet agenda

### DIFF
--- a/static/appointments_vet.js
+++ b/static/appointments_vet.js
@@ -394,17 +394,53 @@ export function selectDays(mode, selectEl = document.getElementById('schedule-di
 }
 
 export function toggleScheduleForm(rootParam) {
-  if (isEvent(rootParam)) {
+  const isParamEvent = isEvent(rootParam);
+  if (isParamEvent) {
     rootParam.preventDefault();
   }
-  const root = getRootElement(rootParam);
+  const shouldCloseInline = rootParam === 'close-inline' || rootParam === 'close';
+  const normalizedRootParam = isParamEvent || shouldCloseInline ? undefined : rootParam;
+  const root = getRootElement(normalizedRootParam);
   const modalEl = document.getElementById('scheduleModal');
+  const inlineContainer = root?.querySelector('[data-schedule-inline-container]');
   const form = document.getElementById('schedule-form');
   const daysSelect = document.getElementById('schedule-dias_semana');
   const vetSelect = document.getElementById('schedule-veterinario_id');
   const titleEl = document.getElementById('scheduleModalTitle');
   const modal = getModalInstance(modalEl);
-  if (!modal || !form) {
+
+  if (!form) {
+    return;
+  }
+
+  const hideInlineContainer = () => {
+    if (!inlineContainer) {
+      return false;
+    }
+    inlineContainer.classList.add('d-none');
+    inlineContainer.dataset.visible = 'false';
+    form.reset();
+    if (daysSelect) {
+      daysSelect.multiple = true;
+    }
+    if (titleEl) {
+      titleEl.textContent = 'Adicionar Horário';
+    }
+    return true;
+  };
+
+  if (inlineContainer) {
+    const inlineVisible = inlineContainer.dataset.visible === 'true' || !inlineContainer.classList.contains('d-none');
+    if (shouldCloseInline) {
+      hideInlineContainer();
+      return;
+    }
+    if (inlineVisible && isParamEvent) {
+      if (hideInlineContainer()) {
+        return;
+      }
+    }
+  } else if (!modal) {
     return;
   }
 
@@ -424,13 +460,21 @@ export function toggleScheduleForm(rootParam) {
     titleEl.textContent = 'Adicionar Horário';
   }
 
+  if (inlineContainer) {
+    inlineContainer.classList.remove('d-none');
+    inlineContainer.dataset.visible = 'true';
+    if (typeof inlineContainer.scrollIntoView === 'function') {
+      inlineContainer.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    return;
+  }
+
   modal.show();
 }
 
 export function editSchedule(dataset, rootParam) {
   const root = getRootElement(rootParam);
   const modalEl = document.getElementById('scheduleModal');
-  const modal = getModalInstance(modalEl);
   const form = document.getElementById('schedule-form');
   const titleEl = document.getElementById('scheduleModalTitle');
   const daysSelect = document.getElementById('schedule-dias_semana');
@@ -438,7 +482,9 @@ export function editSchedule(dataset, rootParam) {
   const endField = document.getElementById('schedule-hora_fim');
   const intervalStart = document.getElementById('schedule-intervalo_inicio');
   const intervalEnd = document.getElementById('schedule-intervalo_fim');
-  if (!modal || !form) {
+  const inlineContainer = root?.querySelector('[data-schedule-inline-container]');
+  const modal = getModalInstance(modalEl);
+  if (!form) {
     return;
   }
 
@@ -475,7 +521,18 @@ export function editSchedule(dataset, rootParam) {
     intervalEnd.value = dataset?.intervaloFim || '';
   }
 
-  modal.show();
+  if (inlineContainer) {
+    inlineContainer.classList.remove('d-none');
+    inlineContainer.dataset.visible = 'true';
+    if (typeof inlineContainer.scrollIntoView === 'function') {
+      inlineContainer.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    return;
+  }
+
+  if (modal) {
+    modal.show();
+  }
 }
 
 export function toggleAppointmentForm(rootParam) {
@@ -1242,6 +1299,23 @@ export function toggleScheduleEdit(rootParam) {
     toggleButton.innerHTML = anyVisible
       ? '<i class="fas fa-times me-1"></i>Cancelar Edição'
       : '<i class="fas fa-edit me-1"></i>Editar horários';
+  }
+  if (!anyVisible) {
+    const inlineContainer = root.querySelector('[data-schedule-inline-container]');
+    if (inlineContainer) {
+      inlineContainer.classList.add('d-none');
+      inlineContainer.dataset.visible = 'false';
+      const form = document.getElementById('schedule-form');
+      const daysSelect = document.getElementById('schedule-dias_semana');
+      const titleEl = document.getElementById('scheduleModalTitle');
+      form?.reset();
+      if (daysSelect) {
+        daysSelect.multiple = true;
+      }
+      if (titleEl) {
+        titleEl.textContent = 'Adicionar Horário';
+      }
+    }
   }
 }
 

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -954,6 +954,25 @@
       </button>
     </div>
     <div class="card-body">
+      <div class="schedule-inline-container border rounded-3 p-4 mb-4 d-none" data-schedule-inline-container>
+        <div class="d-flex justify-content-between align-items-start mb-3">
+          <div>
+            <h5 class="mb-1" id="scheduleModalTitle">Adicionar Horário</h5>
+            <p class="text-muted mb-0">Configure novos horários ou edite os existentes diretamente neste painel.</p>
+          </div>
+          <button type="button" class="btn-close" aria-label="Fechar" onclick="toggleScheduleForm('close-inline')"></button>
+        </div>
+        <form method="post" id="schedule-form" class="d-flex flex-column gap-3">
+          {% include 'partials/schedule_form_body.html' %}
+          <div class="d-flex justify-content-end gap-2">
+            <button type="button" class="btn btn-outline-secondary" onclick="toggleScheduleForm('close-inline')">Cancelar</button>
+            <button type="submit"
+                    class="btn btn-primary"
+                    name="{{ schedule_form.submit.name }}"
+                    value="Salvar Horário">Salvar Horário</button>
+          </div>
+        </form>
+      </div>
       <div class="row">
         {% for grupo in horarios_grouped %}
           <div class="col-md-6 col-lg-4 mb-3">
@@ -1223,7 +1242,6 @@
 
 {% block scripts %}
   {{ super() }}
-  {% include 'partials/schedule_modal.html' %}
 
   <script>
     document.addEventListener('DOMContentLoaded', function () {

--- a/templates/partials/schedule_form_body.html
+++ b/templates/partials/schedule_form_body.html
@@ -1,0 +1,35 @@
+{{ schedule_form.hidden_tag() }}
+<div class="mb-3">
+  {{ schedule_form.veterinario_id.label(class="form-label fw-semibold") }}
+  {{ schedule_form.veterinario_id(class="form-select") }}
+</div>
+<div class="mb-3">
+  {{ schedule_form.dias_semana.label(class="form-label fw-semibold") }}
+  {{ schedule_form.dias_semana(class="form-select", multiple=True, size=7) }}
+  <div class="mt-2 d-flex gap-2 flex-wrap">
+    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('all')">Todos</button>
+    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekday')">Dias úteis</button>
+    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekend')">Fins de semana</button>
+    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('clear')">Limpar</button>
+  </div>
+</div>
+<div class="row g-3">
+  <div class="col-md-6">
+    {{ schedule_form.hora_inicio.label(class="form-label fw-semibold") }}
+    {{ schedule_form.hora_inicio(class="form-control") }}
+  </div>
+  <div class="col-md-6">
+    {{ schedule_form.hora_fim.label(class="form-label fw-semibold") }}
+    {{ schedule_form.hora_fim(class="form-control") }}
+  </div>
+</div>
+<div class="row g-3">
+  <div class="col-md-6">
+    {{ schedule_form.intervalo_inicio.label(class="form-label fw-semibold") }}
+    {{ schedule_form.intervalo_inicio(class="form-control") }}
+  </div>
+  <div class="col-md-6">
+    {{ schedule_form.intervalo_fim.label(class="form-label fw-semibold") }}
+    {{ schedule_form.intervalo_fim(class="form-control") }}
+  </div>
+</div>

--- a/templates/partials/schedule_modal.html
+++ b/templates/partials/schedule_modal.html
@@ -7,41 +7,7 @@
         </div>
         <div class="modal-body">
           <form method="post" id="schedule-form">
-            {{ schedule_form.hidden_tag() }}
-            <div class="mb-3">
-              {{ schedule_form.veterinario_id.label(class="form-label fw-semibold") }}
-              {{ schedule_form.veterinario_id(class="form-select") }}
-            </div>
-            <div class="mb-3">
-              {{ schedule_form.dias_semana.label(class="form-label fw-semibold") }}
-              {{ schedule_form.dias_semana(class="form-select", multiple=True, size=7) }}
-              <div class="mt-2 d-flex gap-2 flex-wrap">
-                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('all')">Todos</button>
-                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekday')">Dias úteis</button>
-                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('weekend')">Fins de semana</button>
-                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="selectDays('clear')">Limpar</button>
-              </div>
-            </div>
-            <div class="row g-3">
-              <div class="col-md-6">
-                {{ schedule_form.hora_inicio.label(class="form-label fw-semibold") }}
-                {{ schedule_form.hora_inicio(class="form-control") }}
-              </div>
-              <div class="col-md-6">
-                {{ schedule_form.hora_fim.label(class="form-label fw-semibold") }}
-                {{ schedule_form.hora_fim(class="form-control") }}
-              </div>
-            </div>
-            <div class="row g-3">
-              <div class="col-md-6">
-                {{ schedule_form.intervalo_inicio.label(class="form-label fw-semibold") }}
-                {{ schedule_form.intervalo_inicio(class="form-control") }}
-              </div>
-              <div class="col-md-6">
-                {{ schedule_form.intervalo_fim.label(class="form-label fw-semibold") }}
-                {{ schedule_form.intervalo_fim(class="form-control") }}
-              </div>
-            </div>
+            {% include 'partials/schedule_form_body.html' %}
           </form>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Summary
- embed the veterinarian schedule form directly in the agenda card so hours can be managed without a modal
- extract the schedule form fields into a reusable partial shared by the modal and inline form
- update the agenda scripts to toggle the inline form, support editing existing entries, and reset the UI when leaving edit mode

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e51ad0f450832e95528355522a0c0c