### PR TITLE
Restrict clinic detail access to clinic owner and admins

### DIFF
--- a/app.py
+++ b/app.py
@@ -14327,6 +14327,8 @@ def clinic_detail(clinica_id):
     from models import VetClinicInvite
 
     is_owner = current_user.id == clinica.owner_id if current_user.is_authenticated else False
+    if not _is_admin() and not is_owner:
+        abort(403)
     staff = None
     if current_user.is_authenticated:
         staff = ClinicStaff.query.filter_by(clinic_id=clinica.id, user_id=current_user.id).first()


### PR DESCRIPTION
### Motivation
- Prevent non-owner authenticated users from viewing sensitive clinic pages by ensuring only the clinic owner or admins can access the `clinic_detail` view (`/clinica/<id>`). 

### Description
- Added an explicit authorization gate in `clinic_detail` (in `app.py`) that returns `abort(403)` if the requester is not an admin and not the clinic owner, preserving access for admins and the owner.

### Testing
- Ran `python -m py_compile app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4cfd1b60832ea995f5350bd1a6dc)