### PR TITLE
Move tutor/animal panels into top navigation and shorten New tab label

### DIFF
--- a/templates/agendamentos/appointments.html
+++ b/templates/agendamentos/appointments.html
@@ -43,7 +43,7 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link d-flex align-items-center gap-2" id="section-new-tab" data-bs-toggle="tab" data-bs-target="#section-new" type="button" role="tab" aria-controls="section-new" aria-selected="false">
         <span class="icon-circle bg-success text-white"><i class="fa-solid fa-plus"></i></span>
-        <span class="fw-semibold">Nova Consulta</span>
+        <span class="fw-semibold">Novo</span>
       </button>
     </li>
     {% endif %}

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -70,7 +70,7 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link d-flex align-items-center gap-2" id="section-new-tab" data-bs-toggle="tab" data-bs-target="#section-new" type="button" role="tab" aria-controls="section-new" aria-selected="false">
         <span class="icon-circle bg-success text-white"><i class="fa-solid fa-plus"></i></span>
-        <span class="fw-semibold">Nova Consulta</span>
+        <span class="fw-semibold">Novo</span>
       </button>
     </li>
     {% endif %}
@@ -90,6 +90,18 @@
       <button class="nav-link d-flex align-items-center gap-2" id="section-horarios-tab" data-bs-toggle="tab" data-bs-target="#section-horarios" type="button" role="tab" aria-controls="section-horarios" aria-selected="false">
         <span class="icon-circle bg-warning text-dark"><i class="fa-solid fa-clock"></i></span>
         <span class="fw-semibold">Horários</span>
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link d-flex align-items-center gap-2" id="section-tutores-tab" data-bs-toggle="tab" data-bs-target="#section-tutores" type="button" role="tab" aria-controls="section-tutores" aria-selected="false">
+        <span class="icon-circle bg-secondary text-white"><i class="fa-solid fa-users"></i></span>
+        <span class="fw-semibold">Tutores</span>
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link d-flex align-items-center gap-2" id="section-animais-tab" data-bs-toggle="tab" data-bs-target="#section-animais" type="button" role="tab" aria-controls="section-animais" aria-selected="false">
+        <span class="icon-circle bg-dark text-white"><i class="fa-solid fa-paw"></i></span>
+        <span class="fw-semibold">Animais</span>
       </button>
     </li>
   </ul>
@@ -1121,7 +1133,9 @@
       </div>
     </div>
 
-    <!-- Novo Tutor -->
+  </div><!-- /tab-pane section-horarios -->
+
+  <div class="tab-pane fade" id="section-tutores" role="tabpanel" aria-labelledby="section-tutores-tab" tabindex="0">
     <div class="card shadow-lg border-0 rounded-4 overflow-hidden mb-4">
       <div class="card-body p-4 p-lg-5 d-flex flex-column">
         {% include 'partials/tutor_management_panel.html' %}
@@ -1144,8 +1158,9 @@
         {% endwith %}
       </div>
     </div>
+  </div><!-- /tab-pane section-tutores -->
 
-    <!-- Novo Pet -->
+  <div class="tab-pane fade" id="section-animais" role="tabpanel" aria-labelledby="section-animais-tab" tabindex="0">
     <div class="card shadow-lg border-0 rounded-4 overflow-hidden mb-4">
       <div class="card-body p-4 p-lg-5 d-flex flex-column">
         {% with animais_adicionados=vet_animais_adicionados,
@@ -1157,8 +1172,7 @@
         {% endwith %}
       </div>
     </div>
-
-  </div><!-- /tab-pane section-horarios -->
+  </div><!-- /tab-pane section-animais -->
 
   </div><!-- /tab-content -->
 


### PR DESCRIPTION
### Motivation
- Improve discoverability by surfacing the Tutor and Animal management panels as top-level tabs in the veterinarian schedule instead of leaving them at the bottom of the Horários section.
- Make the new-appointment tab label shorter and more compact by renaming "Nova Consulta" to "Novo".

### Description
- Added two new top navigation tabs (`Tutores` and `Animais`) to the veterinarian schedule page and wired them to new tab panes. 
- Moved the existing `partials/tutor_management_panel.html` and `partials/novo_pet_panel.html` content into the new `section-tutores` and `section-animais` tab panes respectively, preserving include contexts and data. 
- Updated the top tab label text from `Nova Consulta` to `Novo` in both `templates/agendamentos/edit_vet_schedule.html` and `templates/agendamentos/appointments.html`.
- This change is purely presentational and did not modify routes, models, or backend logic.

### Testing
- Ran `rg -n "Nova Consulta|section-tutores|section-animais|Tutores|Animais"` against the modified templates to confirm the new labels and tab IDs were present, which succeeded. 
- Inspected the patch with `git diff -- templates/agendamentos/edit_vet_schedule.html templates/agendamentos/appointments.html` to verify the intended HTML changes, which succeeded. 
- Printed affected template regions with `nl -ba ... | sed -n` to validate the new tab panes and label updates in-file, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dc20d2d8832ebf4073a1d6f59aca)