### PR TITLE
Ajusta alinhamento visual da ficha do tutor

### DIFF
--- a/static/css/tutor_detail.css
+++ b/static/css/tutor_detail.css
@@ -15,9 +15,13 @@
 
 .tutor-hero__content {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 1.5rem 2.5rem;
+}
+
+.tutor-hero__main {
+  min-width: 0;
 }
 
 .tutor-avatar {
@@ -199,6 +203,10 @@
     grid-template-columns: 1fr;
     justify-items: center;
     text-align: center;
+  }
+
+  .tutor-avatar {
+    order: -1;
   }
 
   .tutor-hero__content .flex-grow-1 {

--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -30,21 +30,7 @@
       </div>
 
       <div class="tutor-hero__content mt-3">
-        <div class="tutor-avatar">
-          <img
-            id="preview-tutor"
-            src="{{ tutor.profile_photo or '' }}"
-            alt="Foto do Tutor"
-            class="avatar {% if not tutor.profile_photo %}d-none{% endif %}"
-            style="--avatar-size:140px;"
-            loading="lazy"
-            data-offset-x="{{ tutor.photo_offset_x or 0 }}"
-            data-offset-y="{{ tutor.photo_offset_y or 0 }}"
-            data-rotation="{{ tutor.photo_rotation or 0 }}"
-            data-zoom="{{ tutor.photo_zoom or 1 }}">
-          <div class="avatar-ring"></div>
-        </div>
-        <div class="flex-grow-1">
+        <div class="tutor-hero__main">
           <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
             <h2 class="mb-0">{{ tutor.name }}</h2>
             {% if tutor.worker %}
@@ -80,6 +66,20 @@
               <strong>{{ tutor.created_at.strftime('%d/%m/%Y') if tutor.created_at else '—' }}</strong>
             </div>
           </div>
+        </div>
+        <div class="tutor-avatar">
+          <img
+            id="preview-tutor"
+            src="{{ tutor.profile_photo or '' }}"
+            alt="Foto do Tutor"
+            class="avatar {% if not tutor.profile_photo %}d-none{% endif %}"
+            style="--avatar-size:140px;"
+            loading="lazy"
+            data-offset-x="{{ tutor.photo_offset_x or 0 }}"
+            data-offset-y="{{ tutor.photo_offset_y or 0 }}"
+            data-rotation="{{ tutor.photo_rotation or 0 }}"
+            data-zoom="{{ tutor.photo_zoom or 1 }}">
+          <div class="avatar-ring"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Melhorar o alinhamento e apresentação do bloco de destaque da ficha do tutor para que a foto apareça à direita do nome e das informações, resultando em aparência mais equilibrada e profissional semelhante à página de consulta. 
- Preservar comportamento responsivo para que em telas menores a foto seja priorizada no topo, mantendo boa legibilidade.

### Description
- Reestruturei o HTML de `templates/animais/tutor_detail.html` criando o bloco `tutor-hero__main` para o conteúdo textual e deixando o avatar em uma coluna separada para facilitar posicionamento. 
- Ajustei o CSS em `static/css/tutor_detail.css` alterando `grid-template-columns` para `minmax(0, 1fr) auto`, adicionando `.tutor-hero__main { min-width: 0; }` para evitar overflow e aplicando `order: -1` ao `.tutor-avatar` em mobile para trazer a imagem ao topo. 
- As alterações visam melhorar consistência de largura, evitar estouros de layout e oferecer uma hierarquia visual mais clara entre texto e imagem.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4894dfbc832e90a2eb795b356a1b)