### PR TITLE
Refina UX das ações em lote na seção de horários

### DIFF
--- a/static/appointments_vet.js
+++ b/static/appointments_vet.js
@@ -314,19 +314,26 @@ function getSelectedScheduleIds(root) {
 function updateScheduleSelectionState(root) {
   const checkboxes = getScheduleSelectInputs(root);
   const selectedCount = checkboxes.filter((checkbox) => checkbox.checked).length;
+  const total = checkboxes.length;
+
+  const selectionCountLabel = root?.querySelector('[data-schedule-selection-count]');
+  if (selectionCountLabel) {
+    const plural = selectedCount === 1 ? 'selecionado' : 'selecionados';
+    selectionCountLabel.textContent = `${selectedCount} ${plural}`;
+  }
+
   const bulkDeleteButton = root?.querySelector(SCHEDULE_SELECTORS.bulkDelete);
   if (bulkDeleteButton) {
     bulkDeleteButton.disabled = selectedCount === 0;
   }
   const selectAllButton = root?.querySelector(SCHEDULE_SELECTORS.selectAll);
   if (selectAllButton) {
-    const total = checkboxes.length;
     const allSelected = total > 0 && selectedCount === total;
     selectAllButton.disabled = total === 0;
     selectAllButton.dataset.scheduleSelectAllState = allSelected ? 'all' : 'partial';
     selectAllButton.innerHTML = allSelected
       ? '<i class="fas fa-times me-1"></i>Limpar seleção'
-      : '<i class="fas fa-check-double me-1"></i>Selecionar tudo';
+      : '<i class="fas fa-check-double me-1"></i>Selecionar todos';
   }
 }
 

--- a/templates/agendamentos/edit_vet_schedule.html
+++ b/templates/agendamentos/edit_vet_schedule.html
@@ -982,23 +982,6 @@
         <div class="card-header bg-light d-flex flex-wrap justify-content-between align-items-center gap-2">
           <h5 class="mb-0"><i class="fas fa-business-time me-2"></i>Horários Cadastrados</h5>
           <div class="d-flex align-items-center gap-2">
-            <div class="d-flex align-items-center gap-2 d-none" data-schedule-bulk-actions>
-              <button
-                type="button"
-                class="btn btn-sm btn-outline-danger"
-                data-schedule-bulk-delete
-                disabled
-              >
-                <i class="fas fa-trash-alt me-1"></i>Excluir selecionados
-              </button>
-              <button
-                type="button"
-                class="btn btn-sm btn-outline-secondary"
-                data-schedule-select-all
-              >
-                <i class="fas fa-check-double me-1"></i>Selecionar tudo
-              </button>
-            </div>
             <button
               class="btn btn-sm btn-outline-primary"
               data-schedule-edit-toggle
@@ -1009,6 +992,29 @@
           </div>
         </div>
         <div class="card-body">
+          <div class="schedule-bulk-toolbar d-none" data-schedule-bulk-actions>
+            <div class="schedule-bulk-toolbar__summary">
+              <i class="fas fa-mouse-pointer me-2" aria-hidden="true"></i>
+              <span data-schedule-selection-count>0 selecionados</span>
+            </div>
+            <div class="d-flex flex-wrap align-items-center gap-2">
+              <button
+                type="button"
+                class="btn btn-sm btn-outline-secondary"
+                data-schedule-select-all
+              >
+                <i class="fas fa-check-double me-1"></i>Selecionar todos
+              </button>
+              <button
+                type="button"
+                class="btn btn-sm btn-outline-danger"
+                data-schedule-bulk-delete
+                disabled
+              >
+                <i class="fas fa-trash-alt me-1"></i>Excluir selecionados
+              </button>
+            </div>
+          </div>
           <div
             class="schedule-inline-container border rounded-3 p-4 mb-4 d-none"
             data-schedule-inline-container
@@ -1360,6 +1366,26 @@
     font-size: 0.75em;
   }
 
+  .schedule-bulk-toolbar {
+    border: 1px solid #d7deea;
+    border-radius: 0.75rem;
+    background: #f7faff;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .schedule-bulk-toolbar__summary {
+    display: flex;
+    align-items: center;
+    color: #3d4f68;
+    font-weight: 600;
+    font-size: 0.92rem;
+  }
+
   @media (max-width: 768px) {
     .btn-group .btn {
       font-size: 0.75rem;
@@ -1374,6 +1400,15 @@
     .d-flex.align-items-center .me-3 {
       margin-right: 0 !important;
       margin-bottom: 0.5rem;
+    }
+
+    .schedule-bulk-toolbar {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .schedule-bulk-toolbar__summary {
+      justify-content: center;
     }
   }
 </style>


### PR DESCRIPTION
### Motivation
- Reduzir ruído visual no cabeçalho do card de "Horários Cadastrados" movendo as ações de seleção em lote para uma barra contextual dentro do corpo do card.
- Dar maior clareza ao fluxo de edição em lote exibindo um resumo do número de itens selecionados e agrupando as ações relevantes junto ao conteúdo.
- Melhorar a experiência em telas pequenas tornando a barra de ações responsiva e menos intrusiva.

### Description
- Remove as ações em lote do cabeçalho e mantém apenas o botão principal `Editar horários` em `templates/agendamentos/edit_vet_schedule.html`.
- Adiciona uma nova barra contextual `schedule-bulk-toolbar` dentro do `card-body` com contador (`data-schedule-selection-count`) e botões `data-schedule-select-all` e `data-schedule-bulk-delete` no template `templates/agendamentos/edit_vet_schedule.html`.
- Inclui estilos CSS para a nova barra (`.schedule-bulk-toolbar` e `.schedule-bulk-toolbar__summary`) com adaptação para dispositivos móveis no mesmo template.
- Atualiza `static/appointments_vet.js` para atualizar dinamicamente o contador de seleção, ajustar textos de botão para "Selecionar todos"/"Limpar seleção" e manter o estado de habilitado/desabilitado dos botões de ação.

### Testing
- Nenhum teste automatizado foi executado para estas mudanças.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01df9ef678832eb29a3581965a0a4d)