### PR TITLE
Fix payment message link handling in chat views

### DIFF
--- a/templates/mensagens/conversa.html
+++ b/templates/mensagens/conversa.html
@@ -15,11 +15,15 @@
         <div class="mb-2 {% if msg.sender_id == current_user.id %}text-end{% endif %}">
             <div class="p-2 rounded {% if msg.sender_id == current_user.id %}bg-info-subtle{% else %}bg-light{% endif %}">
                 <small>{{ msg.sender.name }}:</small><br>
-                {% if 'mercadopago.com.br/checkout' in msg.content %}
+                {% set payment_link = msg.content|trim %}
+                {% if 'mercadopago.com.br' in payment_link or 'mpago.la' in payment_link %}
+                  {% if not payment_link.startswith('http://') and not payment_link.startswith('https://') %}
+                    {% set payment_link = 'https://' ~ payment_link %}
+                  {% endif %}
                   <div class="payment-message rounded p-3 mt-2">
                     <div class="fw-semibold text-primary mb-1">Pagamento da consulta disponível</div>
                     <div class="small text-muted mb-2">Finalize o pagamento no botão abaixo para confirmar a consulta.</div>
-                    <a href="{{ msg.content|trim }}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">Pagar consulta</a>
+                    <a href="{{ payment_link }}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">Pagar consulta</a>
                   </div>
                 {% else %}
                   {{ msg.content }}

--- a/templates/mensagens/conversa_admin.html
+++ b/templates/mensagens/conversa_admin.html
@@ -125,11 +125,15 @@
         <div class="mb-2 {% if msg.sender_id == current_user.id %}text-end{% endif %}">
             <div class="p-2 rounded {% if msg.sender_id == current_user.id %}bg-info-subtle{% else %}bg-light{% endif %}">
                 <small>{{ msg.sender.name }}:</small><br>
-                {% if 'mercadopago.com.br/checkout' in msg.content %}
+                {% set payment_link = msg.content|trim %}
+                {% if 'mercadopago.com.br' in payment_link or 'mpago.la' in payment_link %}
+                  {% if not payment_link.startswith('http://') and not payment_link.startswith('https://') %}
+                    {% set payment_link = 'https://' ~ payment_link %}
+                  {% endif %}
                   <div class="payment-message rounded p-3 mt-2">
                     <div class="fw-semibold text-primary mb-1">Pagamento da consulta disponível</div>
                     <div class="small text-muted mb-2">Finalize o pagamento no botão abaixo para confirmar a consulta.</div>
-                    <a href="{{ msg.content|trim }}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">Pagar consulta</a>
+                    <a href="{{ payment_link }}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">Pagar consulta</a>
                   </div>
                 {% else %}
                   {{ msg.content }}


### PR DESCRIPTION
### Motivation
- Evitar que o botão de pagamento nas conversas abra uma URL relativa e gere `404 - Not Found` quando a mensagem contém um link do Mercado Pago sem protocolo ou em formato curto.

### Description
- Alterados os templates `templates/mensagens/conversa.html` e `templates/mensagens/conversa_admin.html` para tratar links de pagamento de forma mais robusta.
- Agora a mensagem é armazenada em `payment_link = msg.content|trim` e reconhece domínios `mercadopago.com.br` e `mpago.la` em vez de depender de um caminho específico.
- Se `payment_link` não começar com `http://` ou `https://`, o template prefixa `https://` automaticamente antes de renderizar o botão.
- O botão “Pagar consulta” passa a usar `payment_link`, mantendo o fluxo de renderização de mensagens normais sem alteração.

### Testing
- Nenhum teste automatizado foi executado para esta mudança (apenas revisão do diff e commits locais).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd511ca8cc832e88dda31840cb4543)