### PR TITLE
Oculta ações sensíveis do animal e adiciona opção "Marcar como falecido"

### DIFF
--- a/templates/partials/animal_form.html
+++ b/templates/partials/animal_form.html
@@ -134,15 +134,36 @@
   </div>
 </form>
 
-<!-- Botao de deletar -->
-<form method="POST" action="{{ url_for('deletar_animal', animal_id=animal.id) }}"
-      onsubmit="return confirm('Tem certeza que deseja remover permanentemente este animal? Esta acao nao pode ser desfeita.');"
-      class="animal-delete-form mt-3">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-  <button type="submit" class="btn btn-outline-danger">
-    <i class="bi bi-trash me-1"></i> Remover Animal
+<!-- Acoes sensiveis do animal -->
+<div class="animal-sensitive-actions mt-3">
+  <button type="button" class="btn btn-outline-secondary btn-sm" id="toggle-sensitive-actions"
+          aria-expanded="false" aria-controls="animal-sensitive-actions-panel">
+    <i class="bi bi-shield-exclamation me-1"></i> Acoes sensiveis
   </button>
-</form>
+
+  <div id="animal-sensitive-actions-panel" class="d-none mt-2">
+    <div class="d-flex flex-wrap gap-2 align-items-start">
+      <form method="POST" action="{{ url_for('deletar_animal', animal_id=animal.id) }}"
+            onsubmit="return confirm('Tem certeza que deseja remover permanentemente este animal? Esta acao nao pode ser desfeita.');"
+            class="animal-delete-form mb-0">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" class="btn btn-outline-danger">
+          <i class="bi bi-trash me-1"></i> Remover Animal
+        </button>
+      </form>
+
+      <form method="POST" action="{{ url_for('marcar_como_falecido', animal_id=animal.id) }}"
+            onsubmit="return confirm('Deseja marcar este animal como falecido?');"
+            class="animal-mark-deceased-form mb-0">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="falecimento_em" value="">
+        <button type="submit" class="btn btn-outline-warning">
+          <i class="bi bi-x-octagon me-1"></i> Marcar como falecido
+        </button>
+      </form>
+    </div>
+  </div>
+</div>
 
 <!-- Scripts -->
 {% block scripts %}
@@ -169,6 +190,17 @@
       }
       return true;
     };
+
+    const toggleSensitiveActions = document.getElementById('toggle-sensitive-actions');
+    const sensitiveActionsPanel = document.getElementById('animal-sensitive-actions-panel');
+
+    if (toggleSensitiveActions && sensitiveActionsPanel) {
+      toggleSensitiveActions.addEventListener('click', () => {
+        const isHidden = sensitiveActionsPanel.classList.contains('d-none');
+        sensitiveActionsPanel.classList.toggle('d-none');
+        toggleSensitiveActions.setAttribute('aria-expanded', String(isHidden));
+      });
+    }
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Tornar menos expostas ações críticas no formulário do animal (remover e marcar falecido) exibindo-as apenas sob demanda para reduzir riscos de cliques acidentais.

### Description
- Substitui o formulário de remoção isolado por um contêiner recolhível em `templates/partials/animal_form.html` chamado `animal-sensitive-actions` que começa oculto (`d-none`).
- Adiciona o botão de toggle `#toggle-sensitive-actions` e o painel `#animal-sensitive-actions-panel` contendo lado a lado os formulários de `POST` para `deletar_animal` e `marcar_como_falecido`, preservando os `csrf_token` e confirmações `onsubmit`.
- Implementa um listener JavaScript que alterna a classe `d-none` no painel e atualiza o atributo `aria-expanded` do botão para acessibilidade.

### Testing
- Executado `pytest -q tests/test_deletar_animal.py` e os testes automatizados relacionados passaram (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd43d6cfbc832ea514f23c14e38e9e)