### PR TITLE
Padroniza carregamento de clínica com validação de escopo

### DIFF
--- a/app/routes/fiscal_onboarding.py
+++ b/app/routes/fiscal_onboarding.py
@@ -9,7 +9,6 @@ from flask_login import current_user, login_required
 from extensions import db
 from helpers import has_veterinarian_profile
 from models import (
-    Clinica,
     FiscalCertificate,
     FiscalDocument,
     FiscalDocumentStatus,
@@ -21,6 +20,7 @@ from models import (
 )
 from security.crypto import encrypt_bytes, encrypt_text
 from services.fiscal.certificate import parse_pfx
+from authz import get_clinic_or_403
 
 
 FISCAL_UF_CODES = {
@@ -96,7 +96,9 @@ def fiscal_onboarding_step(step: int):
     if not clinic_id:
         abort(403)
 
-    clinic = Clinica.query.filter_by(id=clinic_id).first_or_404()
+    clinic = get_clinic_or_403(clinic_id, current_user)
+    if clinic is None:
+        abort(403)
     emitter = FiscalEmitter.query.filter_by(clinic_id=clinic_id).first()
     certificates = []
     if emitter:

--- a/authz.py
+++ b/authz.py
@@ -126,3 +126,19 @@ def can_manage_fiscal_documents(user: Any, clinic_id: int | None) -> bool:
 
 def can_view_personal_data(user: Any, owner_user_id: int | None) -> bool:
     return bool(user and owner_user_id and getattr(user, "id", None) == owner_user_id) or _can(user, "personal_data", "view")
+
+
+def get_clinic_or_403(clinic_id: int | None, user: Any):
+    """Carrega clínica somente dentro do escopo autorizado do usuário."""
+    if not clinic_id:
+        return None
+    try:
+        clinic_id = int(clinic_id)
+    except (TypeError, ValueError):
+        return None
+    if not can_view_clinic(user, clinic_id):
+        return None
+
+    from models import Clinica
+
+    return Clinica.query.filter_by(id=clinic_id).first()


### PR DESCRIPTION
### Motivation
- Centralizar o carregamento de uma `Clinica` aplicando a validação de escopo do usuário para evitar consultas diretas por ID sem checagem de autorização.
- Evitar padrões perigosos como `Model.query.get(id)` sem filtro de tenant/ownership e padronizar comportamento para endpoints que recebem IDs.

### Description
- Adiciona `get_clinic_or_403(clinic_id, user)` em `authz.py`, que normaliza o ID, valida `can_view_clinic` e retorna a `Clinica` apenas se estiver no escopo autorizado do usuário. 
- Substitui o carregamento direto da clínica em `fiscal_onboarding_step` (`Clinica.query.filter_by(...).first_or_404()`) por `get_clinic_or_403(...)` e converte a ausência de acesso em `abort(403)`.
- Remove o import direto de `Clinica` em `app/routes/fiscal_onboarding.py` já que o carregamento agora é feito pelo helper centralizado.

### Testing
- Executei `pytest -q tests/test_clinic_access.py tests/test_security_authorization.py` para validar alterações no fluxo afetado. 
- Resultado: a execução retornou `9 failed, 30 passed` no conjunto selecionado, sem indicar erro de sintaxe nas alterações aplicadas (falhas já presentes no conjunto de testes selecionado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4ffc96d4832ea738670b900c6467)