### PR TITLE
Reorganize tutor management layout

### DIFF
--- a/templates/animais/tutores.html
+++ b/templates/animais/tutores.html
@@ -1,9 +1,9 @@
 {% extends 'layout.html' %}
 {% block main %}
 <div class="container-fluid py-4">
-  <div class="row g-4 align-items-start">
-    <div class="col-12 col-xl-4">
-      <div class="card shadow-sm border-0 rounded-4 h-100">
+  <div class="row g-4">
+    <div class="col-12">
+      <div class="card shadow-sm border-0 rounded-4">
         <div class="card-body p-4">
           <div class="mb-4">
             <h3 class="fw-semibold mb-1">Gestão de Tutores</h3>
@@ -67,7 +67,7 @@
       </div>
     </div>
 
-    <div class="col-12 col-xl-8">
+    <div class="col-12">
       <div id="tutores-adicionados">
         {% with compact=True %}
           {% include 'partials/tutores_adicionados.html' %}


### PR DESCRIPTION
## Summary
- stack the tutor search and registration card above the tutor list so the form appears first on the page

## Testing
- pytest *(fails: existing fixture expectations in tests/test_vacinas.py and tests/test_vet_pending_exam_status.py that also fail on main)*

------
https://chatgpt.com/codex/tasks/task_e_68e52343237c832e8d4fd4cb869c9ccd