### PR TITLE
Destacar animais falecidos na listagem do tutor

### DIFF
--- a/templates/animais/tutor_detail.html
+++ b/templates/animais/tutor_detail.html
@@ -234,7 +234,14 @@
                           <i class="fas fa-paw"></i>
                         </div>
                       {% endif %}
-                      <span class="animal-name fw-semibold">{{ a.name }}</span>
+                      <div class="d-flex align-items-center gap-2 flex-wrap">
+                        <span class="animal-name fw-semibold">{{ a.name }}</span>
+                        {% if a.falecido_em %}
+                          <span class="badge bg-secondary-subtle text-secondary border" title="Animal marcado como falecido">
+                            <i class="bi bi-heartbreak me-1"></i>Falecido
+                          </span>
+                        {% endif %}
+                      </div>
                     </div>
                   </td>
                   <td class="animal-species">


### PR DESCRIPTION
### Motivation
- Permitir distinguir de forma sutil e respeitosa animais marcados como falecidos diretamente na lista da ficha do tutor.

### Description
- Adiciona um `badge` discreto "Falecido" ao lado do nome do animal no template `templates/animais/tutor_detail.html` quando `a.falecido_em` estiver preenchido; não há mudanças no backend nem na lógica existente.

### Testing
- Nenhuma suíte automatizada foi executada; verificação automática mínima feita: `git add`/`git commit` e inspeção do arquivo com `nl -ba templates/animais/tutor_detail.html`, todos concluíram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c8adb40c832e8301536dcf26f411)