### PR TITLE
Enviar link de pagamento por WhatsApp e mensagem interna ao tutor

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from io import BytesIO, StringIO
 from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal, InvalidOperation
 from functools import wraps
-from urllib.parse import urlparse, parse_qs, urlencode
+from urllib.parse import quote_plus, urlparse, parse_qs, urlencode
 from typing import Iterable, Optional, Set, Dict
 
 # Tests and factory imports may load this module through either name. Keep both
@@ -26741,11 +26741,53 @@ def pagar_orcamento(bloco_id):
         preference=preference,
         sync_payment_classification=_sync_orcamento_payment_classification,
     )
+
+    tutor = getattr(animal, 'owner', None)
+    tutor_user_id = getattr(animal, 'user_id', None)
+    tutor_phone = getattr(tutor, 'phone', None) if tutor else None
+    tutor_name = getattr(tutor, 'name', 'tutor') if tutor else 'tutor'
+    animal_name = getattr(animal, 'name', 'pet')
+    app_message_sent = False
+    whatsapp_url = None
+    message_content = (
+        f'Olá {tutor_name}! O link de pagamento do orçamento de {animal_name} já está disponível:\n'
+        f'{preference.payment_url}'
+    )
+
+    if tutor_phone:
+        whatsapp_url = (
+            f'https://api.whatsapp.com/send?phone={formatar_telefone(tutor_phone)}'
+            f'&text={quote_plus(message_content)}'
+        )
+
+    if tutor_user_id:
+        try:
+            db.session.add(
+                Message(
+                    sender_id=current_user.id,
+                    receiver_id=tutor_user_id,
+                    animal_id=animal.id,
+                    clinica_id=bloco.clinica_id,
+                    content=message_content,
+                    lida=False,
+                )
+            )
+            db.session.commit()
+            app_message_sent = True
+        except Exception:  # pragma: no cover - avoid breaking payment flow on chat failure
+            db.session.rollback()
+            current_app.logger.exception(
+                'Falha ao registrar mensagem interna de pagamento para bloco %s',
+                bloco.id,
+            )
+
     if request.accept_mimetypes.accept_json:
         historico_html = _render_orcamento_history(bloco.animal, bloco.clinica_id)
         return jsonify({
             'success': True,
             'redirect_url': preference.payment_url,
+            'whatsapp_url': whatsapp_url,
+            'app_message_sent': app_message_sent,
             'payment_status': preference.payment_status,
             'html': historico_html,
             'message': 'Link de pagamento gerado com sucesso.'

--- a/templates/partials/historico_orcamentos.html
+++ b/templates/partials/historico_orcamentos.html
@@ -153,8 +153,14 @@ if (!window.enviarBlocoParaPagamento) {
       if (data.redirect_url) {
         window.open(data.redirect_url, '_blank');
       }
+      if (data.whatsapp_url) {
+        window.open(data.whatsapp_url, '_blank');
+      }
       if (typeof showToast === 'function') {
-        showToast(data.message || 'Pagamento iniciado.', 'success');
+        const successMessage = data.app_message_sent
+          ? (data.message || 'Pagamento iniciado.') + ' Link enviado no WhatsApp e também nas mensagens do tutor.'
+          : (data.message || 'Pagamento iniciado.');
+        showToast(successMessage, 'success');
       }
     } catch (error) {
       if (typeof showToast === 'function') {


### PR DESCRIPTION
### Motivation
- Permitir que o fluxo de “Enviar para pagamento” compartilhe o link com o tutor via WhatsApp e registre o envio também nas mensagens internas do aplicativo para melhorar a comunicação do orçamento.
- Fornecer ao frontend informações suficientes para abrir automaticamente o WhatsApp e informar ao usuário quando a mensagem interna foi registrada.

### Description
- No endpoint `pagar_orcamento` adiciona a montagem de `message_content` com saudação e `preference.payment_url` e constrói `whatsapp_url` usando `https://api.whatsapp.com/send` com `quote_plus` para codificar o texto.
- Persiste um `Message` interno direcionado ao tutor (quando o tutor estiver associado como `user_id`) protegendo o fluxo com `try/except` e `db.session.rollback()` para não interromper o processo de pagamento em caso de falha.
- A resposta JSON do endpoint passa agora `whatsapp_url` e `app_message_sent` além de `redirect_url` e `html`, permitindo que o frontend reaja ao novo estado.
- No template `templates/partials/historico_orcamentos.html` o success handler abre `data.redirect_url` (pagamento) e `data.whatsapp_url` (WhatsApp) quando presentes e ajusta o texto do toast para informar quando a mensagem interna também foi enviada.

### Testing
- Executado `python -m compileall app.py templates/partials/historico_orcamentos.html` e a compilação completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4ad41be8832e9233627b0ebcf0c6)