### PR TITLE
Corrige token CSRF ausente no formulário de exclusão de tutor

### DIFF
--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -23,6 +23,7 @@
         <form method="POST" action="{{ url_for('deletar_tutor', tutor_id=tutor.id) }}"
               onsubmit="return confirm('Tem certeza que deseja excluir este tutor e todos os seus dados permanentemente?');"
               class="ms-lg-auto">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="submit" class="btn btn-outline-danger btn-sm rounded-pill px-3 d-flex align-items-center gap-2">
             <i class="fas fa-trash"></i> Excluir tutor
           </button>


### PR DESCRIPTION
### Motivation
- Corrigir erro 400 "The CSRF token is missing" ao tentar excluir um tutor porque o formulário de exclusão não incluía o campo `csrf_token`.

### Description
- Adiciona um input hidden `csrf_token` no formulário de exclusão em `templates/animais/tutor_detail.html` para que o POST envie o token esperado pelo backend.

### Testing
- Não foram executados testes automatizados; alteração foi aplicada ao template e commitada localmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd53372f1c832eacfb1fa1eafd747a)