### PR TITLE
Refine agenda action styles

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -121,6 +121,228 @@
   --schedule-btn-shadow: rgba(124, 58, 237, 0.45);
 }
 
+/* Ações auxiliares da agenda */
+.schedule-action-btn {
+  --schedule-action-fg: #4338ca;
+  --schedule-action-bg: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(59, 130, 246, 0.12));
+  --schedule-action-border: rgba(99, 102, 241, 0.35);
+  --schedule-action-shadow: rgba(79, 70, 229, 0.2);
+  border-radius: 999px;
+  border: 1px solid var(--schedule-action-border);
+  background: var(--schedule-action-bg);
+  color: var(--schedule-action-fg);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1.15rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 16px 32px -28px var(--schedule-action-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.schedule-action-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.55), transparent 65%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.schedule-action-btn:hover,
+.schedule-action-btn:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 40px -28px var(--schedule-action-shadow);
+  text-decoration: none;
+}
+
+.schedule-action-btn:hover::after,
+.schedule-action-btn:focus::after {
+  opacity: 0.65;
+}
+
+.schedule-action-btn:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(99, 102, 241, 0.25), 0 22px 40px -28px var(--schedule-action-shadow);
+}
+
+.schedule-action-btn .bi,
+.schedule-action-btn i,
+.schedule-action-btn svg {
+  font-size: 1.1rem;
+  color: currentColor;
+}
+
+.schedule-action-btn.btn-sm,
+.schedule-action-btn.schedule-action-btn--sm,
+.btn-group-sm > .schedule-action-btn {
+  padding: 0.35rem 0.85rem;
+  font-size: 0.82rem;
+  gap: 0.4rem;
+}
+
+.schedule-action-btn--primary {
+  --schedule-action-fg: #1d4ed8;
+  --schedule-action-bg: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(99, 102, 241, 0.22));
+  --schedule-action-border: rgba(59, 130, 246, 0.45);
+  --schedule-action-shadow: rgba(59, 130, 246, 0.32);
+}
+
+.schedule-action-btn--muted {
+  --schedule-action-fg: #475569;
+  --schedule-action-bg: linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(226, 232, 240, 0.4));
+  --schedule-action-border: rgba(148, 163, 184, 0.55);
+  --schedule-action-shadow: rgba(148, 163, 184, 0.28);
+}
+
+.schedule-action-btn--success {
+  --schedule-action-fg: #047857;
+  --schedule-action-bg: linear-gradient(135deg, rgba(52, 211, 153, 0.2), rgba(16, 185, 129, 0.24));
+  --schedule-action-border: rgba(16, 185, 129, 0.45);
+  --schedule-action-shadow: rgba(16, 185, 129, 0.32);
+}
+
+.schedule-action-btn--danger {
+  --schedule-action-fg: #b91c1c;
+  --schedule-action-bg: linear-gradient(135deg, rgba(248, 113, 113, 0.22), rgba(239, 68, 68, 0.28));
+  --schedule-action-border: rgba(239, 68, 68, 0.5);
+  --schedule-action-shadow: rgba(239, 68, 68, 0.32);
+}
+
+.schedule-action-btn--neutral {
+  --schedule-action-fg: #64748b;
+  --schedule-action-bg: linear-gradient(135deg, rgba(226, 232, 240, 0.28), rgba(148, 163, 184, 0.2));
+  --schedule-action-border: rgba(203, 213, 225, 0.6);
+  --schedule-action-shadow: rgba(15, 23, 42, 0.18);
+}
+
+.schedule-action-btn:disabled,
+.schedule-action-btn[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
+  transform: none;
+}
+
+.schedule-action-btn:disabled::after,
+.schedule-action-btn[aria-disabled="true"]::after {
+  opacity: 0;
+}
+
+/* Chips informativos da agenda */
+.schedule-chip {
+  --schedule-chip-color: #475569;
+  --schedule-chip-bg: linear-gradient(135deg, rgba(226, 232, 240, 0.75), rgba(203, 213, 225, 0.55));
+  --schedule-chip-border: rgba(148, 163, 184, 0.45);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  color: var(--schedule-chip-color);
+  background: var(--schedule-chip-bg);
+  border: 1px solid var(--schedule-chip-border);
+  box-shadow: 0 10px 28px -24px rgba(15, 23, 42, 0.45);
+}
+
+.schedule-chip .bi,
+.schedule-chip i,
+.schedule-chip svg {
+  font-size: 1.1rem;
+  color: currentColor;
+}
+
+.schedule-chip--muted {
+  --schedule-chip-color: #475569;
+  --schedule-chip-bg: linear-gradient(135deg, rgba(226, 232, 240, 0.8), rgba(226, 232, 240, 0.5));
+  --schedule-chip-border: rgba(148, 163, 184, 0.5);
+}
+
+.schedule-chip--primary {
+  --schedule-chip-color: #3730a3;
+  --schedule-chip-bg: linear-gradient(135deg, rgba(129, 140, 248, 0.28), rgba(99, 102, 241, 0.32));
+  --schedule-chip-border: rgba(79, 70, 229, 0.55);
+}
+
+.schedule-chip--info {
+  --schedule-chip-color: #0369a1;
+  --schedule-chip-bg: linear-gradient(135deg, rgba(125, 211, 252, 0.28), rgba(56, 189, 248, 0.32));
+  --schedule-chip-border: rgba(56, 189, 248, 0.45);
+}
+
+.schedule-chip--success {
+  --schedule-chip-color: #047857;
+  --schedule-chip-bg: linear-gradient(135deg, rgba(134, 239, 172, 0.28), rgba(74, 222, 128, 0.32));
+  --schedule-chip-border: rgba(34, 197, 94, 0.45);
+}
+
+.schedule-chip--danger {
+  --schedule-chip-color: #b91c1c;
+  --schedule-chip-bg: linear-gradient(135deg, rgba(248, 113, 113, 0.28), rgba(239, 68, 68, 0.32));
+  --schedule-chip-border: rgba(239, 68, 68, 0.5);
+}
+
+.schedule-chip--neutral {
+  --schedule-chip-color: #475569;
+  --schedule-chip-bg: linear-gradient(135deg, rgba(226, 232, 240, 0.6), rgba(148, 163, 184, 0.3));
+  --schedule-chip-border: rgba(203, 213, 225, 0.5);
+}
+
+.schedule-chip--warning {
+  --schedule-chip-color: #92400e;
+  --schedule-chip-bg: linear-gradient(135deg, rgba(251, 191, 36, 0.35), rgba(245, 158, 11, 0.32));
+  --schedule-chip-border: rgba(245, 158, 11, 0.45);
+}
+
+.schedule-chip.text-white .bi,
+.schedule-chip.text-white i,
+.schedule-chip.text-white svg {
+  color: currentColor;
+}
+
+/* Botões de seleção de horários */
+.schedule-slot {
+  --schedule-slot-icon-color: currentColor;
+  gap: 0.45rem;
+  padding-inline: 0.95rem;
+  white-space: nowrap;
+}
+
+.schedule-slot .bi,
+.schedule-slot i,
+.schedule-slot svg {
+  color: var(--schedule-slot-icon-color);
+}
+
+.schedule-slot--available {
+  --schedule-slot-icon-color: currentColor;
+}
+
+.schedule-slot--booked,
+.schedule-slot--off {
+  --schedule-slot-icon-color: currentColor;
+  opacity: 0.75;
+}
+
+.schedule-slot--selected {
+  --schedule-action-fg: #ffffff;
+  --schedule-action-bg: linear-gradient(135deg, #34d399 0%, #10b981 100%);
+  --schedule-action-border: rgba(16, 185, 129, 0.75);
+  --schedule-action-shadow: rgba(16, 185, 129, 0.45);
+  opacity: 1;
+}
+
 /* Cartões de agenda com visual consistente */
 .schedule-card {
   --schedule-card-bg: #ffffff;

--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -140,7 +140,7 @@
                 ></span>
               </h6>
               <span
-                class="badge rounded-pill text-bg-light small fw-normal"
+                class="schedule-chip schedule-chip--muted"
                 data-schedule-summary
                 aria-live="polite"
               >
@@ -148,22 +148,22 @@
               </span>
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-auto">
-              <div class="d-flex align-items-center gap-2 small text-muted" data-schedule-legend>
-                <span class="d-inline-flex align-items-center gap-1">
-                  <i class="bi bi-check-circle-fill text-success"></i>
+              <div class="d-flex align-items-center flex-wrap gap-2" data-schedule-legend>
+                <span class="schedule-chip schedule-chip--success">
+                  <i class="bi bi-check-circle-fill"></i>
                   Disponível
                 </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-x-circle-fill text-danger"></i>
+                <span class="schedule-chip schedule-chip--danger">
+                  <i class="bi bi-x-circle-fill"></i>
                   Indisponível
                 </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-slash-circle-fill text-secondary"></i>
+                <span class="schedule-chip schedule-chip--neutral">
+                  <i class="bi bi-slash-circle-fill"></i>
                   Fora do expediente
                 </span>
               </div>
               <button
-                class="btn btn-outline-primary btn-sm"
+                class="btn schedule-action-btn schedule-action-btn--primary btn-sm"
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#scheduleOverviewCollapse"
@@ -187,16 +187,16 @@
               <div class="btn-group btn-group-sm" role="group" aria-label="Navegação da agenda semanal">
                 <button
                   type="button"
-                  class="btn btn-outline-secondary"
+                  class="btn schedule-action-btn schedule-action-btn--muted"
                   data-schedule-week-prev
                   aria-label="Semana anterior"
                 >
                   <i class="bi bi-chevron-left"></i>
-                  <span class="d-none d-sm-inline ms-1">Semana anterior</span>
+                  <span class="d-none d-sm-inline">Semana anterior</span>
                 </button>
                 <button
                   type="button"
-                  class="btn btn-outline-secondary"
+                  class="btn schedule-action-btn schedule-action-btn--muted"
                   data-schedule-week-today
                   aria-label="Ir para semana atual"
                 >
@@ -204,11 +204,11 @@
                 </button>
                 <button
                   type="button"
-                  class="btn btn-outline-secondary"
+                  class="btn schedule-action-btn schedule-action-btn--muted"
                   data-schedule-week-next
                   aria-label="Próxima semana"
                 >
-                  <span class="d-none d-sm-inline me-1">Próxima semana</span>
+                  <span class="d-none d-sm-inline">Próxima semana</span>
                   <i class="bi bi-chevron-right"></i>
                 </button>
               </div>
@@ -315,12 +315,14 @@
               <div class="bg-white border rounded-3 shadow-sm p-3">
                 <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
                   <div>
-                    <span class="badge text-bg-primary rounded-pill">Disponibilidade semanal</span>
+                    <span class="schedule-chip schedule-chip--primary">Disponibilidade semanal</span>
                     <p class="small text-muted mb-0">Defina o dia, horário de início e término do atendimento.</p>
                   </div>
                   <div class="d-flex align-items-center gap-2">
-                    <i class="bi bi-calendar-event text-primary"></i>
-                    <span class="small text-muted">Campos obrigatórios</span>
+                    <span class="schedule-chip schedule-chip--info">
+                      <i class="bi bi-calendar-event"></i>
+                      Campos obrigatórios
+                    </span>
                   </div>
                 </div>
                 <div class="row g-3">
@@ -356,7 +358,7 @@
                 </div>
                 <div class="mt-4">
                   <button
-                    class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2"
+                    class="btn schedule-action-btn schedule-action-btn--muted btn-sm"
                     type="button"
                     data-bs-toggle="collapse"
                     data-bs-target="#scheduleIntervalCollapse"
@@ -364,7 +366,7 @@
                     aria-controls="scheduleIntervalCollapse"
                   >
                     <i class="bi bi-arrow-repeat"></i>
-                    Intervalo de atendimento opcional
+                    <span>Intervalo de atendimento opcional</span>
                   </button>
                   <div class="collapse mt-3" id="scheduleIntervalCollapse">
                     <div class="row g-3">
@@ -1018,7 +1020,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function createSlotButton(time, status, { date }) {
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'btn btn-sm rounded-pill d-inline-flex align-items-center gap-1 schedule-slot flex-shrink-0';
+      button.className = 'btn schedule-action-btn schedule-action-btn--sm schedule-slot flex-shrink-0';
       button.dataset.scheduleSlot = time;
       button.dataset.scheduleDate = date;
       button.dataset.scheduleStatus = status;
@@ -1026,19 +1028,19 @@ document.addEventListener('DOMContentLoaded', () => {
       let iconClass = 'bi-clock';
       if (status === 'available') {
         iconClass = 'bi-check-circle';
-        button.classList.add('btn-outline-success');
+        button.classList.add('schedule-action-btn--success', 'schedule-slot--available');
         button.setAttribute('aria-pressed', 'false');
         button.dataset.schedulePeriod = getPeriodFromTime(time);
         button.title = 'Selecionar horário disponível';
       } else if (status === 'booked') {
         iconClass = 'bi-x-circle';
-        button.classList.add('btn-outline-danger', 'opacity-75');
+        button.classList.add('schedule-action-btn--danger', 'schedule-slot--booked');
         button.disabled = true;
         button.setAttribute('aria-disabled', 'true');
         button.title = 'Horário indisponível';
       } else {
         iconClass = 'bi-slash-circle';
-        button.classList.add('btn-outline-secondary', 'opacity-75');
+        button.classList.add('schedule-action-btn--neutral', 'schedule-slot--off');
         button.disabled = true;
         button.setAttribute('aria-disabled', 'true');
         button.title = 'Fora do expediente';
@@ -1071,9 +1073,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
         const isSelected = selectedScheduleSlotKey === button.dataset.scheduleSlotKey;
-        button.classList.toggle('btn-outline-success', !isSelected);
-        button.classList.toggle('btn-success', isSelected);
-        button.classList.toggle('text-white', isSelected);
+        button.classList.toggle('schedule-slot--selected', isSelected);
         button.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
       });
       const cards = scheduleContainer.querySelectorAll('[data-schedule-day]');
@@ -1149,7 +1149,7 @@ document.addEventListener('DOMContentLoaded', () => {
         card.dataset.scheduleDay = normalizedDate;
         if (todayIso === normalizedDate) {
           const todayBadge = document.createElement('span');
-          todayBadge.className = 'badge text-bg-primary position-absolute top-0 end-0 translate-middle-y me-3 mt-3';
+          todayBadge.className = 'schedule-chip schedule-chip--primary position-absolute top-0 end-0 translate-middle-y me-3 mt-3';
           todayBadge.textContent = 'Hoje';
           card.appendChild(todayBadge);
         }
@@ -1190,7 +1190,7 @@ document.addEventListener('DOMContentLoaded', () => {
           body.appendChild(progress);
         } else if (!hasAvailability && notWorkingCount === 0) {
           const badgeInfo = document.createElement('span');
-          badgeInfo.className = 'badge text-bg-light text-muted align-self-start mb-3';
+          badgeInfo.className = 'schedule-chip schedule-chip--neutral align-self-start mb-3';
           badgeInfo.textContent = 'Sem horários cadastrados.';
           body.appendChild(badgeInfo);
         }

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -141,7 +141,7 @@
             <div class="d-flex flex-column gap-4">
               <button
                 type="button"
-                class="btn btn-outline-primary align-self-start d-inline-flex align-items-center gap-2"
+                class="btn schedule-action-btn schedule-action-btn--muted align-self-start"
                 id="agenda-filter-toggle"
                 aria-controls="agenda-filter-card"
                 aria-expanded="false"
@@ -1002,7 +1002,7 @@
                 ></span>
               </h6>
               <span
-                class="badge rounded-pill text-bg-light small fw-normal"
+                class="schedule-chip schedule-chip--muted"
                 data-schedule-summary
                 aria-live="polite"
               >
@@ -1010,22 +1010,22 @@
               </span>
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-auto">
-              <div class="d-flex align-items-center gap-2 small text-muted" data-schedule-legend>
-                <span class="d-inline-flex align-items-center gap-1">
-                  <i class="bi bi-check-circle-fill text-success"></i>
+              <div class="d-flex align-items-center flex-wrap gap-2" data-schedule-legend>
+                <span class="schedule-chip schedule-chip--success">
+                  <i class="bi bi-check-circle-fill"></i>
                   Disponível
                 </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-x-circle-fill text-danger"></i>
+                <span class="schedule-chip schedule-chip--danger">
+                  <i class="bi bi-x-circle-fill"></i>
                   Indisponível
                 </span>
-                <span class="d-inline-flex align-items-center gap-1 ms-2">
-                  <i class="bi bi-slash-circle-fill text-secondary"></i>
+                <span class="schedule-chip schedule-chip--neutral">
+                  <i class="bi bi-slash-circle-fill"></i>
                   Fora do expediente
                 </span>
               </div>
               <button
-                class="btn btn-outline-primary btn-sm"
+                class="btn schedule-action-btn schedule-action-btn--primary btn-sm"
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#scheduleOverviewCollapse"
@@ -1047,15 +1047,15 @@
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2 ms-xl-auto">
               <div class="btn-group btn-group-sm" role="group" aria-label="Navegação da agenda semanal">
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-prev>
+                <button type="button" class="btn schedule-action-btn schedule-action-btn--muted" data-schedule-week-prev>
                   <i class="bi bi-chevron-left"></i>
-                  <span class="d-none d-sm-inline ms-1">Semana anterior</span>
+                  <span class="d-none d-sm-inline">Semana anterior</span>
                 </button>
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-today>
+                <button type="button" class="btn schedule-action-btn schedule-action-btn--muted" data-schedule-week-today>
                   Hoje
                 </button>
-                <button type="button" class="btn btn-outline-secondary" data-schedule-week-next>
-                  <span class="d-none d-sm-inline me-1">Próxima semana</span>
+                <button type="button" class="btn schedule-action-btn schedule-action-btn--muted" data-schedule-week-next>
+                  <span class="d-none d-sm-inline">Próxima semana</span>
                   <i class="bi bi-chevron-right"></i>
                 </button>
               </div>
@@ -1381,8 +1381,8 @@
             label.textContent = visible ? hideLabel : showLabel;
           }
 
-          filterToggle.classList.toggle('btn-primary', visible);
-          filterToggle.classList.toggle('btn-outline-primary', !visible);
+          filterToggle.classList.toggle('schedule-action-btn--primary', visible);
+          filterToggle.classList.toggle('schedule-action-btn--muted', !visible);
         };
 
         const applyFilterVisibility = (visible, { persist = false } = {}) => {


### PR DESCRIPTION
## Summary
- add schedule action button and chip variants derived from the agenda toolbar palette
- replace outline button usages in schedule legends, navigation, and collapses with the new components
- update agenda chips and slot rendering scripts to match the refreshed visual language

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e534974854832e917dbc1687ea16f3