### PR TITLE
Refine vet schedule management collapse

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -51,6 +51,7 @@
   {% set calendar_hide_experimental_tab = True %}
   {% set calendar_show_summary_toggle = False %}
   {% set vet_calendar_collapse_id = 'vet-calendar-collapse-' ~ veterinario.id %}
+  {% set vet_schedule_manage_collapse_id = 'vet-schedule-manage-' ~ veterinario.id %}
   {% set agenda_sidebar_collapse_id = 'vet-agenda-sidebar-' ~ veterinario.id %}
 
   <!-- Gerenciar horários e agendamento -->
@@ -82,7 +83,15 @@
             >
               <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
             </button>
-            <button id="openScheduleModal" class="btn btn-light btn-sm" type="button">
+            <button
+              id="openScheduleModal"
+              class="btn btn-light btn-sm collapsed"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#{{ vet_schedule_manage_collapse_id }}"
+              aria-expanded="false"
+              aria-controls="{{ vet_schedule_manage_collapse_id }}"
+            >
               <i class="bi bi-pencil"></i> Editar Horário
             </button>
             <button
@@ -757,6 +766,125 @@
             {% include 'partials/calendar_layout.html' %}
           </div>
         </div>
+        <div
+          class="collapse"
+          id="{{ vet_schedule_manage_collapse_id }}"
+          data-bs-parent="#{{ schedule_collapse_group_id }}"
+          data-schedule-manage-collapse
+        >
+          <div class="card-body p-4">
+            <div class="card shadow-sm border-0">
+              <div class="card-header bg-light d-flex justify-content-between align-items-center">
+                <h5 class="mb-0"><i class="fas fa-business-time me-2"></i>Horários Cadastrados</h5>
+                <button
+                  class="btn btn-sm btn-outline-primary"
+                  data-schedule-edit-toggle
+                  onclick="toggleScheduleEdit()"
+                >
+                  <i class="fas fa-edit me-1"></i>Editar horários
+                </button>
+              </div>
+              <div class="card-body">
+                <div
+                  class="schedule-inline-container border rounded-3 p-4 mb-4 d-none"
+                  data-schedule-inline-container
+                  data-visible="false"
+                >
+                  <div class="d-flex justify-content-between align-items-start mb-3">
+                    <div>
+                      <h5 class="mb-1" id="scheduleModalTitle">Adicionar Horário</h5>
+                      <p class="text-muted mb-0">Configure novos horários ou edite os existentes diretamente neste painel.</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="btn-close"
+                      aria-label="Fechar"
+                      onclick="toggleScheduleForm('close-inline')"
+                    ></button>
+                  </div>
+                  <form method="post" id="schedule-form" class="d-flex flex-column gap-3">
+                    {% include 'partials/schedule_form_body.html' %}
+                    <div class="d-flex justify-content-end gap-2">
+                      <button
+                        type="button"
+                        class="btn btn-outline-secondary"
+                        onclick="toggleScheduleForm('close-inline')"
+                      >
+                        Cancelar
+                      </button>
+                      <button
+                        type="submit"
+                        class="btn btn-primary"
+                        name="{{ schedule_form.submit.name }}"
+                        value="Salvar Horário"
+                      >
+                        Salvar Horário
+                      </button>
+                    </div>
+                  </form>
+                </div>
+                <div class="row">
+                  {% for grupo in horarios_grouped %}
+                    <div class="col-md-6 col-lg-4 mb-3">
+                      <div class="card h-100" style="opacity: 1; transform: translateY(0px); transition: opacity 0.5s, transform 0.5s;">
+                        <div class="card-header py-2">
+                          <h6 class="mb-0">{{ grupo.dia }}</h6>
+                        </div>
+                        <div class="card-body py-2">
+                          {% for h in grupo.itens %}
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                              <div>
+                                <span class="badge bg-light text-dark">{{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}</span>
+                                {% if h.intervalo_inicio and h.intervalo_fim %}
+                                  <small class="text-muted d-block">Intervalo: {{ h.intervalo_inicio.strftime('%H:%M') }} - {{ h.intervalo_fim.strftime('%H:%M') }}</small>
+                                {% endif %}
+                              </div>
+                              <div class="schedule-actions d-none">
+                                <button
+                                  type="button"
+                                  class="btn btn-sm btn-outline-primary edit-btn"
+                                  data-id="{{ h.id }}"
+                                  data-dia="{{ h.dia_semana }}"
+                                  data-hora-inicio="{{ h.hora_inicio.strftime('%H:%M') }}"
+                                  data-hora-fim="{{ h.hora_fim.strftime('%H:%M') }}"
+                                  data-intervalo-inicio="{{ h.intervalo_inicio.strftime('%H:%M') if h.intervalo_inicio else '' }}"
+                                  data-intervalo-fim="{{ h.intervalo_fim.strftime('%H:%M') if h.intervalo_fim else '' }}"
+                                  data-vet-schedule-bound="true"
+                                >
+                                  <i class="fas fa-edit"></i>
+                                </button>
+                                <form
+                                  method="post"
+                                  action="{{ url_for('delete_vet_schedule', veterinario_id=veterinario.id, horario_id=h.id) }}"
+                                  class="d-inline"
+                                >
+                                  {{ schedule_form.csrf_token }}
+                                  <button
+                                    type="submit"
+                                    class="btn btn-sm btn-outline-danger"
+                                    onclick="return confirm('Excluir este horário?');"
+                                  >
+                                    <i class="fas fa-trash"></i>
+                                  </button>
+                                </form>
+                              </div>
+                            </div>
+                          {% endfor %}
+                        </div>
+                      </div>
+                    </div>
+                  {% else %}
+                    <div class="col-12 text-center py-4">
+                      <i class="fas fa-clock fa-2x text-muted mb-2"></i>
+                      <p class="text-muted mb-0">Nenhum horário cadastrado.</p>
+                    </div>
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          </div>
+    </div>
+
     <div class="collapse" id="newAppointmentForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
       <div class="card-body p-4">
         <form method="POST" class="needs-validation" novalidate>
@@ -946,85 +1074,6 @@
     </div>
 
   
-  <!-- Seção de Horários Cadastrados -->
-  <div class="card mb-4" style="opacity: 1; transform: translateY(0px); transition: opacity 0.5s, transform 0.5s;">
-    <div class="card-header bg-light d-flex justify-content-between align-items-center">
-      <h5 class="mb-0"><i class="fas fa-business-time me-2"></i>Horários Cadastrados</h5>
-      <button class="btn btn-sm btn-outline-primary"
-              data-schedule-edit-toggle
-              onclick="toggleScheduleEdit()">
-        <i class="fas fa-edit me-1"></i>Editar horários
-      </button>
-    </div>
-    <div class="card-body">
-      <div class="schedule-inline-container border rounded-3 p-4 mb-4 d-none" data-schedule-inline-container>
-        <div class="d-flex justify-content-between align-items-start mb-3">
-          <div>
-            <h5 class="mb-1" id="scheduleModalTitle">Adicionar Horário</h5>
-            <p class="text-muted mb-0">Configure novos horários ou edite os existentes diretamente neste painel.</p>
-          </div>
-          <button type="button" class="btn-close" aria-label="Fechar" onclick="toggleScheduleForm('close-inline')"></button>
-        </div>
-        <form method="post" id="schedule-form" class="d-flex flex-column gap-3">
-          {% include 'partials/schedule_form_body.html' %}
-          <div class="d-flex justify-content-end gap-2">
-            <button type="button" class="btn btn-outline-secondary" onclick="toggleScheduleForm('close-inline')">Cancelar</button>
-            <button type="submit"
-                    class="btn btn-primary"
-                    name="{{ schedule_form.submit.name }}"
-                    value="Salvar Horário">Salvar Horário</button>
-          </div>
-        </form>
-      </div>
-      <div class="row">
-        {% for grupo in horarios_grouped %}
-          <div class="col-md-6 col-lg-4 mb-3">
-            <div class="card h-100" style="opacity: 1; transform: translateY(0px); transition: opacity 0.5s, transform 0.5s;">
-              <div class="card-header py-2">
-                <h6 class="mb-0">{{ grupo.dia }}</h6>
-              </div>
-              <div class="card-body py-2">
-                {% for h in grupo.itens %}
-                  <div class="d-flex justify-content-between align-items-center mb-2">
-                    <div>
-                      <span class="badge bg-light text-dark">{{ h.hora_inicio.strftime('%H:%M') }} - {{ h.hora_fim.strftime('%H:%M') }}</span>
-                      {% if h.intervalo_inicio and h.intervalo_fim %}
-                        <small class="text-muted d-block">Intervalo: {{ h.intervalo_inicio.strftime('%H:%M') }} - {{ h.intervalo_fim.strftime('%H:%M') }}</small>
-                      {% endif %}
-                    </div>
-                    <div class="schedule-actions d-none">
-                      <button type="button" class="btn btn-sm btn-outline-primary edit-btn"
-                              data-id="{{ h.id }}"
-                              data-dia="{{ h.dia_semana }}"
-                              data-hora-inicio="{{ h.hora_inicio.strftime('%H:%M') }}"
-                              data-hora-fim="{{ h.hora_fim.strftime('%H:%M') }}"
-                              data-intervalo-inicio="{{ h.intervalo_inicio.strftime('%H:%M') if h.intervalo_inicio else '' }}"
-                              data-intervalo-fim="{{ h.intervalo_fim.strftime('%H:%M') if h.intervalo_fim else '' }}"
-                              data-vet-schedule-bound="true">
-                        <i class="fas fa-edit"></i>
-                      </button>
-                      <form method="post" action="{{ url_for('delete_vet_schedule', veterinario_id=veterinario.id, horario_id=h.id) }}" class="d-inline">
-                        {{ schedule_form.csrf_token }}
-                        <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Excluir este horário?');">
-                          <i class="fas fa-trash"></i>
-                        </button>
-                      </form>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
-            </div>
-          </div>
-        {% else %}
-          <div class="col-12 text-center py-4">
-            <i class="fas fa-clock fa-2x text-muted mb-2"></i>
-            <p class="text-muted mb-0">Nenhum horário cadastrado.</p>
-          </div>
-        {% endfor %}
-      </div>
-    </div>
-  </div>
-
   <!-- Modal de detalhes da consulta -->
   <div class="modal fade" id="appointmentDetailModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- move the inline schedule management card into the same collapse stack as the agenda, calendar, and appointment sections so it starts closed and mutually exclusive
- add JavaScript helpers that reset the inline form and schedule action state whenever the edit mode or collapse visibility changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52101f50c832e9d7bf34fcc697148