### PR TITLE
Fix include syntax for tutor list partial

### DIFF
--- a/templates/animais/tutores.html
+++ b/templates/animais/tutores.html
@@ -69,7 +69,9 @@
 
     <div class="col-12 col-xl-8">
       <div id="tutores-adicionados">
-        {% include 'partials/tutores_adicionados.html' with compact=True %}
+        {% with compact=True %}
+          {% include 'partials/tutores_adicionados.html' %}
+        {% endwith %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace the unsupported include-with syntax in the tutors page with a `with` block to pass the `compact` flag to the partial

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52246ac74832e8fefea6753903223