### PR TITLE
Enviar para tutor sem abrir checkout e CTA de pagamento colorida

### DIFF
--- a/app.py
+++ b/app.py
@@ -26750,8 +26750,10 @@ def pagar_orcamento(bloco_id):
     app_message_sent = False
     whatsapp_url = None
     message_content = (
-        f'Olá {tutor_name}! O link de pagamento do orçamento de {animal_name} já está disponível:\n'
-        f'{preference.payment_url}'
+        f'Olá, {tutor_name}.\n\n'
+        f'O orçamento de {animal_name} foi finalizado e o link de pagamento está disponível:\n'
+        f'{preference.payment_url}\n\n'
+        'Para concluir, acesse o link acima e siga as instruções de pagamento.'
     )
 
     if tutor_phone:
@@ -26785,7 +26787,6 @@ def pagar_orcamento(bloco_id):
         historico_html = _render_orcamento_history(bloco.animal, bloco.clinica_id)
         return jsonify({
             'success': True,
-            'redirect_url': preference.payment_url,
             'whatsapp_url': whatsapp_url,
             'app_message_sent': app_message_sent,
             'payment_status': preference.payment_status,

--- a/templates/partials/historico_orcamentos.html
+++ b/templates/partials/historico_orcamentos.html
@@ -108,9 +108,13 @@
           </a>
           {% endif %}
         {% endif %}
-        <button type="button" class="btn btn-outline-success btn-sm" data-pagamento-btn onclick="enviarBlocoParaPagamento({{ bloco.id }}, this)"><i class="fas fa-credit-card me-1"></i>Enviar para pagamento</button>
+        <button type="button" class="btn btn-outline-success btn-sm" data-pagamento-btn onclick="enviarBlocoParaPagamento({{ bloco.id }}, this)"><i class="fas fa-paper-plane me-1"></i>Enviar para tutor</button>
         {% if bloco.payment_link %}
-        <a href="{{ bloco.payment_link }}" target="_blank" class="btn btn-outline-info btn-sm"><i class="fas fa-link me-1"></i>Link atual</a>
+        {% set pay_status = bloco.payment_status or 'pending' %}
+        {% set is_overdue = pay_status == 'failed' %}
+        {% set payment_btn_class = 'btn-success' if pay_status == 'paid' else ('btn-danger' if is_overdue else 'btn-warning text-dark') %}
+        {% set payment_btn_label = 'Pagamento realizado' if pay_status == 'paid' else ('Pagamento em atraso' if is_overdue else 'Realizar pagamento') %}
+        <a href="{{ bloco.payment_link }}" target="_blank" class="btn {{ payment_btn_class }} btn-sm fw-semibold"><i class="fas fa-credit-card me-1"></i>{{ payment_btn_label }}</a>
         {% endif %}
       </div>
     </div>
@@ -149,9 +153,6 @@ if (!window.enviarBlocoParaPagamento) {
       if (data.html && historico) {
         historico.innerHTML = data.html;
         if (typeof bindSyncForms === 'function') { bindSyncForms(historico); }
-      }
-      if (data.redirect_url) {
-        window.open(data.redirect_url, '_blank');
       }
       if (data.whatsapp_url) {
         window.open(data.whatsapp_url, '_blank');


### PR DESCRIPTION
### Motivation
- Tornar a mensagem enviada ao tutor mais profissional e informativa ao gerar link de pagamento. 
- Evitar que o frontend abra automaticamente a página de checkout ao clicar em “Enviar para tutor”, deixando apenas o envio por WhatsApp e mensagem interna. 
- Deixar o CTA de pagamento no histórico mais claro visualmente, com cores que refletem o status do pagamento.

### Description
- Atualiza o conteúdo enviado ao tutor em `app.py` substituindo a saudação informal por um texto mais profissional e instruções claras (`message_content`).
- Remove o `redirect_url` da resposta JSON em `/pagar_orcamento/<id>` (mantendo `whatsapp_url` e `app_message_sent`) para evitar abertura automática do checkout no cliente. (`app.py`)
- Altera o botão no template `templates/partials/historico_orcamentos.html` de “Enviar para pagamento” para `Enviar para tutor` e troca o ícone para `fa-paper-plane`.
- Substitui o link atual por um botão com classes dinâmicas que exibem cor/label baseado em `bloco.payment_status` (amarelo = pendente, vermelho = atraso/falha, verde = pago) e remove a chamada que abria `data.redirect_url` no JavaScript do histórico.

### Testing
- Executed `python -m pytest -q tests/test_pagar_bloco_orcamento.py`; the run failed with a 502/connection error due to `mercadopago` SDK complaining about an invalid/missing `MERCADOPAGO_ACCESS_TOKEN` in the test environment, which is unrelated to the UI/json changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4dbb48dc832e8e8f6b6a77cb15d8)