### PR TITLE
Restringe exibição de “Minha Clínica” para perfis veterinários

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -168,7 +168,7 @@
                   Meu Perfil</a></li>
               <li><a class="dropdown-item" href="{{ url_for('minhas_compras') }}"><i
                     class="fas fa-box me-2 text-warning"></i> Minhas Compras</a></li>
-              {% if has_clinic_access %}
+              {% if has_clinic_access and has_veterinarian_profile_flag %}
               <li><a class="dropdown-item" href="{{ url_for('minha_clinica') }}"><i
                     class="fas fa-clinic-medical me-2 text-info"></i> Minha Clínica</a></li>
               {% endif %}

--- a/tests/test_minha_clinica.py
+++ b/tests/test_minha_clinica.py
@@ -96,7 +96,7 @@ def test_layout_shows_minha_clinica_for_veterinario(monkeypatch, app):
         assert b'Minha Cl\xc3\xadnica' in resp.data
 
 
-def test_layout_shows_minha_clinica_for_colaborador(monkeypatch, app):
+def test_layout_hides_minha_clinica_for_colaborador_without_vet_profile(monkeypatch, app):
     client = app.test_client()
     with app.app_context():
         db.create_all()
@@ -109,7 +109,7 @@ def test_layout_shows_minha_clinica_for_colaborador(monkeypatch, app):
         monkeypatch.setattr(login_utils, '_get_user', lambda: user)
 
         resp = client.get('/')
-        assert b'Minha Cl\xc3\xadnica' in resp.data
+        assert b'Minha Cl\xc3\xadnica' not in resp.data
 
 
 def test_layout_hides_minha_clinica_without_clinic_access(monkeypatch, app):


### PR DESCRIPTION
### Motivation
- Evitar que tutores/usuários sem perfil veterinário visualizem o link de gestão de clínica "Minha Clínica" no dropdown do usuário.

### Description
- Altera a condição no dropdown do usuário em `templates/layout.html` para exibir "Minha Clínica" apenas quando `has_clinic_access and has_veterinarian_profile_flag`.
- Atualiza o teste em `tests/test_minha_clinica.py` renomeando o caso correspondente e invertendo a asserção para garantir que um colaborador sem perfil veterinário não veja a opção.
- Arquivos modificados: `templates/layout.html` e `tests/test_minha_clinica.py`.

### Testing
- Rodei `pytest -q tests/test_minha_clinica.py -q` e a suíte completa do arquivo apresentou uma falha pré-existente não relacionada em `test_create_clinic_with_logo_uploads`.
- Rodei um subconjunto focalizado com `pytest -q tests/test_minha_clinica.py -k "layout_shows_minha_clinica_for_veterinario or layout_hides_minha_clinica_for_colaborador_without_vet_profile or layout_hides_minha_clinica_without_clinic_access"` e obtive `3 passed`, confirmando o novo comportamento de exibição do menu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd46aeb370832eb8a376c5ebd476d7)