### PR TITLE
Move past events card into schedule panel

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -591,9 +591,6 @@
                   </div>
                 </div>
               </div>
-        </div>
-      </div>
-    </div>
           <!-- Consultas finalizadas, retornos e exames -->
           <div class="card border-secondary">
             <div class="card-header bg-secondary text-white d-flex justify-content-between align-items-center">
@@ -747,6 +744,9 @@
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
           <div
             class="collapse"
             id="{{ vet_calendar_collapse_id }}"


### PR DESCRIPTION
## Summary
- place the past consultations and exams card directly after the upcoming appointments card within the schedule panel
- ensure the past events panel collapses together with the rest of the schedule content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52171b79c832ebd340b9768ac89e4