### PR TITLE
Restyle agenda toolbar buttons

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -8,24 +8,128 @@
   }
 }
 
-/* Botões responsivos na área de agendamentos */
-.button-action-group {
-  width: 100%;
+/* Barra de ações da agenda */
+.schedule-toolbar {
+  --toolbar-gradient-start: #0d6efd;
+  --toolbar-gradient-end: #6610f2;
+  background: linear-gradient(135deg, var(--toolbar-gradient-start), var(--toolbar-gradient-end));
+  padding: 1.1rem 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.85rem;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 18px 45px -35px rgba(79, 70, 229, 0.75);
 }
 
-.btn-stack-item {
-  width: 100%;
-  min-height: 44px;
+.schedule-toolbar::before,
+.schedule-toolbar::after {
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  filter: blur(0);
+  z-index: 0;
 }
 
-@media (min-width: 768px) {
-  .button-action-group {
-    width: auto;
-    align-items: center;
+.schedule-toolbar::before {
+  width: 280px;
+  height: 280px;
+  top: -140px;
+  right: -90px;
+}
+
+.schedule-toolbar::after {
+  width: 220px;
+  height: 220px;
+  bottom: -150px;
+  left: -60px;
+}
+
+.schedule-toolbar-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.85rem;
+  width: 100%;
+  position: relative;
+  z-index: 1;
+}
+
+.schedule-toolbar-btn {
+  --schedule-btn-bg: rgba(255, 255, 255, 0.22);
+  --schedule-btn-color: #ffffff;
+  --schedule-btn-shadow: rgba(15, 23, 42, 0.18);
+  border: none;
+  border-radius: 999px;
+  background: var(--schedule-btn-bg);
+  color: var(--schedule-btn-color);
+  padding: 0.55rem 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  box-shadow: 0 12px 24px -18px var(--schedule-btn-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.schedule-toolbar-btn .bi,
+.schedule-toolbar-btn i,
+.schedule-toolbar-btn svg {
+  font-size: 1rem;
+}
+
+.schedule-toolbar-btn:hover,
+.schedule-toolbar-btn:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px -16px var(--schedule-btn-shadow);
+  text-decoration: none;
+}
+
+.schedule-toolbar-btn:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.35), 0 16px 30px -16px var(--schedule-btn-shadow);
+}
+
+.schedule-toolbar-btn--neutral {
+  --schedule-btn-bg: rgba(255, 255, 255, 0.22);
+  --schedule-btn-shadow: rgba(15, 23, 42, 0.25);
+}
+
+.schedule-toolbar-btn--info {
+  --schedule-btn-bg: linear-gradient(135deg, #38bdf8 0%, #60a5fa 100%);
+  --schedule-btn-shadow: rgba(56, 189, 248, 0.45);
+}
+
+.schedule-toolbar-btn--success {
+  --schedule-btn-bg: linear-gradient(135deg, #34d399 0%, #10b981 100%);
+  --schedule-btn-shadow: rgba(16, 185, 129, 0.45);
+}
+
+.schedule-toolbar-btn--warning {
+  --schedule-btn-bg: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
+  --schedule-btn-color: #1f2937;
+  --schedule-btn-shadow: rgba(245, 158, 11, 0.35);
+}
+
+.schedule-toolbar-btn--primary {
+  --schedule-btn-bg: linear-gradient(135deg, #7c3aed 0%, #2563eb 100%);
+  --schedule-btn-shadow: rgba(124, 58, 237, 0.45);
+}
+
+@media (max-width: 576px) {
+  .schedule-toolbar {
+    padding: 1rem 1.1rem;
+    border-radius: 1rem 1rem 0 0;
   }
 
-  .btn-stack-item {
-    width: auto;
+  .schedule-toolbar-btn {
+    width: 100%;
+    justify-content: center;
   }
 }
 

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -48,16 +48,28 @@
 
   <!-- Gerenciar horários (novo + editar) -->
   <div class="card border-0 shadow-lg rounded-4 mb-5">
-    <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
-      <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
-      <div class="button-action-group d-flex flex-column flex-md-row gap-2 w-100 justify-content-md-end ms-lg-auto">
-        <button id="openScheduleModal" class="btn btn-light btn-stack-item" type="button">
-          <i class="bi bi-pencil"></i> Editar Horário
-        </button>
-        <button class="btn btn-success btn-stack-item" data-bs-toggle="collapse" data-bs-target="#newAppointmentForm">
-          <i class="bi bi-plus-circle"></i> Nova Consulta
-        </button>
-      </div>
+    <div class="card-header border-0 p-0">
+      <nav class="schedule-toolbar rounded-top-4" aria-label="Ações rápidas da agenda">
+        <div class="schedule-toolbar-buttons">
+          <button
+            id="openScheduleModal"
+            class="schedule-toolbar-btn schedule-toolbar-btn--neutral"
+            type="button"
+          >
+            <i class="bi bi-pencil"></i>
+            <span>Editar Horário</span>
+          </button>
+          <button
+            class="schedule-toolbar-btn schedule-toolbar-btn--success"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#newAppointmentForm"
+          >
+            <i class="bi bi-plus-circle"></i>
+            <span>Nova Consulta</span>
+          </button>
+        </div>
+      </nav>
     </div>
 
     <div class="collapse" id="newAppointmentForm">

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -59,71 +59,78 @@
   <div class="row g-4 align-items-start">
     <div class="col-12 d-flex flex-column gap-4">
       <div class="card border-0 shadow-lg rounded-4" id="{{ schedule_collapse_group_id }}">
-        <div class="card-header bg-primary text-white rounded-top-4 d-flex justify-content-between align-items-center">
-          <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i> Gerenciar Horários</h5>
-          <div class="d-flex flex-wrap align-items-center gap-2 justify-content-end">
-            <button
-              class="btn btn-light btn-sm"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#{{ agenda_sidebar_collapse_id }}"
-              aria-expanded="true"
-              aria-controls="{{ agenda_sidebar_collapse_id }}"
-            >
-              <i class="bi bi-journal-text me-1"></i> Agenda
-            </button>
-            <button
-              class="btn btn-light btn-sm collapsed"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#{{ vet_calendar_collapse_id }}"
-              aria-expanded="false"
-              aria-controls="{{ vet_calendar_collapse_id }}"
-              data-calendar-tab-target="#{{ calendar_experimental_tab_id }}"
-            >
-              <i class="bi bi-layout-text-window-reverse me-1"></i> Calendário
-            </button>
-            <button
-              id="openScheduleModal"
-              class="btn btn-light btn-sm collapsed"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#{{ vet_schedule_manage_collapse_id }}"
-              aria-expanded="false"
-              aria-controls="{{ vet_schedule_manage_collapse_id }}"
-            >
-              <i class="bi bi-pencil"></i> Editar Horário
-            </button>
-            <button
-              class="btn btn-success btn-sm collapsed"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#newAppointmentForm"
-              aria-expanded="false"
-            >
-              <i class="bi bi-plus-circle"></i> Nova Consulta
-            </button>
-            <button
-              class="btn btn-light btn-sm collapsed"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#vetNewTutorForm"
-              aria-expanded="false"
-              aria-controls="vetNewTutorForm"
-            >
-              <i class="bi bi-person-plus"></i> Novo Tutor
-            </button>
-            <button
-              class="btn btn-primary btn-sm collapsed"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#vetNewPetForm"
-              aria-expanded="false"
-              aria-controls="vetNewPetForm"
-            >
-              <i class="bi bi-plus-circle"></i> Novo Pet
-            </button>
-          </div>
+        <div class="card-header border-0 p-0">
+          <nav class="schedule-toolbar rounded-top-4" aria-label="Ações rápidas da agenda">
+            <div class="schedule-toolbar-buttons">
+              <button
+                class="schedule-toolbar-btn schedule-toolbar-btn--neutral"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#{{ agenda_sidebar_collapse_id }}"
+                aria-expanded="true"
+                aria-controls="{{ agenda_sidebar_collapse_id }}"
+              >
+                <i class="bi bi-journal-text"></i>
+                <span>Agenda</span>
+              </button>
+              <button
+                class="schedule-toolbar-btn schedule-toolbar-btn--info collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#{{ vet_calendar_collapse_id }}"
+                aria-expanded="false"
+                aria-controls="{{ vet_calendar_collapse_id }}"
+                data-calendar-tab-target="#{{ calendar_experimental_tab_id }}"
+              >
+                <i class="bi bi-layout-text-window-reverse"></i>
+                <span>Calendário</span>
+              </button>
+              <button
+                id="openScheduleModal"
+                class="schedule-toolbar-btn schedule-toolbar-btn--neutral collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#{{ vet_schedule_manage_collapse_id }}"
+                aria-expanded="false"
+                aria-controls="{{ vet_schedule_manage_collapse_id }}"
+              >
+                <i class="bi bi-pencil"></i>
+                <span>Editar Horário</span>
+              </button>
+              <button
+                class="schedule-toolbar-btn schedule-toolbar-btn--success collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#newAppointmentForm"
+                aria-expanded="false"
+              >
+                <i class="bi bi-plus-circle"></i>
+                <span>Nova Consulta</span>
+              </button>
+              <button
+                class="schedule-toolbar-btn schedule-toolbar-btn--warning collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#vetNewTutorForm"
+                aria-expanded="false"
+                aria-controls="vetNewTutorForm"
+              >
+                <i class="bi bi-person-plus"></i>
+                <span>Novo Tutor</span>
+              </button>
+              <button
+                class="schedule-toolbar-btn schedule-toolbar-btn--primary collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#vetNewPetForm"
+                aria-expanded="false"
+                aria-controls="vetNewPetForm"
+              >
+                <i class="bi bi-plus-circle"></i>
+                <span>Novo Pet</span>
+              </button>
+            </div>
+          </nav>
         </div>
         <div
           class="collapse show"


### PR DESCRIPTION
## Summary
- replace the schedule header title with a gradient action toolbar that keeps only the quick buttons in the appointments views
- add reusable styles for colorful pill-shaped toolbar buttons and responsive behavior across screen sizes

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e52950c0e8832ea9503c67227094bf