### PR TITLE
Melhora layout de mensagens de pagamento no chat

### DIFF
--- a/templates/mensagens/conversa.html
+++ b/templates/mensagens/conversa.html
@@ -3,12 +3,27 @@
 
 <h2>Conversando sobre {{ animal.name }} com {{ outro_usuario.name }}</h2>
 
+<style>
+  .payment-message {
+    border: 1px solid #cfe2ff;
+    background: linear-gradient(180deg, #f8fbff 0%, #eef5ff 100%);
+  }
+</style>
+
 <div id="mensagens-container" class="border p-3 mb-3 rounded" style="max-height: 400px; overflow-y: auto;">
     {% for msg in mensagens %}
         <div class="mb-2 {% if msg.sender_id == current_user.id %}text-end{% endif %}">
             <div class="p-2 rounded {% if msg.sender_id == current_user.id %}bg-info-subtle{% else %}bg-light{% endif %}">
                 <small>{{ msg.sender.name }}:</small><br>
-                {{ msg.content }}
+                {% if 'mercadopago.com.br/checkout' in msg.content %}
+                  <div class="payment-message rounded p-3 mt-2">
+                    <div class="fw-semibold text-primary mb-1">Pagamento da consulta disponível</div>
+                    <div class="small text-muted mb-2">Finalize o pagamento no botão abaixo para confirmar a consulta.</div>
+                    <a href="{{ msg.content|trim }}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">Pagar consulta</a>
+                  </div>
+                {% else %}
+                  {{ msg.content }}
+                {% endif %}
                 <div class="text-muted small">{{ msg.timestamp|format_datetime_brazil('%d/%m %H:%M') }}</div>
             </div>
         </div>

--- a/templates/mensagens/conversa_admin.html
+++ b/templates/mensagens/conversa_admin.html
@@ -113,12 +113,27 @@
   </div>
 {% endif %}
 
+<style>
+  .payment-message {
+    border: 1px solid #cfe2ff;
+    background: linear-gradient(180deg, #f8fbff 0%, #eef5ff 100%);
+  }
+</style>
+
 <div id="mensagens-container" class="border p-3 mb-3 rounded" style="max-height: 400px; overflow-y: auto;">
     {% for msg in mensagens %}
         <div class="mb-2 {% if msg.sender_id == current_user.id %}text-end{% endif %}">
             <div class="p-2 rounded {% if msg.sender_id == current_user.id %}bg-info-subtle{% else %}bg-light{% endif %}">
                 <small>{{ msg.sender.name }}:</small><br>
-                {{ msg.content }}
+                {% if 'mercadopago.com.br/checkout' in msg.content %}
+                  <div class="payment-message rounded p-3 mt-2">
+                    <div class="fw-semibold text-primary mb-1">Pagamento da consulta disponível</div>
+                    <div class="small text-muted mb-2">Finalize o pagamento no botão abaixo para confirmar a consulta.</div>
+                    <a href="{{ msg.content|trim }}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">Pagar consulta</a>
+                  </div>
+                {% else %}
+                  {{ msg.content }}
+                {% endif %}
                 <div class="text-muted small">{{ msg.timestamp|format_datetime_brazil('%d/%m %H:%M') }}</div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Tornar mensagens com link de checkout do Mercado Pago mais claras e visualmente oficiais para evitar que pareçam um erro e facilitar o pagamento da consulta.

### Description
- Detecta quando `msg.content` contém `mercadopago.com.br/checkout` e renderiza um card visual com título, texto explicativo e botão de ação `Pagar consulta` em vez de exibir a URL bruta.
- Adiciona o estilo `.payment-message` e aplica a renderização nas templates `templates/mensagens/conversa.html` e `templates/mensagens/conversa_admin.html`.
- Mantém o comportamento anterior para mensagens que não contenham o link, preservando compatibilidade com o fluxo atual.

### Testing
- Nenhum teste automatizado foi executado para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4fc97e7c832e821dc1e3d7fce5b7)