### PR TITLE
Refine tutor DOB inputs with shared Flatpickr helper

### DIFF
--- a/static/js/dob_age_helper.js
+++ b/static/js/dob_age_helper.js
@@ -1,0 +1,204 @@
+(function(window) {
+  function queryElement(base, selectorOrElement) {
+    if (!selectorOrElement) return null;
+    if (selectorOrElement instanceof Element) return selectorOrElement;
+    if (typeof selectorOrElement === 'string') {
+      return base.querySelector(selectorOrElement);
+    }
+    return null;
+  }
+
+  function applyMask(value) {
+    const digits = value.replace(/\D/g, '');
+    let formatted = '';
+
+    if (digits.length > 0) {
+      formatted = digits.slice(0, 2);
+    }
+    if (digits.length >= 3) {
+      formatted += '/' + digits.slice(2, 4);
+    }
+    if (digits.length >= 5) {
+      formatted += '/' + digits.slice(4, 8);
+    }
+
+    return formatted;
+  }
+
+  function computeYearsFromDate(date) {
+    const today = new Date();
+    let years = today.getFullYear() - date.getFullYear();
+    const monthDiff = today.getMonth() - date.getMonth();
+
+    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < date.getDate())) {
+      years--;
+    }
+
+    return years;
+  }
+
+  function setupDobAgeSync(options = {}) {
+    const context = options.context || document;
+    const dobInput = options.dobInput || queryElement(context, options.dobSelector);
+
+    if (!dobInput) {
+      return null;
+    }
+
+    if (typeof window.flatpickr !== 'function') {
+      console.warn('setupDobAgeSync: flatpickr is required but was not found on window');
+      return null;
+    }
+
+    const ageInput = options.ageInput || queryElement(context, options.ageSelector);
+    const formatAge = typeof options.formatAge === 'function'
+      ? options.formatAge
+      : (years) => (years == null ? '' : String(years));
+    const onAgeUpdate = typeof options.onAgeUpdate === 'function' ? options.onAgeUpdate : null;
+    const allowAgeInput = options.allowAgeInput !== undefined
+      ? options.allowAgeInput
+      : Boolean(ageInput && !ageInput.disabled && !ageInput.readOnly);
+    const clampAge = options.clampAge !== undefined ? options.clampAge : true;
+
+    if (dobInput._flatpickr) {
+      dobInput._flatpickr.destroy();
+    }
+
+    const updateAge = (date) => {
+      const metadata = {
+        ageInput,
+        date: date || null,
+        rawYears: null,
+        years: null,
+      };
+
+      if (!date) {
+        if (ageInput) {
+          const formatted = formatAge(null, metadata);
+          if (formatted !== undefined) {
+            ageInput.value = formatted == null ? '' : String(formatted);
+          }
+        }
+        if (onAgeUpdate) {
+          onAgeUpdate(null, metadata);
+        }
+        return;
+      }
+
+      const rawYears = computeYearsFromDate(date);
+      const years = clampAge ? Math.max(rawYears, 0) : rawYears;
+      metadata.rawYears = rawYears;
+      metadata.years = years;
+
+      if (ageInput) {
+        const formatted = formatAge(years, metadata);
+        if (formatted !== undefined) {
+          ageInput.value = formatted == null ? '' : String(formatted);
+        }
+      }
+
+      if (onAgeUpdate) {
+        onAgeUpdate(years, metadata);
+      }
+    };
+
+    const picker = window.flatpickr(dobInput, {
+      locale: options.locale || 'pt',
+      dateFormat: options.dateFormat || 'Y-m-d',
+      altInput: options.altInput !== undefined ? options.altInput : true,
+      altFormat: options.altFormat || 'd/m/Y',
+      allowInput: options.allowInput !== undefined ? options.allowInput : true,
+      maxDate: options.maxDate !== undefined ? options.maxDate : 'today',
+      defaultDate: dobInput.value || options.defaultDate || null,
+      disableMobile: options.disableMobile !== undefined ? options.disableMobile : true,
+      onReady(selectedDates, _dateStr, instance) {
+        const alt = instance.altInput;
+        if (alt) {
+          alt.inputMode = 'numeric';
+          alt.autocomplete = 'off';
+          alt.placeholder = options.altPlaceholder || 'dd/mm/aaaa';
+
+          alt.addEventListener('input', () => {
+            const masked = applyMask(alt.value);
+            if (masked !== alt.value) {
+              alt.value = masked;
+              const newPosition = masked.length;
+              alt.setSelectionRange(newPosition, newPosition);
+            }
+          });
+
+          const syncTypedDate = () => {
+            const digits = alt.value.replace(/\D/g, '');
+            if (digits.length === 8) {
+              const day = digits.slice(0, 2);
+              const month = digits.slice(2, 4);
+              const year = digits.slice(4, 8);
+              instance.setDate(`${year}-${month}-${day}`, true, 'Y-m-d');
+            } else if (digits.length === 0) {
+              instance.clear();
+            }
+          };
+
+          alt.addEventListener('blur', syncTypedDate);
+          alt.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              syncTypedDate();
+              instance.close();
+            }
+          });
+        }
+
+        if (selectedDates.length) {
+          updateAge(selectedDates[0]);
+        } else if (dobInput.value) {
+          const parsed = instance.parseDate(dobInput.value, instance.config.dateFormat);
+          if (parsed) {
+            updateAge(parsed);
+          }
+        } else {
+          updateAge(null);
+        }
+      },
+      onChange(selectedDates) {
+        updateAge(selectedDates[0] || null);
+      },
+      onValueUpdate(selectedDates) {
+        if (!selectedDates.length) {
+          updateAge(null);
+        }
+      },
+      onClose(selectedDates) {
+        if (!selectedDates.length && !dobInput.value) {
+          updateAge(null);
+        }
+      },
+    });
+
+    if (ageInput && allowAgeInput) {
+      ageInput.addEventListener('input', () => {
+        const raw = parseInt(ageInput.value, 10);
+        if (Number.isNaN(raw)) {
+          return;
+        }
+        const clamped = clampAge ? Math.max(raw, 0) : raw;
+        const today = new Date();
+        const estimate = new Date(today.getFullYear() - clamped, today.getMonth(), today.getDate());
+        picker.setDate(estimate, true);
+      });
+    }
+
+    return {
+      picker,
+      updateAge,
+      clear() {
+        picker.clear();
+      },
+      destroy() {
+        picker.destroy();
+      },
+    };
+  }
+
+  window.setupDobAgeSync = setupDobAgeSync;
+})(window);

--- a/templates/animais/tutores.html
+++ b/templates/animais/tutores.html
@@ -81,6 +81,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
 <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
+<script src="{{ url_for('static', filename='js/dob_age_helper.js') }}"></script>
 
 <!-- Script geral -->
 <script>
@@ -154,105 +155,10 @@
   });
 
   // Flatpickr + Sincronização idade
-  const dobInput = document.getElementById("date_of_birth");
-  const ageInput = document.getElementById("age");
-
-  if (dobInput && ageInput) {
-    const atualizarIdade = (date) => {
-      if (!date) {
-        ageInput.value = "";
-        return;
-      }
-
-      const hoje = new Date();
-      let idade = hoje.getFullYear() - date.getFullYear();
-      const mes = hoje.getMonth() - date.getMonth();
-      if (mes < 0 || (mes === 0 && hoje.getDate() < date.getDate())) {
-        idade--;
-      }
-      ageInput.value = Math.max(idade, 0);
-    };
-
-    const aplicarMascaraData = (valor) => {
-      const digitos = valor.replace(/\D/g, "");
-      let formatado = "";
-
-      if (digitos.length > 0) {
-        formatado = digitos.slice(0, 2);
-      }
-      if (digitos.length >= 3) {
-        formatado += "/" + digitos.slice(2, 4);
-      }
-      if (digitos.length >= 5) {
-        formatado += "/" + digitos.slice(4, 8);
-      }
-
-      return formatado;
-    };
-
-    const sincronizarDataDigitada = (instance) => {
-      const altInput = instance.altInput;
-      if (!altInput) return;
-
-      const digitos = altInput.value.replace(/\D/g, "");
-      if (digitos.length === 8) {
-        const dia = digitos.slice(0, 2);
-        const mes = digitos.slice(2, 4);
-        const ano = digitos.slice(4, 8);
-        instance.setDate(`${ano}-${mes}-${dia}`, true, "Y-m-d");
-      } else if (digitos.length === 0) {
-        instance.clear();
-        atualizarIdade(null);
-      }
-    };
-
-    const picker = flatpickr(dobInput, {
-      locale: "pt",
-      dateFormat: "Y-m-d",       // valor REAL enviado ao backend
-      altInput: true,
-      altFormat: "d/m/Y",        // valor VISUAL ao usuário
-      allowInput: true,
-      onReady: function(selectedDates, dateStr, instance) {
-        const alt = instance.altInput;
-        if (!alt) return;
-
-        alt.addEventListener("input", () => {
-          const valorFormatado = aplicarMascaraData(alt.value);
-          if (valorFormatado !== alt.value) {
-            alt.value = valorFormatado;
-            // Ajusta o cursor ao final ao aplicar a máscara
-            alt.setSelectionRange(valorFormatado.length, valorFormatado.length);
-          }
-        });
-
-        const confirmarEntrada = () => sincronizarDataDigitada(instance);
-        alt.addEventListener("blur", confirmarEntrada);
-        alt.addEventListener("keydown", (event) => {
-          if (event.key === "Enter") {
-            event.preventDefault();
-            confirmarEntrada();
-            instance.close();
-          }
-        });
-
-        if (selectedDates.length) {
-          atualizarIdade(selectedDates[0]);
-        }
-      },
-      onChange: function(selectedDates) {
-        atualizarIdade(selectedDates[0]);
-      }
-    });
-
-    ageInput.addEventListener("input", () => {
-      const idade = parseInt(ageInput.value, 10);
-      if (Number.isNaN(idade)) {
-        return;
-      }
-
-      const hoje = new Date();
-      const dataEstimativa = new Date(hoje.getFullYear() - idade, hoje.getMonth(), hoje.getDate());
-      picker.setDate(dataEstimativa, true);
+  if (window.setupDobAgeSync) {
+    window.setupDobAgeSync({
+      dobSelector: '#date_of_birth',
+      ageSelector: '#age',
     });
   }
 </script>

--- a/templates/partials/tutor_form.html
+++ b/templates/partials/tutor_form.html
@@ -74,10 +74,10 @@
     <!-- Data de nascimento + Idade - Com cálculo automático -->
     <div class="col-md-6">
       <label for="tutor-date-of-birth" class="form-label">Data de Nascimento</label>
-      <input type="date" id="tutor-date-of-birth" name="date_of_birth" 
-            class="form-control" max="{{ '%Y-%m-%d' | date_now }}"
+      <input type="text" id="tutor-date-of-birth" name="date_of_birth"
+            class="form-control"
             value="{{ tutor.date_of_birth.strftime('%Y-%m-%d') if has_tutor and tutor.date_of_birth else '' }}"
-            onchange="calcularIdade()">
+            placeholder="dd/mm/aaaa" autocomplete="off">
       <div class="invalid-feedback">Por favor, insira uma data válida</div>
     </div>
 
@@ -129,6 +129,10 @@
 
 <!-- Scripts Aprimorados -->
 {% block scripts %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/pt.js"></script>
+<script src="{{ url_for('static', filename='js/dob_age_helper.js') }}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     // Validação do formulário
@@ -158,28 +162,20 @@
       this.value = this.value.replace(/[^0-9A-Za-z]/g, '');
     });
 
-    // Cálculo de idade
-    function calcularIdadeTutor() {
-      const dataNasc = document.getElementById('tutor-date-of-birth').value;
-      const idadeInput = document.getElementById('tutor-age');
-      
-      if (dataNasc) {
-        const hoje = new Date();
-        const nascimento = new Date(dataNasc);
-        let idade = hoje.getFullYear() - nascimento.getFullYear();
-        const mes = hoje.getMonth() - nascimento.getMonth();
-        
-        if (mes < 0 || (mes === 0 && hoje.getDate() < nascimento.getDate())) {
-          idade--;
-        }
-        
-        idadeInput.value = `${idade} anos`;
-      } else {
-        idadeInput.value = '';
-      }
+    if (window.setupDobAgeSync) {
+      window.setupDobAgeSync({
+        dobSelector: '#tutor-date-of-birth',
+        ageSelector: '#tutor-age',
+        allowAgeInput: false,
+        formatAge: (years) => {
+          if (years == null) {
+            return '';
+          }
+          const label = years === 1 ? 'ano' : 'anos';
+          return `${years} ${label}`;
+        },
+      });
     }
-
-    document.getElementById('tutor-date-of-birth')?.addEventListener('change', calcularIdadeTutor);
 
     // Preview da imagem
 
@@ -275,35 +271,6 @@
     console.log(`Tutor selecionado: ${nome} (${email})`);
   }
 
-  function calcularIdade() {
-    const dataNascimento = document.getElementById('tutor-date-of-birth').value;
-    const campoIdade = document.getElementById('tutor-age');
-    
-    if (dataNascimento) {
-      const hoje = new Date();
-      const nascimento = new Date(dataNascimento);
-      let idade = hoje.getFullYear() - nascimento.getFullYear();
-      
-      // Ajuste para caso ainda não tenha feito aniversário este ano
-      const mesAtual = hoje.getMonth();
-      const mesNascimento = nascimento.getMonth();
-      
-      if (mesNascimento > mesAtual || 
-          (mesNascimento === mesAtual && hoje.getDate() < nascimento.getDate())) {
-        idade--;
-      }
-      
-      campoIdade.value = idade + " anos";
-    } else {
-      campoIdade.value = "";
-    }
-  }
-
-  // Calcular idade ao carregar a página se já existir data
-  document.addEventListener('DOMContentLoaded', function() {
-    if (document.getElementById('tutor-date-of-birth').value) {
-      calcularIdade();
-    }
-  });
+  
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create a reusable `setupDobAgeSync` helper that wires masked Flatpickr inputs to age displays
- migrate the shared tutor form to the helper so the birth date uses the same masked picker as /tutores
- update the /tutores page to reuse the helper rather than keeping its bespoke Flatpickr logic

## Testing
- pytest *(fails: tests/test_vacinas.py::test_alterar_vacina_cria_proxima_dose, tests/test_vacinas.py::test_vaccine_appointments_visible_to_collaborator, tests/test_vet_pending_exam_status.py::test_confirmed_requested_exam_visible_with_status_badge, tests/test_vet_pending_exam_status.py::test_exam_default_deadline_attributes_present)*

------
https://chatgpt.com/codex/tasks/task_e_68e528cad474832e9bf7e592f63b4e97