### PR TITLE
Add authorization decision audit logs and 403 denial metrics aggregation

### DIFF
--- a/authz.py
+++ b/authz.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections import Counter, deque
+from datetime import datetime, timedelta, timezone
+import logging
 from typing import Any
 
 from flask_login import current_user
+from flask import has_request_context, request
+
+from security.redact import redact_sensitive_text
 
 
 SENSITIVE_RESOURCES = {
@@ -43,6 +49,78 @@ ROLE_PERMISSION_MATRIX = {
         "personal_data": {"view": True, "manage": True},
     },
 }
+
+
+AUTHZ_AUDIT_LOGGER = logging.getLogger("authz.audit")
+_DENY_EVENTS_WINDOW = deque(maxlen=3000)
+
+
+def _masked_resource_identifier(resource_identifier: Any) -> str | None:
+    if resource_identifier is None:
+        return None
+    return redact_sensitive_text(str(resource_identifier))
+
+
+def _audit_authz_decision(
+    *,
+    user: Any,
+    role: str,
+    resource: str,
+    resource_identifier: Any,
+    allowed: bool,
+    reason: str,
+) -> None:
+    ip = None
+    user_agent = None
+    route = None
+    if has_request_context():
+        ip = request.headers.get("X-Forwarded-For", request.remote_addr)
+        user_agent = request.headers.get("User-Agent")
+        route = request.path
+
+    payload = {
+        "event": "authorization_decision",
+        "user_id": getattr(user, "id", None),
+        "role": role,
+        "resource": resource,
+        "resource_identifier": _masked_resource_identifier(resource_identifier),
+        "result": "allow" if allowed else "deny",
+        "reason": reason,
+        "ip": _masked_resource_identifier(ip),
+        "user_agent": _masked_resource_identifier(user_agent),
+        "route": route,
+    }
+    AUTHZ_AUDIT_LOGGER.info("authz_decision", extra={"authz": payload})
+
+    if not allowed:
+        _DENY_EVENTS_WINDOW.append(
+            {
+                "at": datetime.now(timezone.utc),
+                "route": route or "<unknown>",
+                "user_id": getattr(user, "id", None),
+                "ip": _masked_resource_identifier(ip) or "<unknown>",
+            }
+        )
+
+
+def summarize_authz_denials(window_minutes: int = 5, top_n: int = 5) -> dict[str, list[dict[str, Any]]]:
+    """Resumo para painel/alerta de picos de 403 por rota/usuário/IP."""
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=max(1, window_minutes))
+    recent = [event for event in _DENY_EVENTS_WINDOW if event["at"] >= cutoff]
+    by_route = Counter(event["route"] for event in recent)
+    by_user = Counter(str(event["user_id"]) for event in recent)
+    by_ip = Counter(event["ip"] for event in recent)
+
+    def _top(counter: Counter) -> list[dict[str, Any]]:
+        return [{"key": key, "count": count} for key, count in counter.most_common(top_n)]
+
+    return {
+        "window_minutes": window_minutes,
+        "total_denies": len(recent),
+        "by_route": _top(by_route),
+        "by_user": _top(by_user),
+        "by_ip": _top(by_ip),
+    }
 
 
 def _user_roles(user: Any) -> set[str]:
@@ -88,10 +166,25 @@ def _viewer_operational_clinic_ids(user: Any) -> set[int]:
 
 def _can(user: Any, resource: str, action: str) -> bool:
     roles = _user_roles(user)
+    allowed_roles: list[str] = []
     for role in roles:
         if ROLE_PERMISSION_MATRIX.get(role, {}).get(resource, {}).get(action):
-            return True
-    return False
+            allowed_roles.append(role)
+
+    reason = (
+        f"policy_allows:{','.join(sorted(allowed_roles))}:{resource}:{action}"
+        if allowed_roles
+        else f"policy_denies_all_roles:{resource}:{action}"
+    )
+    _audit_authz_decision(
+        user=user,
+        role=",".join(sorted(roles)) or "anonymous",
+        resource=f"{resource}:{action}",
+        resource_identifier=None,
+        allowed=bool(allowed_roles),
+        reason=reason,
+    )
+    return bool(allowed_roles)
 
 
 def can_view_clinic(user: Any, clinic_id: int | None) -> bool:

--- a/tests/unit/test_authz_audit.py
+++ b/tests/unit/test_authz_audit.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from authz import _audit_authz_decision, summarize_authz_denials
+
+
+class _User:
+    def __init__(self, user_id: int):
+        self.id = user_id
+
+
+def test_authz_denial_metrics_group_by_route_user_ip(app):
+    with app.test_request_context(
+        "/rota-protegida/12345678901", headers={"User-Agent": "pytest-agent", "X-Forwarded-For": "203.0.113.10"}
+    ):
+        _audit_authz_decision(
+            user=_User(7),
+            role="staff",
+            resource="consultation:view",
+            resource_identifier="consulta-12345678901",
+            allowed=False,
+            reason="fora_do_escopo_clinica",
+        )
+
+    snapshot = summarize_authz_denials(window_minutes=10)
+    assert snapshot["total_denies"] >= 1
+    assert any(item["key"] == "/rota-protegida/12345678901" for item in snapshot["by_route"])
+    assert any(item["key"] == "7" for item in snapshot["by_user"])
+    assert any(item["key"] == "203.0.113.10" for item in snapshot["by_ip"])


### PR DESCRIPTION
### Motivation
- For observability and incident detection we need structured audit records of authorization decisions including who, what resource, outcome and why.
- We must expose lightweight denial metrics so dashboards/alerts can detect spikes of 403s by route, user or IP.
- Logs must avoid leaking sensitive identifiers or request metadata, so redaction should be applied before writing.

### Description
- Added structured authorization audit logging in `authz.py` via `_audit_authz_decision`, recording `user_id`, `role`, `resource`, masked `resource_identifier`, decision (`allow`/`deny`), `reason`, masked IP and masked `User-Agent`, plus `route` when a request context exists.
- Reused existing redaction utility `redact_sensitive_text` to mask identifiers and request metadata before logging.
- Added an in-memory rolling buffer (`_DENY_EVENTS_WINDOW`) and `summarize_authz_denials(window_minutes, top_n)` to aggregate recent denial events grouped by route, user and IP for dashboard/alert consumption.
- Instrumented policy checks in `_can(...)` to emit audit events with a compact `policy_allows` / `policy_denies_all_roles` reason without changing existing permission semantics.
- Introduced unit test `tests/unit/test_authz_audit.py` which exercises `_audit_authz_decision` and `summarize_authz_denials` under a request context.

### Testing
- Ran `pytest -q tests/unit/test_authz_audit.py` and the test passed (`1 passed`).
- The change is limited to `authz.py` and the new unit test; existing authorization behavior is preserved while emitting audit and denial metrics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd53ee11b8832e8577f0406a17f247)