### PR TITLE
Refactor new pet panel for appointments reuse

### DIFF
--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -1078,15 +1078,13 @@
     <div class="collapse" id="vetNewPetForm" data-bs-parent="#{{ schedule_collapse_group_id }}">
       <div class="card-body bg-light p-4 h-100">
         <div class="row justify-content-center align-items-stretch h-100">
-          <div class="col-lg-10 col-xl-8 col-xxl-7 h-100">
+          <div class="col-12 col-xl-11 col-xxl-10 h-100">
             <div class="card shadow-lg border-0 rounded-4 overflow-hidden h-100">
               <div class="card-body p-4 p-lg-5 d-flex flex-column h-100">
-                <div class="text-center text-md-start mb-4">
-                  <h3 class="fw-semibold mb-2">🐾 Cadastrar novo pet</h3>
-                  <p class="text-muted mb-0">Preencha as informações do animal para vinculá-lo rapidamente ao tutor.</p>
-                </div>
-                {% with species_list=species_list, breed_list=breed_list %}
-                  {% include 'partials/animal_register_form.html' %}
+                {% with animais_adicionados=vet_animais_adicionados,
+                        pagination=vet_animais_pagination,
+                        scope=vet_animais_scope %}
+                  {% include 'partials/novo_pet_panel.html' %}
                 {% endwith %}
               </div>
             </div>

--- a/templates/animais/novo_animal.html
+++ b/templates/animais/novo_animal.html
@@ -2,27 +2,6 @@
 
 {% block main %}
   <div class="container-fluid py-4">
-    <div class="row g-4 align-items-start">
-      <div class="col-12 col-xl-5 d-flex flex-column gap-4">
-        <div class="card shadow-sm border-0 rounded-4">
-          <div class="card-body p-4">
-            <div class="mb-4">
-              <h3 class="fw-semibold mb-1">Cadastro de Animais</h3>
-              <p class="text-muted small mb-0">Associe rapidamente um novo pet a um tutor e visualize os registros existentes ao lado.</p>
-            </div>
-            {% include 'partials/animal_register_form.html' %}
-          </div>
-        </div>
-      </div>
-      <div class="col-12 col-xl-7">
-        <div class="d-flex flex-column gap-4">
-          <div id="animais-adicionados">
-            {% set compact = True %}
-            {% include 'partials/animais_adicionados.html' %}
-            {% set compact = None %}
-          </div>
-        </div>
-      </div>
-    </div>
+    {% include 'partials/novo_pet_panel.html' %}
   </div>
 {% endblock %}

--- a/templates/partials/novo_pet_panel.html
+++ b/templates/partials/novo_pet_panel.html
@@ -1,0 +1,22 @@
+<div class="row g-4 align-items-start">
+  <div class="col-12 col-xl-5 d-flex flex-column gap-4">
+    <div class="card shadow-sm border-0 rounded-4 h-100">
+      <div class="card-body p-4">
+        <div class="mb-4">
+          <h3 class="fw-semibold mb-1">Cadastro de Animais</h3>
+          <p class="text-muted small mb-0">Associe rapidamente um novo pet a um tutor e visualize os registros existentes ao lado.</p>
+        </div>
+        {% include 'partials/animal_register_form.html' %}
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-xl-7">
+    <div class="d-flex flex-column gap-4">
+      <div id="animais-adicionados">
+        {% set compact = True %}
+        {% include 'partials/animais_adicionados.html' %}
+        {% set compact = None %}
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add a shared `_get_recent_animais` helper so both the new animal view and the veterinarian schedule can load the same pet list and pagination context
- extract the registration form plus recent pets layout into a new `partials/novo_pet_panel.html` partial and include it from both `novo_animal.html` and the vet schedule collapse
- update the veterinarian appointments view to pass the shared panel context so the collapse renders the full form-and-list experience

## Testing
- `pytest` *(fails: tests/test_vacinas.py::test_alterar_vacina_cria_proxima_dose, tests/test_vacinas.py::test_vaccine_appointments_visible_to_collaborator, tests/test_vet_pending_exam_status.py::test_confirmed_requested_exam_visible_with_status_badge, tests/test_vet_pending_exam_status.py::test_exam_default_deadline_attributes_present)*


------
https://chatgpt.com/codex/tasks/task_e_68e52e18315c832eba587607a67b05bf