### PR TITLE
Style schedule controls with toolbar-inspired buttons

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -121,6 +121,316 @@
   --schedule-btn-shadow: rgba(124, 58, 237, 0.45);
 }
 
+.schedule-action-btn {
+  --schedule-action-border: rgba(148, 163, 184, 0.45);
+  --schedule-action-bg: rgba(255, 255, 255, 0.86);
+  --schedule-action-color: #1f2937;
+  --schedule-action-hover-bg: rgba(15, 23, 42, 0.08);
+  --schedule-action-hover-color: #111827;
+  --schedule-action-focus-ring: rgba(37, 99, 235, 0.28);
+  --schedule-action-shadow: rgba(15, 23, 42, 0.28);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: 1.5px solid var(--schedule-action-border);
+  background: var(--schedule-action-bg);
+  color: var(--schedule-action-color);
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+  padding: 0.45rem 1.15rem;
+  box-shadow: 0 12px 28px -22px var(--schedule-action-shadow);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.2s ease, border-color 0.2s ease;
+  text-decoration: none;
+}
+
+.schedule-action-btn:hover,
+.schedule-action-btn:focus {
+  background: var(--schedule-action-hover-bg);
+  color: var(--schedule-action-hover-color);
+  box-shadow: 0 16px 32px -20px var(--schedule-action-shadow);
+  transform: translateY(-1px);
+}
+
+.schedule-action-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 0.22rem var(--schedule-action-focus-ring),
+    0 16px 32px -20px var(--schedule-action-shadow);
+}
+
+.schedule-action-btn:disabled,
+.schedule-action-btn[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
+}
+
+.schedule-action-btn .bi,
+.schedule-action-btn i,
+.schedule-action-btn svg {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.schedule-action-btn--sm {
+  font-size: 0.82rem;
+  padding: 0.35rem 0.9rem;
+  gap: 0.4rem;
+}
+
+.schedule-action-btn--primary {
+  --schedule-action-border: rgba(37, 99, 235, 0.32);
+  --schedule-action-bg: rgba(37, 99, 235, 0.12);
+  --schedule-action-hover-bg: rgba(37, 99, 235, 0.18);
+  --schedule-action-color: #1d4ed8;
+  --schedule-action-hover-color: #1e40af;
+  --schedule-action-focus-ring: rgba(37, 99, 235, 0.35);
+  --schedule-action-shadow: rgba(37, 99, 235, 0.45);
+}
+
+.schedule-action-btn--muted {
+  --schedule-action-border: rgba(100, 116, 139, 0.4);
+  --schedule-action-bg: rgba(241, 245, 249, 0.8);
+  --schedule-action-hover-bg: rgba(148, 163, 184, 0.22);
+  --schedule-action-color: #475569;
+  --schedule-action-hover-color: #1f2937;
+  --schedule-action-focus-ring: rgba(100, 116, 139, 0.32);
+  --schedule-action-shadow: rgba(100, 116, 139, 0.35);
+}
+
+.schedule-action-btn--success {
+  --schedule-action-border: rgba(16, 185, 129, 0.32);
+  --schedule-action-bg: rgba(16, 185, 129, 0.12);
+  --schedule-action-hover-bg: rgba(16, 185, 129, 0.18);
+  --schedule-action-color: #059669;
+  --schedule-action-hover-color: #047857;
+  --schedule-action-focus-ring: rgba(16, 185, 129, 0.28);
+  --schedule-action-shadow: rgba(16, 185, 129, 0.35);
+}
+
+.schedule-action-btn--danger {
+  --schedule-action-border: rgba(248, 113, 113, 0.35);
+  --schedule-action-bg: rgba(248, 113, 113, 0.14);
+  --schedule-action-hover-bg: rgba(248, 113, 113, 0.2);
+  --schedule-action-color: #dc2626;
+  --schedule-action-hover-color: #b91c1c;
+  --schedule-action-focus-ring: rgba(239, 68, 68, 0.3);
+  --schedule-action-shadow: rgba(239, 68, 68, 0.35);
+}
+
+.schedule-action-btn--dark {
+  --schedule-action-border: rgba(30, 41, 59, 0.45);
+  --schedule-action-bg: rgba(30, 41, 59, 0.12);
+  --schedule-action-hover-bg: rgba(30, 41, 59, 0.2);
+  --schedule-action-color: #111827;
+  --schedule-action-hover-color: #0f172a;
+  --schedule-action-focus-ring: rgba(30, 41, 59, 0.28);
+  --schedule-action-shadow: rgba(30, 41, 59, 0.38);
+}
+
+.schedule-action-btn.is-active {
+  --schedule-action-border: rgba(79, 70, 229, 0.65);
+  --schedule-action-bg: linear-gradient(135deg, #6366f1 0%, #2563eb 100%);
+  --schedule-action-hover-bg: linear-gradient(135deg, #4f46e5 0%, #1d4ed8 100%);
+  --schedule-action-color: #ffffff;
+  --schedule-action-hover-color: #f8fafc;
+  --schedule-action-shadow: rgba(79, 70, 229, 0.5);
+}
+
+.schedule-action-btn.is-active .bi,
+.schedule-action-btn.is-active i,
+.schedule-action-btn.is-active svg {
+  color: inherit;
+}
+
+.schedule-chip {
+  --schedule-chip-bg: rgba(148, 163, 184, 0.18);
+  --schedule-chip-color: #334155;
+  --schedule-chip-border: rgba(148, 163, 184, 0.28);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  background: var(--schedule-chip-bg);
+  color: var(--schedule-chip-color);
+  border: 1px solid var(--schedule-chip-border);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  line-height: 1.1;
+  white-space: nowrap;
+  backdrop-filter: blur(6px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.schedule-chip .bi,
+.schedule-chip i,
+.schedule-chip svg {
+  font-size: 0.95rem;
+}
+
+.schedule-chip--light {
+  --schedule-chip-bg: rgba(241, 245, 249, 0.7);
+  --schedule-chip-color: #0f172a;
+  --schedule-chip-border: rgba(148, 163, 184, 0.3);
+}
+
+.schedule-chip--muted {
+  --schedule-chip-bg: rgba(148, 163, 184, 0.18);
+  --schedule-chip-color: #475569;
+  --schedule-chip-border: rgba(148, 163, 184, 0.32);
+}
+
+.schedule-chip--info {
+  --schedule-chip-bg: rgba(56, 189, 248, 0.18);
+  --schedule-chip-color: #075985;
+  --schedule-chip-border: rgba(56, 189, 248, 0.32);
+}
+
+.schedule-chip--success {
+  --schedule-chip-bg: rgba(16, 185, 129, 0.18);
+  --schedule-chip-color: #047857;
+  --schedule-chip-border: rgba(16, 185, 129, 0.32);
+}
+
+.schedule-chip--warning {
+  --schedule-chip-bg: rgba(245, 158, 11, 0.2);
+  --schedule-chip-color: #92400e;
+  --schedule-chip-border: rgba(245, 158, 11, 0.35);
+}
+
+.schedule-chip--danger {
+  --schedule-chip-bg: rgba(248, 113, 113, 0.22);
+  --schedule-chip-color: #b91c1c;
+  --schedule-chip-border: rgba(248, 113, 113, 0.35);
+}
+
+.schedule-chip--dark {
+  --schedule-chip-bg: rgba(15, 23, 42, 0.22);
+  --schedule-chip-color: #e2e8f0;
+  --schedule-chip-border: rgba(15, 23, 42, 0.45);
+}
+
+.schedule-chip--outline {
+  --schedule-chip-bg: rgba(255, 255, 255, 0.05);
+  --schedule-chip-color: #1f2937;
+  --schedule-chip-border: rgba(148, 163, 184, 0.32);
+}
+
+.schedule-chip--subtle {
+  --schedule-chip-bg: rgba(255, 255, 255, 0.7);
+  --schedule-chip-color: #1f2937;
+  --schedule-chip-border: rgba(203, 213, 225, 0.65);
+}
+
+.schedule-chip + .schedule-chip {
+  margin-left: 0.35rem;
+}
+
+.schedule-slot {
+  --schedule-slot-bg: rgba(255, 255, 255, 0.82);
+  --schedule-slot-border: rgba(148, 163, 184, 0.28);
+  --schedule-slot-color: #1f2937;
+  --schedule-slot-hover-bg: rgba(37, 99, 235, 0.16);
+  --schedule-slot-hover-color: #1d4ed8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1.5px solid var(--schedule-slot-border);
+  background: var(--schedule-slot-bg);
+  color: var(--schedule-slot-color);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease;
+  text-decoration: none;
+  box-shadow: 0 10px 24px -22px rgba(15, 23, 42, 0.28);
+}
+
+.schedule-slot .bi,
+.schedule-slot i,
+.schedule-slot svg {
+  font-size: 1.05rem;
+}
+
+.schedule-slot:hover,
+.schedule-slot:focus {
+  background: var(--schedule-slot-hover-bg);
+  color: var(--schedule-slot-hover-color);
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px -18px rgba(37, 99, 235, 0.28);
+}
+
+.schedule-slot:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.28),
+    0 14px 28px -18px rgba(37, 99, 235, 0.28);
+}
+
+.schedule-slot:disabled,
+.schedule-slot[aria-disabled="true"] {
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.schedule-slot--available {
+  --schedule-slot-border: rgba(16, 185, 129, 0.35);
+  --schedule-slot-bg: rgba(16, 185, 129, 0.12);
+  --schedule-slot-hover-bg: rgba(16, 185, 129, 0.18);
+  --schedule-slot-color: #047857;
+  --schedule-slot-hover-color: #065f46;
+}
+
+.schedule-slot--booked {
+  --schedule-slot-border: rgba(248, 113, 113, 0.4);
+  --schedule-slot-bg: rgba(248, 113, 113, 0.18);
+  --schedule-slot-color: #b91c1c;
+  --schedule-slot-hover-bg: rgba(248, 113, 113, 0.22);
+  --schedule-slot-hover-color: #991b1b;
+  opacity: 0.7;
+}
+
+.schedule-slot--blocked {
+  --schedule-slot-border: rgba(148, 163, 184, 0.35);
+  --schedule-slot-bg: rgba(226, 232, 240, 0.8);
+  --schedule-slot-color: #475569;
+  --schedule-slot-hover-bg: rgba(203, 213, 225, 0.6);
+  --schedule-slot-hover-color: #334155;
+  opacity: 0.65;
+}
+
+.schedule-slot--booked:hover,
+.schedule-slot--booked:focus,
+.schedule-slot--blocked:hover,
+.schedule-slot--blocked:focus {
+  transform: none;
+}
+
+.schedule-slot--selected {
+  --schedule-slot-bg: linear-gradient(135deg, #34d399 0%, #059669 100%);
+  --schedule-slot-border: rgba(5, 150, 105, 0.65);
+  --schedule-slot-color: #ffffff;
+  --schedule-slot-hover-bg: linear-gradient(135deg, #22c55e 0%, #047857 100%);
+  --schedule-slot-hover-color: #f8fafc;
+  box-shadow: 0 16px 28px -16px rgba(5, 150, 105, 0.5);
+}
+
+.schedule-slot--selected .bi,
+.schedule-slot--selected i,
+.schedule-slot--selected svg {
+  color: inherit;
+}
+
 @media (max-width: 576px) {
   .schedule-toolbar {
     padding: 1rem 1.1rem;

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -140,7 +140,7 @@
                 ></span>
               </h6>
               <span
-                class="badge rounded-pill text-bg-light small fw-normal"
+                class="schedule-chip schedule-chip--subtle"
                 data-schedule-summary
                 aria-live="polite"
               >
@@ -148,22 +148,22 @@
               </span>
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-auto">
-              <div class="d-flex align-items-center gap-2 small text-muted" data-schedule-legend>
-                <span class="d-inline-flex align-items-center gap-1">
-                  <i class="bi bi-check-circle-fill text-success"></i>
+              <div class="d-flex align-items-center flex-wrap gap-2" data-schedule-legend>
+                <span class="schedule-chip schedule-chip--success">
+                  <i class="bi bi-check-circle-fill"></i>
                   Disponível
                 </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-x-circle-fill text-danger"></i>
+                <span class="schedule-chip schedule-chip--danger">
+                  <i class="bi bi-x-circle-fill"></i>
                   Indisponível
                 </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-slash-circle-fill text-secondary"></i>
+                <span class="schedule-chip schedule-chip--muted">
+                  <i class="bi bi-slash-circle-fill"></i>
                   Fora do expediente
                 </span>
               </div>
               <button
-                class="btn btn-outline-primary btn-sm"
+                class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#scheduleOverviewCollapse"
@@ -184,31 +184,33 @@
               </span>
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2 ms-xl-auto">
-              <div class="btn-group btn-group-sm" role="group" aria-label="Navegação da agenda semanal">
+              <div class="d-flex flex-wrap align-items-center gap-2" role="group" aria-label="Navegação da agenda semanal">
                 <button
                   type="button"
-                  class="btn btn-outline-secondary"
+                  class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"
                   data-schedule-week-prev
                   aria-label="Semana anterior"
                 >
                   <i class="bi bi-chevron-left"></i>
-                  <span class="d-none d-sm-inline ms-1">Semana anterior</span>
+                  <span class="d-none d-sm-inline">Semana anterior</span>
                 </button>
                 <button
                   type="button"
-                  class="btn btn-outline-secondary"
+                  class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"
                   data-schedule-week-today
                   aria-label="Ir para semana atual"
                 >
-                  Hoje
+                  <i class="bi bi-calendar-week"></i>
+                  <span class="d-none d-sm-inline">Hoje</span>
+                  <span class="d-sm-none">Hoje</span>
                 </button>
                 <button
                   type="button"
-                  class="btn btn-outline-secondary"
+                  class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"
                   data-schedule-week-next
                   aria-label="Próxima semana"
                 >
-                  <span class="d-none d-sm-inline me-1">Próxima semana</span>
+                  <span class="d-none d-sm-inline">Próxima semana</span>
                   <i class="bi bi-chevron-right"></i>
                 </button>
               </div>
@@ -356,7 +358,7 @@
                 </div>
                 <div class="mt-4">
                   <button
-                    class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2"
+                    class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"
                     type="button"
                     data-bs-toggle="collapse"
                     data-bs-target="#scheduleIntervalCollapse"
@@ -406,7 +408,7 @@
           <i class="bi bi-shield-check me-1"></i>Alterações salvas atualizam instantaneamente o portal de agendamentos.
         </div>
         <div class="d-flex gap-2">
-          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="button" class="schedule-action-btn schedule-action-btn--muted" data-bs-dismiss="modal">Cancelar</button>
           <button
             type="submit"
             form="schedule-edit-form"
@@ -1018,7 +1020,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function createSlotButton(time, status, { date }) {
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'btn btn-sm rounded-pill d-inline-flex align-items-center gap-1 schedule-slot flex-shrink-0';
+      button.className = 'schedule-slot flex-shrink-0';
       button.dataset.scheduleSlot = time;
       button.dataset.scheduleDate = date;
       button.dataset.scheduleStatus = status;
@@ -1026,19 +1028,19 @@ document.addEventListener('DOMContentLoaded', () => {
       let iconClass = 'bi-clock';
       if (status === 'available') {
         iconClass = 'bi-check-circle';
-        button.classList.add('btn-outline-success');
+        button.classList.add('schedule-slot--available');
         button.setAttribute('aria-pressed', 'false');
         button.dataset.schedulePeriod = getPeriodFromTime(time);
         button.title = 'Selecionar horário disponível';
       } else if (status === 'booked') {
         iconClass = 'bi-x-circle';
-        button.classList.add('btn-outline-danger', 'opacity-75');
+        button.classList.add('schedule-slot--booked');
         button.disabled = true;
         button.setAttribute('aria-disabled', 'true');
         button.title = 'Horário indisponível';
       } else {
         iconClass = 'bi-slash-circle';
-        button.classList.add('btn-outline-secondary', 'opacity-75');
+        button.classList.add('schedule-slot--blocked');
         button.disabled = true;
         button.setAttribute('aria-disabled', 'true');
         button.title = 'Fora do expediente';
@@ -1071,9 +1073,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
         const isSelected = selectedScheduleSlotKey === button.dataset.scheduleSlotKey;
-        button.classList.toggle('btn-outline-success', !isSelected);
-        button.classList.toggle('btn-success', isSelected);
-        button.classList.toggle('text-white', isSelected);
+        button.classList.toggle('schedule-slot--selected', isSelected);
         button.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
       });
       const cards = scheduleContainer.querySelectorAll('[data-schedule-day]');

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -141,7 +141,7 @@
             <div class="d-flex flex-column gap-4">
               <button
                 type="button"
-                class="btn btn-outline-primary align-self-start d-inline-flex align-items-center gap-2"
+                class="schedule-action-btn schedule-action-btn--primary align-self-start"
                 id="agenda-filter-toggle"
                 aria-controls="agenda-filter-card"
                 aria-expanded="false"
@@ -192,26 +192,26 @@
                       <button class="btn btn-primary flex-fill">
                         <i class="fas fa-search me-1"></i>Aplicar Filtro
                       </button>
-                      <button type="button" class="btn btn-outline-secondary flex-fill" data-action="clear-dates">
+                      <button type="button" class="schedule-action-btn schedule-action-btn--muted flex-fill" data-action="clear-dates">
                         <i class="fas fa-undo me-1"></i>Limpar
                       </button>
                     </div>
                     <div class="col-12">
                       <div class="d-flex flex-wrap gap-2">
                         <span class="text-muted me-2 align-self-center small fw-semibold text-uppercase">Atalhos rápidos:</span>
-                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="today">
+                        <button type="button" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm" data-range="today">
                           <i class="fas fa-sun me-1"></i>Hoje
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="tomorrow">
+                        <button type="button" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm" data-range="tomorrow">
                           <i class="fas fa-sunrise me-1"></i>Amanhã
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="week">
+                        <button type="button" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm" data-range="week">
                           <i class="fas fa-calendar-week me-1"></i>Semana Atual
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="next7">
+                        <button type="button" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm" data-range="next7">
                           <i class="fas fa-calendar-plus me-1"></i>Próximos 7 dias
                         </button>
-                        <button type="button" class="btn btn-sm btn-outline-primary" data-range="month">
+                        <button type="button" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm" data-range="month">
                           <i class="fas fa-calendar-alt me-1"></i>Mês Atual
                         </button>
                       </div>
@@ -487,8 +487,8 @@
                               </div>
                             </div>
                             <div class="btn-group">
-                              <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                              <a href="{{ url_for('ficha_tutor', tutor_id=appt.animal.owner.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                              <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                              <a href="{{ url_for('ficha_tutor', tutor_id=appt.animal.owner.id) }}" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"><i class="fas fa-user me-1"></i>Tutor</a>
                             </div>
                           </div>
                         </div>
@@ -539,9 +539,9 @@
                               </div>
                             </div>
                             <div class="btn-group">
-                              <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                              <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
-                              <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
+                              <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                              <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"><i class="fas fa-user me-1"></i>Tutor</a>
+                              <a href="{{ url_for('consulta_direct', animal_id=appt.animal_id, appointment_id=appt.id) }}" class="schedule-action-btn schedule-action-btn--success schedule-action-btn--sm"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
                             </div>
                           </div>
                         </div>
@@ -606,8 +606,8 @@
                             </div>
                             <div class="d-flex flex-column align-items-end gap-2">
                               <div class="btn-group">
-                                <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
-                                <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                                <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                                <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"><i class="fas fa-user me-1"></i>Tutor</a>
                               </div>
                               <span class="badge bg-success"><i class="fas fa-check me-1"></i>{{ status_label }}</span>
                             </div>
@@ -673,13 +673,13 @@
                           </div>
                           <div class="d-flex flex-column align-items-end gap-2">
                             <div class="btn-group">
-                              <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                              <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"><i class="fas fa-file-medical me-1"></i>Ficha</a>
                               {% if tutor %}
-                              <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                              <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"><i class="fas fa-user me-1"></i>Tutor</a>
                               {% endif %}
-                              <a href="{{ url_for('consulta_direct', animal_id=animal.id, c=consulta.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-stethoscope me-1"></i>Detalhes</a>
+                              <a href="{{ url_for('consulta_direct', animal_id=animal.id, c=consulta.id) }}" class="schedule-action-btn schedule-action-btn--success schedule-action-btn--sm"><i class="fas fa-stethoscope me-1"></i>Detalhes</a>
                             </div>
-                            <a href="{{ url_for('imprimir_consulta', consulta_id=consulta.id) }}" class="btn btn-sm btn-outline-dark" target="_blank"><i class="fas fa-print me-1"></i>Imprimir consulta</a>
+                            <a href="{{ url_for('imprimir_consulta', consulta_id=consulta.id) }}" class="schedule-action-btn schedule-action-btn--dark schedule-action-btn--sm" target="_blank"><i class="fas fa-print me-1"></i>Imprimir consulta</a>
                           </div>
                         </div>
                       </div>
@@ -695,11 +695,11 @@
                             <span class="badge bg-secondary mt-1">Consulta aceita e não finalizada</span>
                           </div>
                           <div class="btn-group">
-                            <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                            <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"><i class="fas fa-file-medical me-1"></i>Ficha</a>
                             {% if tutor %}
-                            <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                            <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"><i class="fas fa-user me-1"></i>Tutor</a>
                             {% endif %}
-                            <a href="{{ url_for('consulta_direct', animal_id=animal.id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
+                            <a href="{{ url_for('consulta_direct', animal_id=animal.id, appointment_id=appt.id) }}" class="schedule-action-btn schedule-action-btn--success schedule-action-btn--sm"><i class="fas fa-play-circle me-1"></i>Iniciar</a>
                           </div>
                         </div>
                       </div>
@@ -726,11 +726,11 @@
                           <small class="text-muted d-block">Consulta de origem: #{{ event.consulta_id }}</small>
                         </div>
                         <div class="btn-group">
-                          <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                          <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"><i class="fas fa-file-medical me-1"></i>Ficha</a>
                           {% if tutor %}
-                          <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                          <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"><i class="fas fa-user me-1"></i>Tutor</a>
                           {% endif %}
-                          <a href="{{ url_for('consulta_direct', animal_id=animal.id, appointment_id=appt.id) }}" class="btn btn-sm btn-outline-success"><i class="fas fa-redo me-1"></i>Abrir retorno</a>
+                          <a href="{{ url_for('consulta_direct', animal_id=animal.id, appointment_id=appt.id) }}" class="schedule-action-btn schedule-action-btn--success schedule-action-btn--sm"><i class="fas fa-redo me-1"></i>Abrir retorno</a>
                         </div>
                       </div>
                     </div>
@@ -758,9 +758,9 @@
                           <small class="text-muted d-block">Status: {{ exam.status_display }}</small>
                         </div>
                         <div class="btn-group">
-                          <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
+                          <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"><i class="fas fa-file-medical me-1"></i>Ficha</a>
                           {% if tutor %}
-                          <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
+                          <a href="{{ url_for('ficha_tutor', tutor_id=tutor.id) }}" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm"><i class="fas fa-user me-1"></i>Tutor</a>
                           {% endif %}
                         </div>
                       </div>
@@ -801,7 +801,7 @@
               <div class="card-header bg-light d-flex justify-content-between align-items-center">
                 <h5 class="mb-0"><i class="fas fa-business-time me-2"></i>Horários Cadastrados</h5>
                 <button
-                  class="btn btn-sm btn-outline-primary"
+                  class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"
                   data-schedule-edit-toggle
                   onclick="toggleScheduleEdit()"
                 >
@@ -831,7 +831,7 @@
                     <div class="d-flex justify-content-end gap-2">
                       <button
                         type="button"
-                        class="btn btn-outline-secondary"
+                        class="schedule-action-btn schedule-action-btn--muted"
                         onclick="toggleScheduleForm('close-inline')"
                       >
                         Cancelar
@@ -866,7 +866,7 @@
                               <div class="schedule-actions d-none">
                                 <button
                                   type="button"
-                                  class="btn btn-sm btn-outline-primary edit-btn"
+                                  class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm edit-btn"
                                   data-id="{{ h.id }}"
                                   data-dia="{{ h.dia_semana }}"
                                   data-hora-inicio="{{ h.hora_inicio.strftime('%H:%M') }}"
@@ -885,7 +885,7 @@
                                   {{ schedule_form.csrf_token }}
                                   <button
                                     type="submit"
-                                    class="btn btn-sm btn-outline-danger"
+                                    class="schedule-action-btn schedule-action-btn--danger schedule-action-btn--sm"
                                     onclick="return confirm('Excluir este horário?');"
                                   >
                                     <i class="fas fa-trash"></i>
@@ -978,7 +978,7 @@
                 ></span>
               </h6>
               <span
-                class="badge rounded-pill text-bg-light small fw-normal"
+                class="schedule-chip schedule-chip--subtle"
                 data-schedule-summary
                 aria-live="polite"
               >
@@ -986,22 +986,22 @@
               </span>
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-auto">
-              <div class="d-flex align-items-center gap-2 small text-muted" data-schedule-legend>
-                <span class="d-inline-flex align-items-center gap-1">
-                  <i class="bi bi-check-circle-fill text-success"></i>
+              <div class="d-flex align-items-center flex-wrap gap-2" data-schedule-legend>
+                <span class="schedule-chip schedule-chip--success">
+                  <i class="bi bi-check-circle-fill"></i>
                   Disponível
                 </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-x-circle-fill text-danger"></i>
+                <span class="schedule-chip schedule-chip--danger">
+                  <i class="bi bi-x-circle-fill"></i>
                   Indisponível
                 </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-slash-circle-fill text-secondary"></i>
+                <span class="schedule-chip schedule-chip--muted">
+                  <i class="bi bi-slash-circle-fill"></i>
                   Fora do expediente
                 </span>
               </div>
               <button
-                class="btn btn-outline-primary btn-sm"
+                class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm"
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#scheduleOverviewCollapse"
@@ -1022,16 +1022,18 @@
               </span>
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2 ms-xl-auto">
-              <div class="btn-group btn-group-sm" role="group" aria-label="Navegação da agenda semanal">
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-prev>
+              <div class="d-flex flex-wrap align-items-center gap-2" role="group" aria-label="Navegação da agenda semanal">
+                <button type="button" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm" data-schedule-week-prev>
                   <i class="bi bi-chevron-left"></i>
-                  <span class="d-none d-sm-inline ms-1">Semana anterior</span>
+                  <span class="d-none d-sm-inline">Semana anterior</span>
                 </button>
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-today>
-                  Hoje
+                <button type="button" class="schedule-action-btn schedule-action-btn--primary schedule-action-btn--sm" data-schedule-week-today>
+                  <i class="bi bi-calendar-week"></i>
+                  <span class="d-none d-sm-inline">Hoje</span>
+                  <span class="d-sm-none">Hoje</span>
                 </button>
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-next>
-                  <span class="d-none d-sm-inline me-1">Próxima semana</span>
+                <button type="button" class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm" data-schedule-week-next>
+                  <span class="d-none d-sm-inline">Próxima semana</span>
                   <i class="bi bi-chevron-right"></i>
                 </button>
               </div>
@@ -1199,9 +1201,9 @@
           </div>
         </div>
         <div class="modal-footer">
-          <a id="modal-animal-link" class="btn btn-outline-primary" target="_blank"><i class="fas fa-file-medical me-1"></i>Ficha Animal</a>
-          <a id="modal-tutor-link" class="btn btn-outline-secondary" target="_blank"><i class="fas fa-user me-1"></i>Ficha Tutor</a>
-          <a id="modal-consulta-link" class="btn btn-outline-success" target="_blank"><i class="fas fa-play-circle me-1"></i>Iniciar Consulta</a>
+          <a id="modal-animal-link" class="schedule-action-btn schedule-action-btn--primary" target="_blank"><i class="fas fa-file-medical me-1"></i>Ficha Animal</a>
+          <a id="modal-tutor-link" class="schedule-action-btn schedule-action-btn--muted" target="_blank"><i class="fas fa-user me-1"></i>Ficha Tutor</a>
+          <a id="modal-consulta-link" class="schedule-action-btn schedule-action-btn--success" target="_blank"><i class="fas fa-play-circle me-1"></i>Iniciar Consulta</a>
           <button type="button" class="btn btn-primary" id="modal-save-btn">Salvar Alterações</button>
         </div>
       </div>
@@ -1241,7 +1243,7 @@
               </div>
               <button
                 type="button"
-                class="btn btn-outline-secondary btn-sm w-100 w-lg-auto mt-2 mt-lg-0"
+                class="schedule-action-btn schedule-action-btn--muted schedule-action-btn--sm w-100 w-lg-auto mt-2 mt-lg-0"
                 id="exam-requester-apply-default"
               >
                 <i class="bi bi-arrow-clockwise me-1"></i>Aplicar padrão
@@ -1258,7 +1260,7 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Fechar</button>
+          <button type="button" class="schedule-action-btn schedule-action-btn--muted" data-bs-dismiss="modal">Fechar</button>
           <button type="button" class="btn btn-primary" id="exam-requester-save">Salvar alterações</button>
         </div>
       </div>
@@ -1359,8 +1361,9 @@
             label.textContent = visible ? hideLabel : showLabel;
           }
 
-          filterToggle.classList.toggle('btn-primary', visible);
-          filterToggle.classList.toggle('btn-outline-primary', !visible);
+          filterToggle.classList.toggle('schedule-action-btn--primary', visible);
+          filterToggle.classList.toggle('schedule-action-btn--muted', !visible);
+          filterToggle.classList.toggle('is-active', visible);
         };
 
         const applyFilterVisibility = (visible, { persist = false } = {}) => {
@@ -1510,9 +1513,9 @@
       const setActiveRange = (range) => {
         quickButtons.forEach((button) => {
           const isActive = button.dataset.range === range;
-          button.classList.toggle('btn-primary', isActive);
-          button.classList.toggle('btn-outline-primary', !isActive);
-          button.classList.toggle('text-white', isActive);
+          button.classList.toggle('schedule-action-btn--primary', isActive);
+          button.classList.toggle('schedule-action-btn--muted', !isActive);
+          button.classList.toggle('is-active', isActive);
           button.classList.toggle('active', isActive);
           button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
         });


### PR DESCRIPTION
## Summary
- add pill-shaped schedule action button, chip, and slot styles derived from the toolbar palette
- restyle appointment legend, weekly navigation, and slot rendering to use the new schedule action and chip variants
- update the vet schedule editor buttons, quick filters, and scripts to adopt the new styling and active-state handling

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e52e71b8c4832eb0229a5f75efc9d9