### PR TITLE
Add reusable schedule card styles

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -121,6 +121,187 @@
   --schedule-btn-shadow: rgba(124, 58, 237, 0.45);
 }
 
+/* Cartões de agenda com visual consistente */
+.schedule-card {
+  --schedule-card-bg: #ffffff;
+  background: var(--schedule-card-bg);
+  border: 0;
+  border-radius: 1.25rem;
+  box-shadow: 0 24px 48px -32px rgba(30, 64, 175, 0.35);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.schedule-card__header {
+  --schedule-card-header-start: #4f46e5;
+  --schedule-card-header-end: #2563eb;
+  --schedule-card-header-text: #ffffff;
+  --schedule-card-header-subtitle: rgba(255, 255, 255, 0.78);
+  --schedule-card-header-icon-bg: rgba(255, 255, 255, 0.18);
+  background: linear-gradient(
+    135deg,
+    var(--schedule-card-header-start),
+    var(--schedule-card-header-end)
+  );
+  color: var(--schedule-card-header-text);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  position: relative;
+}
+
+.schedule-card__header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at top right,
+    rgba(255, 255, 255, 0.18),
+    transparent 55%
+  );
+  pointer-events: none;
+}
+
+.schedule-card__header > * {
+  position: relative;
+  z-index: 1;
+}
+
+.schedule-card__header-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--schedule-card-header-icon-bg);
+  color: inherit;
+  flex-shrink: 0;
+}
+
+.schedule-card__title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: inherit;
+}
+
+.schedule-card__subtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--schedule-card-header-subtitle);
+}
+
+.schedule-card__header--primary {
+  --schedule-card-header-start: #4338ca;
+  --schedule-card-header-end: #2563eb;
+}
+
+.schedule-card__header--success {
+  --schedule-card-header-start: #10b981;
+  --schedule-card-header-end: #047857;
+}
+
+.schedule-card__header--info {
+  --schedule-card-header-start: #38bdf8;
+  --schedule-card-header-end: #0ea5e9;
+}
+
+.schedule-card__header--warning {
+  --schedule-card-header-start: #fbbf24;
+  --schedule-card-header-end: #f97316;
+  --schedule-card-header-text: #1f2937;
+  --schedule-card-header-subtitle: rgba(31, 41, 55, 0.75);
+  --schedule-card-header-icon-bg: rgba(255, 255, 255, 0.7);
+}
+
+.schedule-card__header--secondary {
+  --schedule-card-header-start: #64748b;
+  --schedule-card-header-end: #475569;
+}
+
+.schedule-card__tag {
+  --schedule-card-tag-bg: rgba(15, 23, 42, 0.08);
+  --schedule-card-tag-color: #0f172a;
+  --schedule-card-tag-border: transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  background: var(--schedule-card-tag-bg);
+  color: var(--schedule-card-tag-color);
+  border: 1px solid var(--schedule-card-tag-border);
+  line-height: 1;
+}
+
+.schedule-card__tag--primary {
+  --schedule-card-tag-bg: rgba(59, 130, 246, 0.25);
+  --schedule-card-tag-color: #1d4ed8;
+  --schedule-card-tag-border: rgba(59, 130, 246, 0.35);
+}
+
+.schedule-card__tag--success {
+  --schedule-card-tag-bg: rgba(16, 185, 129, 0.24);
+  --schedule-card-tag-color: #047857;
+  --schedule-card-tag-border: rgba(16, 185, 129, 0.35);
+}
+
+.schedule-card__tag--info {
+  --schedule-card-tag-bg: rgba(14, 165, 233, 0.24);
+  --schedule-card-tag-color: #0369a1;
+  --schedule-card-tag-border: rgba(14, 165, 233, 0.35);
+}
+
+.schedule-card__tag--warning {
+  --schedule-card-tag-bg: rgba(251, 191, 36, 0.25);
+  --schedule-card-tag-color: #92400e;
+  --schedule-card-tag-border: rgba(251, 191, 36, 0.45);
+}
+
+.schedule-card__tag--danger {
+  --schedule-card-tag-bg: rgba(248, 113, 113, 0.3);
+  --schedule-card-tag-color: #b91c1c;
+  --schedule-card-tag-border: rgba(248, 113, 113, 0.4);
+}
+
+.schedule-card__tag--secondary {
+  --schedule-card-tag-bg: rgba(100, 116, 139, 0.28);
+  --schedule-card-tag-color: #1e293b;
+  --schedule-card-tag-border: rgba(100, 116, 139, 0.35);
+}
+
+.schedule-card__tag--muted {
+  --schedule-card-tag-bg: rgba(148, 163, 184, 0.26);
+  --schedule-card-tag-color: #334155;
+  --schedule-card-tag-border: rgba(148, 163, 184, 0.45);
+}
+
+.schedule-card__tag--inverse {
+  --schedule-card-tag-bg: rgba(255, 255, 255, 0.2);
+  --schedule-card-tag-color: #ffffff;
+  --schedule-card-tag-border: rgba(255, 255, 255, 0.35);
+}
+
+@media (max-width: 576px) {
+  .schedule-card__header {
+    padding: 1.1rem 1.25rem;
+  }
+
+  .schedule-card__tag {
+    white-space: normal;
+  }
+}
+
 @media (max-width: 576px) {
   .schedule-toolbar {
     padding: 1rem 1.1rem;

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -154,19 +154,17 @@
 
               <!-- Filtros com design melhorado -->
               <div
-                class="card shadow-sm border-0 h-100 d-none"
+                class="card schedule-card h-100 d-none"
                 id="agenda-filter-card"
                 data-default-visible="false"
               >
-                <div class="card-header bg-primary bg-gradient text-white border-0 py-3 position-relative overflow-hidden">
-                  <div class="d-flex align-items-center">
-                    <div class="bg-white text-primary rounded-circle d-flex align-items-center justify-content-center me-3" style="width: 42px; height: 42px;">
-                      <i class="fas fa-filter"></i>
-                    </div>
-                    <div>
-                      <h5 class="mb-1 text-white">Filtrar Agenda</h5>
-                      <small class="text-white-50">Selecione um período ou utilize os atalhos rápidos abaixo</small>
-                    </div>
+                <div class="schedule-card__header schedule-card__header--primary">
+                  <div class="schedule-card__header-icon" aria-hidden="true">
+                    <i class="fas fa-filter" aria-hidden="true"></i>
+                  </div>
+                  <div class="flex-grow-1">
+                    <h5 class="schedule-card__title mb-1">Filtrar Agenda</h5>
+                    <p class="schedule-card__subtitle mb-0">Selecione um período ou utilize os atalhos rápidos abaixo</p>
                   </div>
                 </div>
                 <div class="card-body">
@@ -221,9 +219,18 @@
               </div>
 
               <!-- Agendamentos pendentes -->
-              <div class="card border-warning">
-                <div class="card-header bg-warning text-dark">
-                  <h5 class="mb-0"><i class="fas fa-clock me-2"></i>Agendamentos Pendentes</h5>
+              <div class="card schedule-card">
+                <div class="schedule-card__header schedule-card__header--warning">
+                  <div class="schedule-card__header-icon" aria-hidden="true">
+                    <i class="fas fa-clock" aria-hidden="true"></i>
+                  </div>
+                  <div class="flex-grow-1">
+                    <h5 class="schedule-card__title mb-1">Agendamentos Pendentes</h5>
+                    <p class="schedule-card__subtitle mb-0">Consultas e exames aguardando confirmação ou ação.</p>
+                  </div>
+                  <span class="schedule-card__tag schedule-card__tag--warning mt-2 mt-sm-0">
+                    <i class="fas fa-bell" aria-hidden="true"></i>Pendências
+                  </span>
                 </div>
                 <div class="card-body p-0">
                   <div class="list-group list-group-flush">
@@ -281,11 +288,11 @@
                                 <small class="text-muted">
                                   {{ display_tutor.name if display_tutor else '' }}
                                   {% if item.kind == 'banho_tosa' %}
-                                    <span class="badge bg-primary ms-1">Banho e Tosa</span>
+                                    <span class="schedule-card__tag schedule-card__tag--primary ms-2">Banho e Tosa</span>
                                   {% elif item.kind == 'vacina' %}
-                                    <span class="badge bg-success ms-1">Vacina</span>
+                                    <span class="schedule-card__tag schedule-card__tag--success ms-2">Vacina</span>
                                   {% elif item.kind == 'retorno' %}
-                                    <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                                    <span class="schedule-card__tag schedule-card__tag--warning ms-2">Retorno</span>
                                   {% endif %}
                                 </small>
                                 <div class="mt-1">
@@ -359,13 +366,13 @@
                               <small class="text-muted">
                                 {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
                                 {% if item.kind == 'banho_tosa' %}
-                                  <span class="badge bg-primary ms-1">Banho e Tosa</span>
+                                  <span class="schedule-card__tag schedule-card__tag--primary ms-2">Banho e Tosa</span>
                                 {% elif item.kind == 'vacina' %}
-                                  <span class="badge bg-success ms-1">Vacina</span>
+                                  <span class="schedule-card__tag schedule-card__tag--success ms-2">Vacina</span>
                                 {% elif item.kind == 'retorno' %}
-                                  <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                                  <span class="schedule-card__tag schedule-card__tag--warning ms-2">Retorno</span>
                                 {% endif %}
-                                <span class="badge bg-light text-dark border ms-1"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
+                                <span class="schedule-card__tag schedule-card__tag--muted ms-2"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
                               </small>
                               <div class="mt-1">
                                 {% if can_respond %}
@@ -379,9 +386,9 @@
                           </div>
                           <div class="text-end">
                             {% if can_respond %}
-                              <span class="badge bg-warning text-dark"><i class="fas fa-user-clock me-1"></i>Aguardando confirmação</span>
+                              <span class="schedule-card__tag schedule-card__tag--warning"><i class="fas fa-user-clock me-1"></i>Aguardando confirmação</span>
                             {% else %}
-                              <span class="badge bg-secondary"><i class="fas fa-hourglass-end me-1"></i>Prazo expirado</span>
+                              <span class="schedule-card__tag schedule-card__tag--secondary"><i class="fas fa-hourglass-end me-1"></i>Prazo expirado</span>
                             {% endif %}
                           </div>
                         </div>
@@ -445,7 +452,7 @@
                                 <small class="text-muted"><i class="fas fa-user-md me-1"></i>Especialista responsável: {{ exam.specialist.user.name if exam.specialist and exam.specialist.user else '—' }}</small>
                               </div>
                             </div>
-                            <span class="badge bg-secondary"><i class="fas fa-hourglass-half me-1"></i>Aguardando</span>
+                            <span class="schedule-card__tag schedule-card__tag--secondary"><i class="fas fa-hourglass-half me-1"></i>Aguardando</span>
                           </div>
                         </div>
                       {% endfor %}
@@ -461,9 +468,18 @@
               </div>
 
               <!-- Próximos agendamentos -->
-              <div class="card border-primary">
-                <div class="card-header bg-primary text-white">
-                  <h5 class="mb-0"><i class="fas fa-calendar-check me-2"></i>Próximos Agendamentos</h5>
+              <div class="card schedule-card">
+                <div class="schedule-card__header schedule-card__header--primary">
+                  <div class="schedule-card__header-icon" aria-hidden="true">
+                    <i class="fas fa-calendar-check" aria-hidden="true"></i>
+                  </div>
+                  <div class="flex-grow-1">
+                    <h5 class="schedule-card__title mb-1">Próximos Agendamentos</h5>
+                    <p class="schedule-card__subtitle mb-0">Veja o que está por vir e acesse rapidamente os detalhes.</p>
+                  </div>
+                  <span class="schedule-card__tag schedule-card__tag--primary mt-2 mt-sm-0">
+                    <i class="fas fa-arrow-right" aria-hidden="true"></i>Em breve
+                  </span>
                 </div>
                 <div class="card-body p-0">
                   <div class="list-group list-group-flush">
@@ -483,7 +499,7 @@
                               </div>
                               <div>
                                 <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
-                                <small class="text-muted">{{ appt.animal.owner.name }} <span class="badge bg-info ms-1">Exame</span></small>
+                                <small class="text-muted">{{ appt.animal.owner.name }} <span class="schedule-card__tag schedule-card__tag--info ms-2">Exame</span></small>
                               </div>
                             </div>
                             <div class="btn-group">
@@ -529,11 +545,11 @@
                                 <h6 class="mb-0">{{ appt.scheduled_at|format_datetime_brazil('%d/%m/%Y %H:%M') }} - {{ appt.animal.name }}</h6>
                                 <small class="text-muted">{{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
                                   {% if item.kind == 'retorno' %}
-                                    <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                                    <span class="schedule-card__tag schedule-card__tag--warning ms-2">Retorno</span>
                                   {% elif item.kind == 'banho_tosa' %}
-                                    <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
+                                    <span class="schedule-card__tag schedule-card__tag--primary ms-2">Banho e Tosa</span>
                                   {% elif item.kind == 'vacina' %}
-                                    <span class="badge bg-success text-white ms-1">Vacina</span>
+                                    <span class="schedule-card__tag schedule-card__tag--success ms-2">Vacina</span>
                                   {% endif %}
                                 </small>
                               </div>
@@ -594,13 +610,13 @@
                                 <small class="text-muted">
                                   {{ appt.tutor.name if item.kind in ['consulta', 'retorno', 'banho_tosa', 'vacina'] else appt.animal.owner.name }}
                                   {% if item.kind == 'retorno' %}
-                                    <span class="badge bg-warning text-dark ms-1">Retorno</span>
+                                    <span class="schedule-card__tag schedule-card__tag--warning ms-2">Retorno</span>
                                   {% elif item.kind == 'banho_tosa' %}
-                                    <span class="badge bg-primary text-white ms-1">Banho e Tosa</span>
+                                    <span class="schedule-card__tag schedule-card__tag--primary ms-2">Banho e Tosa</span>
                                   {% elif item.kind == 'vacina' %}
-                                    <span class="badge bg-success text-white ms-1">Vacina</span>
+                                    <span class="schedule-card__tag schedule-card__tag--success ms-2">Vacina</span>
                                   {% endif %}
-                                  <span class="badge bg-light text-dark border ms-1"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
+                                  <span class="schedule-card__tag schedule-card__tag--muted ms-2"><i class="fas fa-user-md me-1"></i>{{ appt.veterinario.user.name }}</span>
                                 </small>
                               </div>
                             </div>
@@ -609,7 +625,7 @@
                                 <a href="{{ url_for('ficha_animal', animal_id=appt.animal_id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>
                                 <a href="{{ url_for('ficha_tutor', tutor_id=appt.tutor_id) }}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-user me-1"></i>Tutor</a>
                               </div>
-                              <span class="badge bg-success"><i class="fas fa-check me-1"></i>{{ status_label }}</span>
+                              <span class="schedule-card__tag schedule-card__tag--success"><i class="fas fa-check me-1"></i>{{ status_label }}</span>
                             </div>
                           </div>
                         </div>
@@ -625,10 +641,18 @@
                 </div>
               </div>
           <!-- Consultas finalizadas, retornos e exames -->
-          <div class="card border-secondary">
-            <div class="card-header bg-secondary text-white d-flex justify-content-between align-items-center">
-              <h5 class="mb-0"><i class="fas fa-history me-2"></i>Consultas e exames no período</h5>
-              <button id="toggle-past" class="btn btn-sm btn-light">
+          <div class="card schedule-card">
+            <div class="schedule-card__header schedule-card__header--secondary">
+              <div class="d-flex align-items-center gap-3 flex-grow-1 flex-wrap">
+                <div class="schedule-card__header-icon" aria-hidden="true">
+                  <i class="fas fa-history" aria-hidden="true"></i>
+                </div>
+                <div class="flex-grow-1">
+                  <h5 class="schedule-card__title mb-1">Consultas e exames no período</h5>
+                  <p class="schedule-card__subtitle mb-0">Acompanhe atendimentos concluídos, retornos e exames confirmados.</p>
+                </div>
+              </div>
+              <button id="toggle-past" class="btn btn-sm btn-light mt-3 mt-sm-0">
                 <i class="fas fa-chevron-down me-1"></i>Mostrar
               </button>
             </div>
@@ -650,7 +674,7 @@
                             <h6 class="mb-1">{{ event.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }} – {{ animal.name }}</h6>
                             <small class="text-muted d-block">Tutor: {{ tutor.name if tutor else '—' }}</small>
                             {% if consulta.retorno_de_id %}
-                              <span class="badge bg-warning text-dark mt-1">Retorno da consulta #{{ consulta.retorno_de_id }}</span>
+                              <span class="schedule-card__tag schedule-card__tag--warning mt-2">Retorno da consulta #{{ consulta.retorno_de_id }}</span>
                             {% endif %}
                             {% if event.exam_summary %}
                               <div class="mt-2">
@@ -692,7 +716,7 @@
                           <div>
                             <h6 class="mb-1">{{ event.timestamp|format_datetime_brazil('%d/%m/%Y %H:%M') }} – {{ animal.name }}</h6>
                             <small class="text-muted d-block">Tutor: {{ tutor.name if tutor else '—' }}</small>
-                            <span class="badge bg-secondary mt-1">Consulta aceita e não finalizada</span>
+                            <span class="schedule-card__tag schedule-card__tag--secondary mt-2">Consulta aceita e não finalizada</span>
                           </div>
                           <div class="btn-group">
                             <a href="{{ url_for('ficha_animal', animal_id=animal.id) }}" class="btn btn-sm btn-outline-primary"><i class="fas fa-file-medical me-1"></i>Ficha</a>

--- a/templates/veterinarios/vet_detail.html
+++ b/templates/veterinarios/vet_detail.html
@@ -52,13 +52,18 @@
     </div>
   </div>
   <section class="mb-4" aria-labelledby="vet-agenda-title-{{ veterinario.id }}">
-    <div class="card shadow-sm border-0">
-      <div class="card-header bg-primary bg-gradient text-white d-flex flex-column flex-lg-row align-items-lg-center justify-content-between">
-        <div>
-          <h3 id="vet-agenda-title-{{ veterinario.id }}" class="h5 mb-1">
-            <i class="fas fa-calendar-alt me-2"></i>Agenda do veterinário
-          </h3>
-          <small class="text-white-50">Visualize os compromissos e alterne rapidamente para novos agendamentos.</small>
+    <div class="card schedule-card">
+      <div class="schedule-card__header schedule-card__header--primary">
+        <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3 flex-grow-1 flex-wrap">
+          <div class="schedule-card__header-icon" aria-hidden="true">
+            <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+          </div>
+          <div class="flex-grow-1">
+            <h3 id="vet-agenda-title-{{ veterinario.id }}" class="h5 mb-1 schedule-card__title">
+              Agenda do veterinário
+            </h3>
+            <p class="schedule-card__subtitle mb-0">Visualize os compromissos e alterne rapidamente para novos agendamentos.</p>
+          </div>
         </div>
         <div class="d-flex flex-wrap justify-content-end gap-2 mt-3 mt-lg-0">
           <button class="btn btn-light mb-1" onclick="toggleScheduleForm()">


### PR DESCRIPTION
## Summary
- add unified `.schedule-card` utilities with gradient headers and accessible badge variants
- update vet schedule filters and pending/upcoming cards to use the new styles and responsive tags
- reuse the refreshed layout on the veterinarian detail agenda card for visual consistency

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e52e6ffed8832ea6fe35681c3d62ee