### PR TITLE
Ajusta alinhamento do campo de foto na ficha do tutor

### DIFF
--- a/static/css/tutor_detail.css
+++ b/static/css/tutor_detail.css
@@ -218,3 +218,20 @@
     justify-content: center;
   }
 }
+
+.tutor-photo-field {
+  display: flex;
+  flex-direction: column;
+}
+
+.tutor-photo-field .photo-uploader {
+  flex: 1;
+  min-height: 184px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tutor-photo-field .photo-uploader .photo-cropper {
+  width: 100%;
+}

--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -145,7 +145,7 @@
               <label class="form-label">Idade</label>
               <input id="tutor_age" type="number" class="form-control" min="0">
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4 tutor-photo-field">
               <label class="form-label">Foto do Tutor</label>
               <div class="photo-uploader">
                 {{ photo_cropper(tutor_form.profile_photo, tutor_form.photo_rotation, tutor_form.photo_zoom, tutor_form.photo_offset_x, tutor_form.photo_offset_y, tutor.profile_photo, 150, 'profile_photo', 'user') }}


### PR DESCRIPTION
### Motivation
- Melhorar o alinhamento do campo "Foto do Tutor" no formulário de dados do tutor para que fique alinhado com os campos "Data de Nascimento" e "Idade" e evitar desalinhamento em desktop.

### Description
- Adiciona a classe `tutor-photo-field` em `templates/animais/tutor_detail.html` na coluna que contém o uploader de foto.
- Atualiza `static/css/tutor_detail.css` com regras que tornam a coluna um container flex vertical, fazem `.photo-uploader` usar `flex: 1` com `min-height: 184px` e centralizam o conteúdo, e ajustam `.photo-cropper` para `width: 100%`.

### Testing
- Nenhuma suíte automatizada foi executada, pois a alteração é puramente visual/CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd49ab21ec832e9bb54238f6e93422)