### PR TITLE
Remove redundant clinic action buttons from clinic detail header

### DIFF
--- a/templates/clinica/clinic_detail.html
+++ b/templates/clinica/clinic_detail.html
@@ -63,15 +63,7 @@
           <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
           Editar dados
         </a>
-        <a href="{{ clinic_new_animal_url }}" class="btn btn-outline-primary">
-          <i class="fa-solid fa-paw" aria-hidden="true"></i>
-          Novo animal
-        </a>
       {% endif %}
-      <a href="{{ url_for('novo_orcamento', clinica_id=clinica.id) }}" class="btn btn-outline-dark">
-        <i class="fa-solid fa-file-circle-plus" aria-hidden="true"></i>
-        Novo orçamento
-      </a>
     </div>
   </section>
 


### PR DESCRIPTION
### Motivation
- Remover os botões redundantes “Novo animal” e “Novo orçamento” do cabeçalho da página de clínica para reduzir duplicação e manter apenas a ação de edição.

### Description
- Removidos os botões `Novo animal` e `Novo orçamento` do bloco `clinic-context-card__actions` em `templates/clinica/clinic_detail.html`, preservando apenas o botão `Editar dados`.

### Testing
- Atualização automática do trecho HTML aplicada e verificada com `nl -ba templates/clinica/clinic_detail.html | sed -n '52,90p'`, e alteração confirmada com `git commit`, todos os passos concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c28f523c832e81021b7a2ee545da)