### PR TITLE
Improve vet schedule inline editing flow

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -803,7 +803,7 @@
                 <button
                   class="btn btn-sm btn-outline-primary"
                   data-schedule-edit-toggle
-                  onclick="toggleScheduleEdit()"
+                  onclick="toggleScheduleEdit(event)"
                 >
                   <i class="fas fa-edit me-1"></i>Editar horários
                 </button>


### PR DESCRIPTION
## Summary
- update the schedule edit toggle to rely on the enhanced JavaScript handler that opens the inline form
- extend the vet schedule script with helpers to focus the form, manage inline/modal visibility, and expose a cleaner toggle flow
- adjust collapse listeners to exit edit mode consistently and only reset the form when leaving editing

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e52e837568832e98f99a3fbb539229