### PR TITLE
Centraliza autorização por recurso e aplica camada authz em rotas de orçamento

### DIFF
--- a/app.py
+++ b/app.py
@@ -1673,6 +1673,11 @@ from services import (
     update_financial_snapshots_daily,
 )
 from services.geocode_queue import AddressGeocodeQueue
+from authz import (
+    can_manage_budget,
+    can_view_budget,
+    can_view_clinic,
+)
 from services.finance import (
     build_accounting_dashboard,
     build_cash_flow_report,
@@ -2625,14 +2630,10 @@ def get_user_or_404(user_id, *, viewer=None, clinic_scope=None):
 
 
 def ensure_clinic_access(clinica_id):
-    """Abort with 404 if the current user cannot access the given clinic."""
-    if not clinica_id:
-        return
-    if not current_user.is_authenticated:
+    """Abort with 404 if the current user cannot view the given clinic."""
+    if not clinica_id or not current_user.is_authenticated:
         abort(404)
-    if current_user.is_authenticated and current_user.role == 'admin':
-        return
-    if clinica_id not in _viewer_operational_clinic_ids(current_user):
+    if not can_view_clinic(current_user, clinica_id):
         abort(404)
 
 
@@ -26672,7 +26673,8 @@ def imprimir_bloco_orcamento(bloco_id):
 @login_required
 def imprimir_orcamento_padrao(orcamento_id):
     orcamento = Orcamento.query.get_or_404(orcamento_id)
-    ensure_clinic_access(orcamento.clinica_id)
+    if not can_view_budget(current_user, orcamento.clinica_id, orcamento.consulta_id):
+        abort(404)
     return render_template(
         'orcamentos/imprimir_orcamento_padrao.html',
         itens=orcamento.items,
@@ -26801,7 +26803,8 @@ def pagar_orcamento(bloco_id):
 @login_required
 def gerar_link_pagamento_orcamento(orcamento_id):
     orcamento = Orcamento.query.get_or_404(orcamento_id)
-    ensure_clinic_access(orcamento.clinica_id)
+    if not can_manage_budget(current_user, orcamento.clinica_id, orcamento.consulta_id):
+        abort(404)
     if not orcamento.items:
         return jsonify({'success': False, 'message': 'Nenhum item no orçamento.'}), 400
 
@@ -26915,7 +26918,8 @@ def adicionar_orcamento_item(consulta_id):
     clinic_id = _coerce_int(data.get('clinica_id'))
     if clinic_id is None:
         return jsonify({'success': False, 'message': 'Clínica obrigatória.'}), 400
-    ensure_clinic_access(clinic_id)
+    if not can_manage_budget(current_user, clinic_id, consulta.id):
+        abort(404)
     if consulta.clinica_id and consulta.clinica_id != clinic_id:
         return jsonify({'success': False, 'message': 'Consulta pertence a outra clínica.'}), 400
     if not consulta.clinica_id:
@@ -26988,7 +26992,8 @@ def deletar_orcamento_item(item_id):
     if not is_veterinarian(current_user):
         return jsonify({'success': False, 'message': 'Apenas veterinários podem remover itens.'}), 403
     consulta = item.consulta
-    ensure_clinic_access(consulta.clinica_id)
+    if not can_manage_budget(current_user, consulta.clinica_id, consulta.id):
+        abort(404)
     db.session.delete(item)
     db.session.commit()
     return jsonify({'total': float(consulta.total_orcamento)}), 200
@@ -27006,7 +27011,8 @@ def salvar_bloco_orcamento(consulta_id):
     clinic_id = _coerce_int(data.get('clinica_id'))
     if clinic_id is None:
         return jsonify({'success': False, 'message': 'Clínica obrigatória.'}), 400
-    ensure_clinic_access(clinic_id)
+    if not can_manage_budget(current_user, clinic_id, consulta.id):
+        abort(404)
     if consulta.clinica_id and consulta.clinica_id != clinic_id:
         return jsonify({'success': False, 'message': 'Consulta pertence a outra clínica.'}), 400
     if not consulta.clinica_id:
@@ -27067,8 +27073,8 @@ def historico_orcamentos_partial(consulta_id):
     consulta = get_consulta_or_404(consulta_id)
     clinic_id = consulta.clinica_id or current_user_clinic_id() or getattr(consulta.animal, 'clinica_id', None)
 
-    if clinic_id:
-        ensure_clinic_access(clinic_id)
+    if clinic_id and not can_view_budget(current_user, clinic_id, consulta.id):
+        abort(404)
 
     historico_html = _render_orcamento_history(consulta.animal, clinic_id)
     return jsonify({'success': True, 'html': historico_html})
@@ -27078,7 +27084,8 @@ def historico_orcamentos_partial(consulta_id):
 @login_required
 def deletar_bloco_orcamento(bloco_id):
     bloco = BlocoOrcamento.query.get_or_404(bloco_id)
-    ensure_clinic_access(bloco.clinica_id)
+    if not can_manage_budget(current_user, bloco.clinica_id):
+        abort(404)
     if not is_veterinarian(current_user):
         return jsonify({'success': False, 'message': 'Apenas veterinários podem excluir.'}), 403
     animal_id = bloco.animal_id
@@ -27099,7 +27106,8 @@ def deletar_bloco_orcamento(bloco_id):
 @login_required
 def editar_bloco_orcamento(bloco_id):
     bloco = BlocoOrcamento.query.get_or_404(bloco_id)
-    ensure_clinic_access(bloco.clinica_id)
+    if not can_manage_budget(current_user, bloco.clinica_id):
+        abort(404)
     if not is_veterinarian(current_user):
         return jsonify({'success': False, 'message': 'Apenas veterinários podem editar.'}), 403
     return render_template('orcamentos/editar_bloco_orcamento.html', bloco=bloco)
@@ -27109,7 +27117,8 @@ def editar_bloco_orcamento(bloco_id):
 @login_required
 def atualizar_bloco_orcamento(bloco_id):
     bloco = BlocoOrcamento.query.get_or_404(bloco_id)
-    ensure_clinic_access(bloco.clinica_id)
+    if not can_manage_budget(current_user, bloco.clinica_id):
+        abort(404)
     if not is_veterinarian(current_user):
         return jsonify({'success': False, 'message': 'Apenas veterinários podem editar.'}), 403
 
@@ -27117,7 +27126,8 @@ def atualizar_bloco_orcamento(bloco_id):
     clinic_id = _coerce_int(data.get('clinica_id'))
     if clinic_id is None:
         return jsonify({'success': False, 'message': 'Clínica obrigatória.'}), 400
-    ensure_clinic_access(clinic_id)
+    if not can_manage_budget(current_user, clinic_id):
+        abort(404)
     if clinic_id != bloco.clinica_id:
         abort(404)
     itens = data.get('itens', [])

--- a/authz.py
+++ b/authz.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from flask_login import current_user
+
+
+SENSITIVE_RESOURCES = {
+    "clinic": "Dados gerais e administrativos da clínica",
+    "budget": "Orçamentos, itens e blocos de orçamento",
+    "consultation": "Consultas, evoluções e prontuário clínico",
+    "financial": "Pagamentos, relatórios contábeis e fluxo financeiro",
+    "fiscal_documents": "NFSe/NFe, certificados e documentos fiscais",
+    "personal_data": "Dados pessoais de tutores, veterinários e equipe",
+}
+
+ROLE_PERMISSION_MATRIX = {
+    "admin": {resource: {"view": True, "manage": True} for resource in SENSITIVE_RESOURCES},
+    "owner": {resource: {"view": True, "manage": True} for resource in SENSITIVE_RESOURCES},
+    "staff": {
+        "clinic": {"view": True, "manage": False},
+        "budget": {"view": True, "manage": True},
+        "consultation": {"view": True, "manage": True},
+        "financial": {"view": True, "manage": False},
+        "fiscal_documents": {"view": False, "manage": False},
+        "personal_data": {"view": True, "manage": False},
+    },
+    "veterinario": {
+        "clinic": {"view": True, "manage": False},
+        "budget": {"view": True, "manage": True},
+        "consultation": {"view": True, "manage": True},
+        "financial": {"view": True, "manage": False},
+        "fiscal_documents": {"view": False, "manage": False},
+        "personal_data": {"view": True, "manage": False},
+    },
+    "tutor": {
+        "clinic": {"view": False, "manage": False},
+        "budget": {"view": True, "manage": False},
+        "consultation": {"view": True, "manage": False},
+        "financial": {"view": False, "manage": False},
+        "fiscal_documents": {"view": False, "manage": False},
+        "personal_data": {"view": True, "manage": True},
+    },
+}
+
+
+def _user_roles(user: Any) -> set[str]:
+    if not user:
+        return set()
+    roles: set[str] = set()
+    if getattr(user, "role", None) == "admin":
+        roles.add("admin")
+    worker = (getattr(user, "worker", None) or "").lower()
+    if worker in {"colaborador", "staff", "assistente"}:
+        roles.add("staff")
+    if worker == "veterinario" or getattr(user, "veterinario", None):
+        roles.add("veterinario")
+    if getattr(user, "clinicas", None):
+        roles.add("owner")
+    if not roles:
+        roles.add("tutor")
+    return roles
+
+
+def _viewer_operational_clinic_ids(user: Any) -> set[int]:
+    ids: set[int] = set()
+    if not user:
+        return ids
+    for clinic in getattr(user, "clinicas", []) or []:
+        if getattr(clinic, "id", None):
+            ids.add(clinic.id)
+    clinic_id = getattr(user, "clinica_id", None)
+    if clinic_id:
+        ids.add(clinic_id)
+    vet = getattr(user, "veterinario", None)
+    if vet:
+        if getattr(vet, "clinica_id", None):
+            ids.add(vet.clinica_id)
+        for clinic in getattr(vet, "clinicas", []) or []:
+            if getattr(clinic, "id", None):
+                ids.add(clinic.id)
+    for role in getattr(user, "clinic_roles", []) or []:
+        if getattr(role, "clinic_id", None):
+            ids.add(role.clinic_id)
+    return ids
+
+
+def _can(user: Any, resource: str, action: str) -> bool:
+    roles = _user_roles(user)
+    for role in roles:
+        if ROLE_PERMISSION_MATRIX.get(role, {}).get(resource, {}).get(action):
+            return True
+    return False
+
+
+def can_view_clinic(user: Any, clinic_id: int | None) -> bool:
+    return bool(clinic_id) and _can(user, "clinic", "view") and int(clinic_id) in _viewer_operational_clinic_ids(user)
+
+
+def can_manage_clinic(user: Any, clinic_id: int | None) -> bool:
+    return bool(clinic_id) and _can(user, "clinic", "manage") and int(clinic_id) in _viewer_operational_clinic_ids(user)
+
+
+def can_view_budget(user: Any, clinic_id: int | None, consultation_id: int | None = None) -> bool:
+    del consultation_id
+    return bool(clinic_id) and _can(user, "budget", "view") and int(clinic_id) in _viewer_operational_clinic_ids(user)
+
+
+def can_manage_budget(user: Any, clinic_id: int | None, consultation_id: int | None = None) -> bool:
+    del consultation_id
+    return bool(clinic_id) and _can(user, "budget", "manage") and int(clinic_id) in _viewer_operational_clinic_ids(user)
+
+
+def can_view_financial(user: Any, clinic_id: int | None) -> bool:
+    return bool(clinic_id) and _can(user, "financial", "view") and int(clinic_id) in _viewer_operational_clinic_ids(user)
+
+
+def can_view_fiscal_documents(user: Any, clinic_id: int | None) -> bool:
+    return bool(clinic_id) and _can(user, "fiscal_documents", "view") and int(clinic_id) in _viewer_operational_clinic_ids(user)
+
+
+def can_manage_fiscal_documents(user: Any, clinic_id: int | None) -> bool:
+    return bool(clinic_id) and _can(user, "fiscal_documents", "manage") and int(clinic_id) in _viewer_operational_clinic_ids(user)
+
+
+def can_view_personal_data(user: Any, owner_user_id: int | None) -> bool:
+    return bool(user and owner_user_id and getattr(user, "id", None) == owner_user_id) or _can(user, "personal_data", "view")


### PR DESCRIPTION
### Motivation
- Centralizar a lógica de autorização para eliminar verificações ad‑hoc espalhadas e criar uma fonte única de verdade para recursos sensíveis (clínica, orçamento, consulta, financeiro, documentos fiscais, dados pessoais). 
- Evitar vazamento por enumeração mantendo a política de responder `404` quando o usuário não tem visibilidade do recurso.

### Description
- Adiciona o módulo `authz.py` que define `SENSITIVE_RESOURCES`, uma `ROLE_PERMISSION_MATRIX` e funções públicas por recurso como `can_view_clinic`, `can_manage_clinic`, `can_view_budget`, `can_manage_budget`, `can_view_financial`, `can_view_fiscal_documents` e `can_view_personal_data`.
- Substitui verificações ad‑hoc relacionadas a clínica/orçamento em `app.py` por chamadas à camada `authz` e importa `can_view_clinic`, `can_view_budget` e `can_manage_budget` onde necessário.
- Atualiza `ensure_clinic_access` para delegar a decisão de visibilidade a `can_view_clinic` mantendo o comportamento de abortar com `404` quando não autorizado.
- Aplica as novas verificações em fluxos de orçamento (impressão, geração de link de pagamento, adicionar/remover itens, salvar/editar/deletar bloco, histórico), preservando mensagens e retornos existentes para outros erros.

### Testing
- Executado `python -m py_compile authz.py app.py` e a checagem passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4e673018832e9fa50af5c99f6485)