### PR TITLE
Fix "Enviar para pagamento" button in orçamento history

### DIFF
--- a/templates/partials/historico_orcamentos.html
+++ b/templates/partials/historico_orcamentos.html
@@ -108,7 +108,7 @@
           </a>
           {% endif %}
         {% endif %}
-        <button type="button" class="btn btn-outline-success btn-sm" onclick="enviarBlocoParaPagamento({{ bloco.id }})"><i class="fas fa-credit-card me-1"></i>Enviar para pagamento</button>
+        <button type="button" class="btn btn-outline-success btn-sm" data-pagamento-btn onclick="enviarBlocoParaPagamento({{ bloco.id }}, this)"><i class="fas fa-credit-card me-1"></i>Enviar para pagamento</button>
         {% if bloco.payment_link %}
         <a href="{{ bloco.payment_link }}" target="_blank" class="btn btn-outline-info btn-sm"><i class="fas fa-link me-1"></i>Link atual</a>
         {% endif %}
@@ -123,12 +123,21 @@
 
 <script>
 if (!window.enviarBlocoParaPagamento) {
-  window.enviarBlocoParaPagamento = async function enviarBlocoParaPagamento(blocoId) {
+  window.enviarBlocoParaPagamento = async function enviarBlocoParaPagamento(blocoId, buttonEl) {
     const historico = document.getElementById('historico-orcamentos');
+    const button = buttonEl && buttonEl.tagName ? buttonEl : null;
+    const originalButtonHtml = button ? button.innerHTML : null;
     try {
+      if (button) {
+        button.disabled = true;
+        button.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+      }
       const resp = await fetch(`/pagar_orcamento/${blocoId}`, {
         method: 'POST',
-        headers: {'Accept': 'application/json'}
+        headers: {
+          'Accept': 'application/json',
+          'X-CSRFToken': '{{ csrf_token() }}'
+        }
       });
       const data = await resp.json();
       if (!resp.ok || !data.success) {
@@ -152,6 +161,11 @@ if (!window.enviarBlocoParaPagamento) {
         showToast('Erro ao comunicar com o servidor.', 'danger');
       }
       console.error(error);
+    } finally {
+      if (button) {
+        button.disabled = false;
+        button.innerHTML = originalButtonHtml;
+      }
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Corrigir fluxo de pagamento do histórico de orçamentos para que o `POST` não seja bloqueado por proteção CSRF e melhorar a resposta visual do botão durante a requisição.

### Description
- Atualizei `templates/partials/historico_orcamentos.html` para enviar o header `X-CSRFToken` na chamada `fetch` ao endpoint `/pagar_orcamento/<id>`.
- Altereio o `onclick` do botão para passar o elemento (`this`) à função `enviarBlocoParaPagamento` e adicionei lógica para desabilitar o botão e mostrar um `spinner` durante a requisição.
- Garanti que o botão seja restaurado no bloco `finally` em caso de sucesso ou erro e mantive a atualização do histórico quando a resposta contém `html`/`redirect_url`.

### Testing
- Nenhum teste automatizado foi executado; as alterações foram validadas localmente inspecionando o `git diff` e confirmando o commit de `templates/partials/historico_orcamentos.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4767635c832e8e6498887ea7a021)